### PR TITLE
Includes fanout of geocode/index jobs from core

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.12)
+    mas-rad_core (0.0.13)
       active_model_serializers
       geocoder
       http
@@ -111,7 +111,7 @@ GEM
     mime-types (2.4.3)
     mini_portile (0.6.2)
     minitest (5.5.1)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pg (0.18.1)

--- a/spec/support/elastic_search_helper.rb
+++ b/spec/support/elastic_search_helper.rb
@@ -1,8 +1,17 @@
 module ElasticSearchHelper
   def with_fresh_index!
+    rebuild_index!
+    yield
+    index_all!
+    refresh_index!
+  end
+
+  def rebuild_index!
     `curl -XDELETE -sS http://127.0.0.1:9200/rad_test`
     `curl -XPOST -sS http://127.0.0.1:9200/rad_test -d @elastic_search_mapping.json`
-    yield
+  end
+
+  def refresh_index!
     `curl -XPOST -sS http://127.0.0.1:9200/rad_test/_refresh`
     `sleep 3` if ENV['TRAVIS']
   end
@@ -16,5 +25,9 @@ module ElasticSearchHelper
         WebMock.disable_net_connect!
       end
     end
+  end
+
+  def index_all!
+    Firm.all.map { |f| IndexFirmJob.perform_later(f) }
   end
 end


### PR DESCRIPTION
Required a slight change to trigger indexing of factory data. Also took
the opportunity to break out the individual elasticsearch helper
actions since `with_fresh_index!` was becoming unwieldy.