### PR TITLE
Add a FurtherInfo (quasi-tooltip) JS module

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,16 +1,5 @@
-// This is a manifest file that'll be compiled into application.js, which will include all the files
-// listed below.
-//
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, vendor/assets/javascripts,
-// or any plugin's vendor/assets/javascripts directory can be referenced here using a relative path.
-//
-// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// compiled file.
-//
-// Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
-// about supported directives.
-//
-//= require jquery
-//= require jquery_ujs
-//= require turbolinks
-//= require_tree .
+//= require require_config.js.erb
+
+require(['jquery'], function ($) {
+  require(['FurtherInfo']);
+});

--- a/app/assets/javascripts/modules/FurtherInfo.js
+++ b/app/assets/javascripts/modules/FurtherInfo.js
@@ -1,0 +1,18 @@
+define(['jquery'], function($) {
+
+  'use strict';
+
+  var $element = $('[data-further-info]'),
+      $trigger = $('[data-further-info-trigger]'),
+      $target = $('[data-further-info-target]');
+
+  $element.each(function() {
+    var $this = $(this);
+
+    $this.find($trigger).on('click', function(event) {
+      $this.find($target).toggleClass('is-hidden');
+      event.preventDefault();
+    });
+  });
+
+});

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -1,0 +1,20 @@
+//= depend_on_asset jquery/dist/jquery
+//= depend_on_asset modules/FurtherInfo
+
+<%
+  def requirejs_path(asset)
+    javascript_path(asset).sub(/.js\z/, '')
+  end
+
+  requirejs_config = {
+    paths: {
+      jquery: requirejs_path('jquery/dist/jquery'),
+      FurtherInfo: requirejs_path('modules/FurtherInfo')
+    }
+  }
+%>
+
+// If requirejs is present convert the requirejs_config hash to a JSON object
+if(window.requirejs) {
+  requirejs.config(<%= JSON.pretty_generate(requirejs_config) %>);
+}

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -13,4 +13,4 @@
 
 @import 'components/video';
 @import 'components/advert';
-@import 'components/tooltip';
+@import 'components/further_info';

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -13,4 +13,4 @@
 
 @import 'components/video';
 @import 'components/advert';
-@import 'components/further_info';
+@import 'components/further_info/all';

--- a/app/assets/stylesheets/base/_headings.scss
+++ b/app/assets/stylesheets/base/_headings.scss
@@ -1,4 +1,0 @@
-.heading-three {
-  @include body(22, 30);
-  color: $color-black;
-}

--- a/app/assets/stylesheets/components/_further_info.scss
+++ b/app/assets/stylesheets/components/_further_info.scss
@@ -1,0 +1,11 @@
+.further_info {
+  @include body(14, 24);
+  border-left: 5px solid #3C97BF;
+  padding-left: $baseline-unit*2;
+  margin-bottom: $baseline-unit*6;
+}
+
+.further_info__trigger {
+  @include body(14, 24);
+  white-space: nowrap;
+}

--- a/app/assets/stylesheets/components/_tooltip.scss
+++ b/app/assets/stylesheets/components/_tooltip.scss
@@ -1,8 +1,0 @@
-.tooltip {
-  // styles coming in another story
-}
-
-.tooltip__link {
-  @include body(14,18);
-  text-decoration: underline;
-}

--- a/app/assets/stylesheets/components/further_info/_all.scss
+++ b/app/assets/stylesheets/components/further_info/_all.scss
@@ -1,0 +1,2 @@
+@import 'settings';
+@import 'further_info';

--- a/app/assets/stylesheets/components/further_info/_further_info.scss
+++ b/app/assets/stylesheets/components/further_info/_further_info.scss
@@ -1,6 +1,6 @@
 .further_info {
   @include body(14, 24);
-  border-left: 5px solid #3C97BF;
+  border-left: 5px solid $further-info-border-color;
   padding-left: $baseline-unit*2;
   margin-bottom: $baseline-unit*6;
 }

--- a/app/assets/stylesheets/components/further_info/_settings.scss
+++ b/app/assets/stylesheets/components/further_info/_settings.scss
@@ -1,0 +1,1 @@
+$further-info-border-color: #3C97BF;

--- a/app/assets/stylesheets/layouts/_landing_page.scss
+++ b/app/assets/stylesheets/layouts/_landing_page.scss
@@ -37,5 +37,10 @@
 }
 
 .l-landing-page__button {
-  margin-top: $baseline-unit*6;
+  @include body(16, 24);
+  margin-top: $baseline-unit*3;
+}
+
+.l-landing-page__union-statement {
+    @include row(12);
 }

--- a/app/assets/stylesheets/layouts/_landing_page.scss
+++ b/app/assets/stylesheets/layouts/_landing_page.scss
@@ -36,11 +36,16 @@
   background-color: $background-color;
 }
 
