### PR TITLE
Disable the retirement income options link

### DIFF
--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -80,7 +80,7 @@
       <% t('retirement_income_options.content').each do |item| %>
         <p><%= item[:text] %></p>
       <% end %>
-      <a class="button button--primary l-landing-page__button" href="<%= t('retirement_income_options.link_url') %>" target="_blank"><%= t('retirement_income_options.link_text') %></a>
+      <a class="button button--primary l-landing-page__button is-disabled" href="<%= t('retirement_income_options.link_url') %>" target="_blank"><%= t('retirement_income_options.link_text') %></a>
     </section>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@
     content:
       - text: The retirement landscape is changing fast and it’s tricky to understand all the retirement income options available to you.
       - text: Use our retirement income options tool to understand the key considerations and pension income products available to you.
+      - text: The retirement income options tool will be available in early 2015.
     link_text: Explore your options
     link_url: 'https://moneyadviceservice.org.uk'
 


### PR DESCRIPTION
@moneyadviceservice/frontend @benlovell 

As the retirement income option tool is currently not available I have added in a short disclaimer (to be authorised by props I'm sure) and disabled the call to action.