### PR TITLE
Extract ElasticSearchHelper from consumer search by postcode

### DIFF
--- a/spec/features/consumer_searches_by_postcode_only_spec.rb
+++ b/spec/features/consumer_searches_by_postcode_only_spec.rb
@@ -86,22 +86,4 @@ RSpec.feature 'Consumer searches by postcode only' do
   def then_i_am_told_the_postcode_is_incorrect
     expect(landing_page.in_person).to be_invalid_postcode
   end
-
-  def with_fresh_index!
-    `curl -XDELETE -sS http://127.0.0.1:9200/rad_test`
-    `curl -XPOST -sS http://127.0.0.1:9200/rad_test -d @elastic_search_mapping.json`
-    yield
-    `curl -XPOST -sS http://127.0.0.1:9200/rad_test/_refresh`
-  end
-
-  def with_elastic_search!
-    VCR.turned_off do
-      begin
-        WebMock.allow_net_connect!
-        yield
-      ensure
-        WebMock.disable_net_connect!
-      end
-    end
-  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,5 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.include FactoryGirl::Syntax::Methods
+  config.include ElasticSearchHelper, type: :feature
 end

--- a/spec/support/elastic_search_helper.rb
+++ b/spec/support/elastic_search_helper.rb
@@ -1,0 +1,19 @@
+module ElasticSearchHelper
+  def with_fresh_index!
+    `curl -XDELETE -sS http://127.0.0.1:9200/rad_test`
+    `curl -XPOST -sS http://127.0.0.1:9200/rad_test -d @elastic_search_mapping.json`
+    yield
+    `curl -XPOST -sS http://127.0.0.1:9200/rad_test/_refresh`
+  end
+
+  def with_elastic_search!
+    VCR.turned_off do
+      begin
+        WebMock.allow_net_connect!
+        yield
+      ensure
+        WebMock.disable_net_connect!
+      end
+    end
+  end
+end


### PR DESCRIPTION
I would like to re-use methods `with_fresh_index` and `with_elastic_search` methods in features for upcoming remote advisories search functionality. This PR attempts to extract them into a RSpec mixin. Lemme know what you think.

@lshepstone @benlovell 