### PR TITLE
Shuffles around responsibilities for normalising

### DIFF
--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -1,13 +1,22 @@
 class SearchForm
   include ActiveModel::Model
+  include ActiveModel::Validations::Callbacks
 
   attr_accessor :postcode, :checkbox
 
+  before_validation :upcase_postcode
+
   validate :geocode_postcode
+
+  private
 
   def geocode_postcode
     unless postcode =~ /\A[A-Z\d]{1,4} [A-Z\d]{1,3}\z/ && Geocode.call(postcode)
       errors.add(:postcode, I18n.t('search.errors.geocode_failure'))
     end
+  end
+
+  def upcase_postcode
+    self.postcode.try(:upcase!)
   end
 end

--- a/lib/geocode.rb
+++ b/lib/geocode.rb
@@ -1,6 +1,6 @@
 class Geocode
   def self.call(postcode)
-    normalised_postcode = postcode.upcase.delete(' ')
+    normalised_postcode = postcode.delete(' ')
 
     Geocoder.coordinates("#{normalised_postcode}, United Kingdom")
   end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -1,4 +1,14 @@
 RSpec.describe SearchForm do
+  it 'upcases the postcode before validation' do
+    VCR.use_cassette(:rg2_1aa) do
+      described_class.new(postcode: 'rg2 1aa').tap do |search|
+        search.validate
+
+        expect(search.postcode).to eql('RG2 1AA')
+      end
+    end
+  end
+
   describe 'validation' do
     it 'is valid with valid attributes' do
       VCR.use_cassette(:rg2_1aa) do

--- a/spec/lib/geocode_spec.rb
+++ b/spec/lib/geocode_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Geocode, '#call' do
   it 'normalises the postcode' do
     expect(Geocoder).to receive(:coordinates).with('RG11GG, United Kingdom')
 
-    Geocode.call('rg1 1gg')
+    Geocode.call('RG1 1GG')
   end
 
   it 'returns the lat/long pair' do


### PR DESCRIPTION
Prior to this PR, the user would have to provide postcodes in uppercase, to
pass the validation checks. This didn't make much sense as we were then
uppercasing the postcode as part of the normalisation occurring in
`Geocode.call`.