### PR TITLE
Distance search firms order spec - actually perform order check

### DIFF
--- a/spec/features/consumer_searches_by_postcode_only_spec.rb
+++ b/spec/features/consumer_searches_by_postcode_only_spec.rb
@@ -96,11 +96,11 @@ RSpec.feature 'Consumer searches by postcode only' do
   end
 
   def and_the_firms_are_ordered_by_distance_in_miles_to_me
-    expect(results_page.firms.map(&:name)).to contain_exactly(
+    expect(results_page.firms.map(&:name)).to eql([
       @reading.firm.registered_name,
       @leicester.firm.registered_name,
       @glasgow.firm.registered_name
-    )
+    ])
   end
 
   def when_i_submit_a_invalid_postcode_search


### PR DESCRIPTION
When working on #5725, I realised that `contain_exactly` method checks for set equality (i.e. does two collections have the same items), rather than list equality (the same items in the same order). Before proposed change, one could change order of the companies in the example and it wouldn't fail the test. 