### PR TITLE
#6019 Fix meta/title tags on remote search page

### DIFF
--- a/app/controllers/remote_search_controller.rb
+++ b/app/controllers/remote_search_controller.rb
@@ -1,5 +1,5 @@
 class RemoteSearchController < ApplicationController
-  def show
+  def index
     @form        = SearchForm.new(params[:search_form])
     @remote_form = RemoteSearchForm.new(params[:remote_search_form])
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -196,7 +196,7 @@
       online: Ar-lein
       phone: Ffôn
 
-  search:
+  search: &search
     errors:
       geocode_failure: yn anghywir
       missing_advice_method: TODO
@@ -204,6 +204,8 @@
       title_tag: Canlyniadau chwilio | Cyfeirlyfr Cynghorydd Ymddeoliad
       meta_tag_description: Defnyddiwch y Cyfeirlyfr Cynghorydd Ymddeoliad i ddod o hyd i gynghorwyr ariannol a reoleiddir i helpu gyda chynllunio ymddeoliad, treth etifeddiant, rhyddhau ecwiti, ewyllysiau a phrofebion, gofal hirdymor a throsglwyddo pensiwn.
     back_to_top: "Ewch i'r brig"
+
+  remote_search: *search
 
   advice_methods:
     ordinal:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@
       online: Online
       phone: Phone
 
-  search:
+  search: &search
     errors:
       geocode_failure: is incorrect
       missing_advice_method: To continue please select online, telephone or both and run your search again.
@@ -263,6 +263,8 @@
         - text: You may be able to save money by finding an adviser who will deal with you online or by phone.
         - text: These advisers are regulated in exactly the same way and you will have exactly the same protections as if you used a face to face adviser.
         - text: Select ‘online’ or ‘telephone’ in the receive advice section above if you would like to receive advice remotely.
+
+  remote_search: *search
 
   advice_methods:
     ordinal:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
     root 'landing_page#show'
 
     get '/search', to: 'search#index'
-    get '/remote-help-search', to: 'remote_search#show', as: :search_remote_advice
+    get '/remote-help-search', to: 'remote_search#index', as: :search_remote_advice
   end
 end


### PR DESCRIPTION
Fix meta/title tags by providing references in the`YAML` translations.

Also, refactored `RemoteSearchController#index` action to #show to improve consistency with `SearchController` class

@alexwllms 