### PR TITLE
Fix the margin-top issue on the search filter

### DIFF
--- a/app/assets/stylesheets/components/search_filter/_search_filter.scss
+++ b/app/assets/stylesheets/components/search_filter/_search_filter.scss
@@ -8,6 +8,11 @@
   margin: $baseline-unit*4 $baseline-unit*4 0 $baseline-unit*4;
 }
 
+.search-filter__form {
+  // this is needed to override the required Dough class 'form' that applies a margin to forms
+  margin-top: 0;
+}
+
 .search-filter__heading {
   @include body(16, 18);
   color: $search-filter-heading-color;

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -29,7 +29,7 @@
 
       <div class="search-filter">
         <section class="t-in-person" data-search-filter>
-          <%= form_for @form, url: search_path, method: 'GET', html: { class: 'form' }, builder: Dough::Forms::Builders::Validation do |f| %>
+          <%= form_for @form, url: search_path, method: 'GET', html: { class: 'form search-filter__form' }, builder: Dough::Forms::Builders::Validation do |f| %>
             <%= f.validation_summary %>
             <%= heading_tag( level: 3, class: 'search-filter__heading search-filter__heading--first', data: { search_filter_heading: ''}) do %>
               <span class="search-filter__triangle-icon search-filter__triangle-icon--down" data-search-filter-icon></span>
@@ -51,8 +51,9 @@
             </div>
           <% end %>
         </section>
-        <section class="" data-search-filter>
-          <%= form_for @form, url: search_path, method: 'GET', html: { class: 'form' }, builder: Dough::Forms::Builders::Validation do |f| %>
+
+        <section data-search-filter>
+          <%= form_for @form, url: search_path, method: 'GET', html: { class: 'form search-filter__form' }, builder: Dough::Forms::Builders::Validation do |f| %>
             <%= heading_tag(level: 3, class: 'search-filter__heading search-filter__heading--second', data: { search_heading_second: '', search_filter_heading: ''}) do %>
               <span class="search-filter__triangle-icon" data-search-filter-icon></span>
               <span class="search-filter__heading-text"><%= t('search_filter.remote.heading') %></span>


### PR DESCRIPTION
@lshepstone @moneyadviceservice/frontend

Override to the Dough class `.form` which is applying a top margin.