+.l-landing-page__heading {
+  @include body(22, 30);
+  color: $color-black;
+}
+
 .l-landing-page__button {
   @include body(16, 24);
   margin-top: $baseline-unit*3;
 }
 
 .l-landing-page__union-statement {
-    @include row(12);
+  @include row(12);
 }

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -5,18 +5,13 @@
 
     <ul class="list-benefits">
       <% t('trust_banner.items').each do |item| %>
-        <li><%= raw item[:text] %>
-          <a class="tooltip__link" href=""><%= t('learn_more') %></a>
-          <p class="is-hidden"><%= t('workplace_scheme.tooltip') %></p>
+        <li data-further-info>
+          <%= raw item[:text] %>
+          <a class="further_info__trigger" href="" data-further-info-trigger><%= t('learn_more') %><span class="visually-hidden"><%= t('learn_more_hidden_text') %></span></a>
+          <p class="further_info is-hidden" data-further-info-target><%= t('workplace_scheme.tooltip') %></p>
         </li>
       <% end %>
     </ul>
-  </section>
-
-  <section class="l-landing-page__1col">
-    <!-- This addition needs design consideration -->
-    <p><%= t('workplace_scheme.question') %> <a class="tooltip__link" href=""><%= t('learn_more') %></a></p>
-    <p class="is-hidden"><%= t('workplace_scheme.tooltip') %></p>
   </section>
 </div>
 
@@ -25,6 +20,14 @@
     <section class="l-landing-page__1col">
       <%= heading_tag(t('find_retirement_adviser.heading'), level: 2) %>
       <p><%= t('find_retirement_adviser.description') %></p>
+
+      <div class="l-landing-page__union-statement">
+        <div class="l-landing-page__2col" data-further-info>
+          <%= t('workplace_scheme.question') %>
+          <a class="further_info__trigger" href="" data-further-info-trigger><%= t('learn_more') %></a>
+          <p class="further_info is-hidden" data-further-info-target><%= t('workplace_scheme.tooltip') %></p>
+        </div>
+      </div>
 
       <section class="l-landing-page__2col">
         <!-- Filter to be included here -->
@@ -77,9 +80,7 @@
       <% t('retirement_income_options.content').each do |item| %>
         <p><%= item[:text] %></p>
       <% end %>
-      <div class="l-landing-page__button">
-        <a class="button button--primary" href="<%= t('retirement_income_options.link_url') %>"><%= t('retirement_income_options.link_text') %></a>
-      </div>
+      <a class="button button--primary l-landing-page__button" href="<%= t('retirement_income_options.link_url') %>"><%= t('retirement_income_options.link_text') %></a>
     </section>
   </div>
 </div>

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -87,7 +87,7 @@
 
 <div class="l-constrained">
   <section class="l-landing-page__2col">
-    <%= heading_tag(t('useful_links.heading'), level: 2, class: 'l-landing-page__subheading') %>
+    <%= heading_tag(t('useful_links.heading'), level: 2, class: 'l-landing-page__heading') %>
     <ul class="unstyled-list">
       <% t('useful_links.links').each do |item| %>
         <li><a href="<%= item[:url] %>"><%= item[:text] %></a></li>
@@ -96,7 +96,7 @@
   </section>
 
   <section class="l-landing-page__2col">
-    <%= heading_tag(t('our_promise.heading'), level: 2, class: 'l-landing-page__subheading') %>
+    <%= heading_tag(t('our_promise.heading'), level: 2, class: 'l-landing-page__heading') %>
     <ul class="list-benefits">
       <% t('our_promise.key_points').each do |item| %>
         <li><%= item[:text] %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,5 +32,6 @@
   <%= yield %>
 </main>
 
+<%= javascript_include_tag 'requirejs/require', data: { main: javascript_path('application') } %>
 </body>
 </html>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
 
   # Application JavaScript
   config.assets.precompile += %w(
-
+    modules/FurtherInfo.js
   )
 
   # Vendor JavaScript

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@
 
   page_title: Retirement adviser directory
   learn_more: Learn more
+  learn_more_hidden_text: (click this link and further information will appear directly below)
 
   trust_banner:
     heading: The directory contains details of hundreds of financial advisers who can help you with your financial decisions whether you are thinking about retirement; semi-retired but still working or fully retired.


### PR DESCRIPTION
@benbarnett @benlovell 

Added RequireJS.
Added a FurtherInfo module which displays large quantities of explanatory information on click. Similar to a expand/collapse function in an FAQ section.
Added temporary styles for the `union-statement` which has not been through proper design yet.

Needs JS tests and possible promotion to Dough (if useful).