### PR TITLE
#5725 Remote search scenarios 1&3

### DIFF
--- a/app/serializers/remote_search_form_serializer.rb
+++ b/app/serializers/remote_search_form_serializer.rb
@@ -18,10 +18,4 @@ class RemoteSearchFormSerializer < ActiveModel::Serializer
       }
     }
   end
-
-  private
-
-  def remote_advice_method_ids
-    object.advice_methods.select(&:present?)
-  end
 end

--- a/app/serializers/remote_search_form_serializer.rb
+++ b/app/serializers/remote_search_form_serializer.rb
@@ -18,4 +18,10 @@ class RemoteSearchFormSerializer < ActiveModel::Serializer
       }
     }
   end
+
+  private
+
+  def remote_advice_method_ids
+    object.advice_methods.select(&:present?)
+  end
 end

--- a/spec/features/consumer_filters_by_types_of_advice_spec.rb
+++ b/spec/features/consumer_filters_by_types_of_advice_spec.rb
@@ -53,6 +53,6 @@ RSpec.feature 'Consumer searches by postcode with types of advice filters' do
   def and_they_are_ordered_by_business_split_and_location
     ordered_results = [@first, @second].map(&:registered_name)
 
-    expect(results_page.firms.map(&:name)).to eql(ordered_results)
+    expect(results_page.firm_names).to eql(ordered_results)
   end
 end

--- a/spec/features/consumer_searches_by_postcode_only_spec.rb
+++ b/spec/features/consumer_searches_by_postcode_only_spec.rb
@@ -91,12 +91,12 @@ RSpec.feature 'Consumer searches by postcode only' do
 
   def and_i_am_not_shown_non_postcode_searchable_firms
     expect(
-      results_page.firms.map(&:name)
+      results_page.firm_names
     ).to_not include(@missing.registered_name)
   end
 
   def and_the_firms_are_ordered_by_distance_in_miles_to_me
