### PR TITLE
#5725 Support for filtering by advice type

### DIFF
--- a/app/forms/remote_search_form.rb
+++ b/app/forms/remote_search_form.rb
@@ -1,10 +1,17 @@
 class RemoteSearchForm
   include ActiveModel::Model
 
+  TYPES_OF_ADVICE = [
+    :options_when_paying_for_care,
+    :equity_release,
+    :inheritance_tax_planning,
+    :wills_and_probate
+  ]
+
   attr_accessor :advice_methods,
     :pension_transfer,
     :checkbox,
-    *SearchForm::TYPES_OF_ADVICE
+    *TYPES_OF_ADVICE
 
   validate :advice_methods_present
 
@@ -20,5 +27,9 @@ class RemoteSearchForm
     if remote_advice_method_ids.empty?
       errors.add(:advice_methods, I18n.t('search.errors.missing_advice_method'))
     end
+  end
+
+  def types_of_advice
+    TYPES_OF_ADVICE.select { |type| public_send(type) == '1' }
   end
 end

--- a/app/serializers/remote_search_form_serializer.rb
+++ b/app/serializers/remote_search_form_serializer.rb
@@ -10,12 +10,32 @@ class RemoteSearchFormSerializer < ActiveModel::Serializer
   def query
     {
       'filtered': {
-        'filter': {
-          'in': {
-            'other_advice_methods': object.remote_advice_method_ids
+        'filter': [
+          {
+            'in': {
+              'other_advice_methods': object.remote_advice_method_ids
+            }
+          }
+        ]
+      }
+    }.tap do |query|
+      if types_of_advice?
+        query[:filtered][:filter] << {
+          'script': {
+            'script': types_of_advice_filter_expression
           }
         }
-      }
-    }
+      end
+    end
+  end
+
+  private
+
+  def types_of_advice_filter_expression
+    object.types_of_advice.map { |field| "doc['#{field}'].value > 0" }.join(' && ')
+  end
+
+  def types_of_advice?
+    object.types_of_advice.present?
   end
 end

--- a/spec/support/remote_section.rb
+++ b/spec/support/remote_section.rb
@@ -3,6 +3,11 @@ class RemoteSection < SitePrism::Section
   element :online, '.t-advice-method-2'
   element :search, '.button--primary'
 
+  element :options_when_paying_for_care, '#remote_search_form_options_when_paying_for_care'
+  element :equity_release, '#remote_search_form_equity_release'
+  element :inheritance_tax_planning, '#remote_search_form_inheritance_tax_planning'
+  element :wills_and_probate, '#remote_search_form_wills_and_probate'
+
   def invalid_advice_methods?
     has_css?('.field_with_errors .t-advice_methods')
   end


### PR DESCRIPTION
Scenario #4 of #5725:

```
Scenario: Selecting phone and/or online advice with advice filters
Given that I am on the RAD landing page
When I submit a search selecting online and/or phone advice with selected 'types of advice' filters
Then I am show FIRMS AND SUBSIDIARIES that provide advice by phone and/or online (based on the rules above for selecting phone advice, online advice or phone and online advice)
And provide the 'type of advice' I have selected 
And are ordered in alphabetical order (A-Z)
```

Implementation is partially based on existing implementation of filters for `SearchForm`.