### PR TITLE
#5725 scenario #5 - form validation

### DIFF
--- a/app/controllers/remote_search_controller.rb
+++ b/app/controllers/remote_search_controller.rb
@@ -1,8 +1,15 @@
 class RemoteSearchController < ApplicationController
   def show
     @remote_form = RemoteSearchForm.new(params[:remote_search_form])
-    @result = FirmRepository.new.search(@remote_form.to_query, page: page)
 
-    render 'search/index'
+    if @remote_form.valid?
+      @result = FirmRepository.new.search(@remote_form.to_query, page: page)
+
+      render 'search/index'
+    else
+      @form = SearchForm.new(params[:search_form])
+
+      render 'landing_page/show'
+    end
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,11 +1,12 @@
 class SearchController < ApplicationController
   def index
     @form = SearchForm.new(params[:search_form])
-    @remote_form = RemoteSearchForm.new(params[:remote_search_form])
 
     if @form.valid?
       @result = FirmRepository.new.search(@form.to_query, page: page)
     else
+      @remote_form = RemoteSearchForm.new(params[:remote_search_form])
+
       render 'landing_page/show'
     end
   end

--- a/app/forms/remote_search_form.rb
+++ b/app/forms/remote_search_form.rb
@@ -6,11 +6,19 @@ class RemoteSearchForm
     :checkbox,
     *SearchForm::TYPES_OF_ADVICE
 
+  validate :advice_methods_present
+
   def to_query
     RemoteSearchFormSerializer.new(self).to_json
   end
 
   def remote_advice_method_ids
     advice_methods.select(&:present?)
+  end
+
+  def advice_methods_present
+    if remote_advice_method_ids.empty?
+      errors.add(:advice_methods, I18n.t('search.errors.missing_advice_method'))
+    end
   end
 end

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -51,8 +51,9 @@
           <% end %>
         </section>
 
-        <section data-search-filter>
-          <%= form_for @remote_form, url: search_remote_advice_path, method: 'GET', html: { class: 'form search-filter__form t-remote' }, builder: Dough::Forms::Builders::Validation do |f| %>
+        <section class="t-remote" data-search-filter>
+          <%= form_for @remote_form, url: search_remote_advice_path, method: 'GET', html: { class: 'form search-filter__form' }, builder: Dough::Forms::Builders::Validation do |f| %>
+            <%= f.validation_summary %>
             <%= heading_tag(level: 3, class: 'search-filter__heading search-filter__heading--second', data: { search_heading_second: '', search_filter_heading: ''}) do %>
               <span class="search-filter__triangle-icon" data-search-filter-icon></span>
               <span class="search-filter__heading-text"><%= t('search_filter.remote.heading') %></span>
@@ -64,7 +65,7 @@
                   <%= f.errors_for :advice_methods %>
                   <%= f.collection_check_boxes(:advice_methods, remote_advice_methods, :id, :name) do |advice_method| %>
                     <div class="form__group-item search-filter__checkbox-container">
-                      <%= advice_method.check_box class: "form__group-input t-advice-method-#{advice_method.object.order}" %>
+                      <%= advice_method.check_box class: "form__group-input t-advice_methods t-advice-method-#{advice_method.object.order}" %>
                       <%= advice_method.label do %>
                         <%= t("advice_methods.ordinal.#{advice_method.object.order}") %>
                       <% end %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -199,6 +199,7 @@
   search:
     errors:
       geocode_failure: yn anghywir
+      missing_advice_method: TODO
     index:
       title_tag: Canlyniadau chwilio | Cyfeirlyfr Cynghorydd Ymddeoliad
       meta_tag_description: Defnyddiwch y Cyfeirlyfr Cynghorydd Ymddeoliad i ddod o hyd i gynghorwyr ariannol a reoleiddir i helpu gyda chynllunio ymddeoliad, treth etifeddiant, rhyddhau ecwiti, ewyllysiau a phrofebion, gofal hirdymor a throsglwyddo pensiwn.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,6 +205,7 @@
   search:
     errors:
       geocode_failure: is incorrect
+      missing_advice_method: To continue please select online, telephone or both and run your search again.
     index:
       title_tag: 'Search results | Retirement Adviser Directory'
       meta_tag_description: Use the Retirement Adviser Directory to find FCA regulated financial advisers for help with retirement planning, inheritance tax, equity release, wills and probate, long-term care and pension transfers.

--- a/spec/features/consumer_searches_remote_advice_spec.rb
+++ b/spec/features/consumer_searches_remote_advice_spec.rb
@@ -35,6 +35,16 @@ RSpec.feature 'Consumer searches for phone or online advice' do
     end
   end
 
+  scenario 'Consumer tries to run remote advice search WITHOUT selecting phone or online' do
+    with_elastic_search! do
+      given_i_am_on_the_rad_landing_page
+      and_firms_providing_remote_services_were_previously_indexed
+      when_i_submit_a_search_without_selecting_advice_methods
+      then_i_am_shown_an_error_message
+      and_i_am_still_on_landing_page
+    end
+  end
+
 
   def and_firms_providing_remote_services_were_previously_indexed
     with_fresh_index! do
@@ -91,5 +101,19 @@ RSpec.feature 'Consumer searches for phone or online advice' do
     expect(remote_results_page).to have_firms(count: 3)
 
     expect(remote_results_page.firm_names).not_to include(@only_in_person.registered_name)
+  end
+
+  def when_i_submit_a_search_without_selecting_advice_methods
+    landing_page.remote.tap do |section|
+      section.search.click
+    end
+  end
+
+  def then_i_am_shown_an_error_message
+    expect(landing_page.remote).to be_invalid_advice_methods
+  end
+
+  def and_i_am_still_on_landing_page
+    expect(landing_page).to be_displayed
   end
 end

--- a/spec/support/remote_section.rb
+++ b/spec/support/remote_section.rb
@@ -2,4 +2,8 @@ class RemoteSection < SitePrism::Section
   element :by_phone, '.t-advice-method-1'
   element :online, '.t-advice-method-2'
   element :search, '.button--primary'
+
+  def invalid_advice_methods?
+    has_css?('.field_with_errors .t-advice_methods')
+  end
 end


### PR DESCRIPTION
TL;DR: validate that user checked phone or online;

```
Scenario: Consumer tries to run a phone / online advice search WITHOUT selecting phone or online options
Given that I am on the RAD landing page
When I submit a search via the phone / online workflow
And I have NOT selected phone or online (even if I have selected a type of advice e.g. Equity release, Wills and probate etc.)
Then I am shown an error message: To continue please select online, telephone or both and run your search again’
And I CANNOT run my search until I select online and / or telephone 
```