-    expect(results_page.firms.map(&:name)).to eql([
+    expect(results_page.firm_names).to eql([
       @reading.firm.registered_name,
       @leicester.firm.registered_name,
       @glasgow.firm.registered_name

--- a/spec/features/consumer_searches_remote_advice_spec.rb
+++ b/spec/features/consumer_searches_remote_advice_spec.rb
@@ -5,12 +5,32 @@ RSpec.feature 'Consumer searches for phone or online advice' do
   let!(:phone_advice)  { create(:other_advice_method, name: 'Advice by telephone', order: 1) }
   let!(:online_advice) { create(:other_advice_method, name: 'Advice online (e.g. by video call / conference / email)', order: 2) }
 
+  scenario 'Selecting telephone advice' do
+    with_elastic_search! do
+      given_i_am_on_the_rad_landing_page
+      and_firms_providing_remote_services_were_previously_indexed
+      when_i_submit_a_search_selecting_telephone_advice
+      then_i_am_shown_firms_that_provide_advice_by_telephone
+      and_they_are_ordered_alphabetically
+    end
+  end
+
   scenario 'Selecting online advice' do
     with_elastic_search! do
       given_i_am_on_the_rad_landing_page
       and_firms_providing_remote_services_were_previously_indexed
       when_i_submit_a_search_selecting_online_advice
       then_i_am_shown_firms_that_provide_advice_online
+      and_they_are_ordered_alphabetically
+    end
+  end
+
+  scenario 'Selecting online and telephone advice' do
+    with_elastic_search! do
+      given_i_am_on_the_rad_landing_page
+      and_firms_providing_remote_services_were_previously_indexed
+      when_i_submit_a_search_selecting_online_and_telephone_advice
+      then_i_am_shown_firms_that_provide_advice_online_and_by_telephone
       and_they_are_ordered_alphabetically
     end
   end
@@ -37,13 +57,38 @@ RSpec.feature 'Consumer searches for phone or online advice' do
   end
 
   def then_i_am_shown_firms_that_provide_advice_online
-    expect(remote_results_page.firms).to be_present
+    expect(remote_results_page.firms.map(&:name)).
+      to include(@online_only.registered_name, @online_and_phone.registered_name)
   end
 
   def and_they_are_ordered_alphabetically
-    expect(remote_results_page.firms.map(&:name)).to eql([
-      @online_and_phone.registered_name,
-      @online_only.registered_name,
-    ])
+    names = remote_results_page.firms.map(&:name)
+    expect(names).to eql(names.sort)
+  end
+
+  def when_i_submit_a_search_selecting_telephone_advice
+    landing_page.remote.tap do |section|
+      section.by_phone.set(true)
+      section.search.click
+    end
+  end
+
+  def then_i_am_shown_firms_that_provide_advice_by_telephone
+    expect(remote_results_page.firms.map(&:name)).
+      to include(@phone_only.registered_name, @online_and_phone.registered_name)
+  end
+
+  def when_i_submit_a_search_selecting_online_and_telephone_advice
+    landing_page.remote.tap do |section|
+      section.online.set(true)
+      section.by_phone.set(true)
+      section.search.click
+    end
+  end
+
+  def then_i_am_shown_firms_that_provide_advice_online_and_by_telephone
+    expect(remote_results_page).to have_firms(count: 3)
+
+    expect(remote_results_page.firms.map(&:name)).not_to include(@only_in_person.registered_name)
   end
 end

--- a/spec/features/consumer_searches_remote_advice_spec.rb
+++ b/spec/features/consumer_searches_remote_advice_spec.rb
@@ -57,12 +57,13 @@ RSpec.feature 'Consumer searches for phone or online advice' do
   end
 
   def then_i_am_shown_firms_that_provide_advice_online
-    expect(remote_results_page.firms.map(&:name)).
+    expect(remote_results_page.firm_names).
       to include(@online_only.registered_name, @online_and_phone.registered_name)
   end
 
   def and_they_are_ordered_alphabetically
-    names = remote_results_page.firms.map(&:name)
+    names = remote_results_page.firm_names
+
     expect(names).to eql(names.sort)
   end
 
@@ -74,7 +75,7 @@ RSpec.feature 'Consumer searches for phone or online advice' do
   end
 
   def then_i_am_shown_firms_that_provide_advice_by_telephone
-    expect(remote_results_page.firms.map(&:name)).
+    expect(remote_results_page.firm_names).
       to include(@phone_only.registered_name, @online_and_phone.registered_name)
   end
 
@@ -89,6 +90,6 @@ RSpec.feature 'Consumer searches for phone or online advice' do
   def then_i_am_shown_firms_that_provide_advice_online_and_by_telephone
     expect(remote_results_page).to have_firms(count: 3)
 
-    expect(remote_results_page.firms.map(&:name)).not_to include(@only_in_person.registered_name)
+    expect(remote_results_page.firm_names).not_to include(@only_in_person.registered_name)
   end
 end

--- a/spec/support/remote_results_page.rb
+++ b/spec/support/remote_results_page.rb
@@ -5,4 +5,8 @@ class RemoteResultsPage < SitePrism::Page
   set_url_matcher %r{/(en|cy)/remote-help-search}
 
   sections :firms, FirmSection, 'li.t-firm'
+
+  def firm_names
+    firms.collect(&:name)
+  end
 end

--- a/spec/support/results_page.rb
+++ b/spec/support/results_page.rb
@@ -29,4 +29,8 @@ class ResultsPage < SitePrism::Page
   def total?(n)
     total_records.text == n.to_s
   end
+
+  def firm_names
+    firms.collect(&:name)
+  end
 end


### PR DESCRIPTION
Scenario: Selecting phone advice
Given that I am on the RAD landing page
When I submit a search selecting phone advice 
Then I am shown FIRMS and SUBSIDIARIES that provide advice by phone 
And they are ordered alphabetically, (A-Z)
 
Scenario: Selecting phone AND online advice
Given that I am on the RAD landing page
When I submit a search selecting online AND phone advice
Then I am shown FIRMS and SUBSIDIARIES that provide advice by phone OR online
And I am shown FIRMS and SUBSIDIARIES that provide advice by phone AND online
And they are ordered alphabetically, (A-Z)
