### PR TITLE
Case insensitive company name sort

### DIFF
--- a/elastic_search_mapping.json
+++ b/elastic_search_mapping.json
@@ -1,8 +1,17 @@
 {
+  "settings": {
+    "index": {
+      "analysis": {
+        "analyzer": {
+          "firm_name_analyzer": { "tokenizer": "keyword", "filter": "lowercase" }
+        }
+      }
+    }
+  },
   "mappings": {
     "firms": {
       "properties": {
-        "registered_name": { "type": "string", "index": "not_analyzed" },
+        "registered_name": { "type": "string", "analyzer": "firm_name_analyzer" },
         "postcode_searchable": { "type": "boolean" },
         "other_advice_methods": { "type": "integer" },
         "investment_sizes": { "type": "integer" },


### PR DESCRIPTION
Solution for the problem Kemi mentioned on slack earlier today (https://slack-files.com/files-tmb/T024GQVEQ-F04142H4C-47dfe46c16/screen_shot_2015-03-13_at_13.17.17_1024.png).

ES Sorting expression was using case sensitive index to sort records. This PR addresses that issue. 

It will require developers to build all indices from scratch.