### PR TITLE
Switching advice type from RAD search results page #5496

### DIFF
--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -66,6 +66,10 @@ class SearchForm
     advice_methods.select(&:present?)
   end
 
+  def advice_methods
+    Array(@advice_methods).select(&:present?).map(&:to_i)
+  end
+
   def advice_methods_present
     if remote_advice_method_ids.empty?
       errors.add(:advice_methods, I18n.t('search.errors.missing_advice_method'))

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -13,12 +13,11 @@
           <div class="search-filter__border">
             <fieldset class="form__group search-filter__section">
               <legend class="search-filter__label search-filter__label--padded"><%= t('search.filter.receive_advice.heading') %></legend>
-
               <%= f.form_row(:checkbox) do %>
                 <%= f.errors_for :checkbox %>
                 <div class="form__group-item">
                   <label>
-                    <%= f.radio_button :advice_method, SearchForm::ADVICE_METHOD_FACE_TO_FACE, class: 'form__group-input' %>
+                    <%= f.radio_button :advice_method, SearchForm::ADVICE_METHOD_FACE_TO_FACE, class: 'form__group-input t-face_to_face_advice' %>
                     <%= t('search.filter.receive_advice.face_to_face') %>
                   </label>
                 </div>
@@ -30,7 +29,7 @@
 
                 <div class="form__group-item">
                   <label>
-                    <%= f.radio_button :advice_method, SearchForm::ADVICE_METHOD_PHONE_OR_ONLINE, class: 'form__group-input' %>
+                    <%= f.radio_button :advice_method, SearchForm::ADVICE_METHOD_PHONE_OR_ONLINE, class: 'form__group-input t-phone_or_online' %>
                     <%= t('search.filter.receive_advice.phone_online') %>
                   </label>
 

--- a/spec/features/channel_filter_on_results_page_spec.rb
+++ b/spec/features/channel_filter_on_results_page_spec.rb
@@ -1,0 +1,175 @@
+RSpec.feature 'Consumer views channel filters on search results page' do
+  let(:landing_page) { LandingPage.new }
+  let(:results_page) { ResultsPage.new }
+
+  let!(:phone_advice)  { create(:other_advice_method, name: 'Advice by telephone', order: 1) }
+  let!(:online_advice) { create(:other_advice_method, name: 'Advice online (e.g. by video call / conference / email)', order: 2) }
+
+  scenario 'Consumer views current filters applied to their search' do
+    with_elastic_search! do
+      given_some_firms_were_indexed
+      and_i_am_on_the_rad_landing_page
+      when_i_select_a_remote_advice_method
+      and_i_submit_the_remote_search_form
+      then_i_am_on_results_page
+      and_i_see_remote_advice_method_selected
+      and_only_remote_firms_are_displayed
+    end
+  end
+
+  scenario 'Consumer changes advice method from in person to remote' do
+    with_elastic_search! do
+      given_some_firms_were_indexed
+      and_i_have_performed_an_in_person_search_from_the_landing_page
+      when_i_select_remote_advice
+      and_i_submit_the_sidebar_search_form
+      then_i_am_on_results_page
+      and_i_see_remote_advice_method_selected
+      and_only_remote_firms_are_displayed
+    end
+  end
+
+  scenario 'Consumer changes advice method from remote to in person' do
+    with_elastic_search! do
+      given_some_firms_were_indexed
+      and_i_have_performed_a_remote_search_from_the_landing_page
+      when_i_select_face_to_face_advice
+      and_i_submit_the_sidebar_search_form
+      then_i_am_on_results_page
+      and_i_see_face_to_face_advice_method_selected
+      and_only_in_person_firms_are_displayed
+    end
+  end
+
+  scenario 'Consumer changes advice method to in person without providing postcode' do
+    with_elastic_search! do
+      given_some_firms_were_indexed
+      and_i_have_performed_a_remote_search_from_the_landing_page
+      when_i_select_face_to_face_advice_without_providing_postcode
+      and_i_submit_the_sidebar_search_form
+      then_i_am_on_the_landing_page
+      and_a_validation_error_message_is_displayed
+    end
+  end
+
+  scenario 'Consumer changes advice method to remote without selecting remote advice type' do
+    with_elastic_search! do
+      given_some_firms_were_indexed
+      and_i_have_performed_an_in_person_search_from_the_landing_page
+      when_i_select_remote_advice_without_providing_type
+      and_i_submit_the_sidebar_search_form
+      then_i_am_on_the_landing_page
+      and_a_validation_error_message_is_displayed
+    end
+  end
+
+
+  def given_some_firms_were_indexed
+    with_fresh_index! do
+      @phone_firm = create(:firm, registered_name: 'The Willers Ltd', in_person_advice_methods: [], other_advice_methods: [ phone_advice ])
+      create(:adviser, postcode: 'RG2 8EE', firm: @phone_firm,       latitude: 51.428473, longitude: -0.943616)
+
+      @online_firm = create(:firm, registered_name: 'The Equiters Ltd', in_person_advice_methods: [], other_advice_methods: [ online_advice ])
+      create(:adviser, postcode: 'LE1 6SL', firm: @online_firm, latitude: 52.633013, longitude: -1.131257)
+
+      @in_person_firm = create(:firm, registered_name: 'Estate Traders Ltd', other_advice_methods: [])
+      create(:adviser, postcode: 'G1 5QT', firm: @in_person_firm, latitude: 55.856191, longitude: -4.247082)
+    end
+  end
+
+  def and_i_am_on_the_rad_landing_page
+    landing_page.load
+  end
+
+  def and_i_have_performed_an_in_person_search_from_the_landing_page
+    landing_page.load
+    landing_page.in_person.tap do |section|
+      section.postcode.set 'G1 5QT'
+      section.equity_release.set(true)
+      section.search.click
+    end
+  end
+
+  def and_i_have_performed_a_remote_search_from_the_landing_page
+    landing_page.load
+    landing_page.remote.tap do |section|
+      section.online.set(true)
+      section.search.click
+    end
+  end
+
+  def when_i_select_a_remote_advice_method
+    landing_page.load
+    landing_page.in_person.tap do |section|
+      section.online.set(true)
+      section.search.click
+    end
+  end
+
+  def when_i_select_remote_advice
+    results_page.criteria.remote_advice.set(true)
+    results_page.criteria.online.set(true)
+  end
+
+  def when_i_select_face_to_face_advice_without_providing_postcode
+    results_page.criteria.in_person_advice.set(true)
+  end
+
+  def when_i_select_remote_advice_without_providing_type
+    results_page.criteria.remote_advice.set(true)
+  end
+
+  def and_i_submit_the_sidebar_search_form
+    results_page.criteria.search.click
+  end
+
+  def and_i_submit_the_remote_search_form
+    landing_page.remote.search.click
+  end
+
+  def when_i_select_a_remote_advice_method
+    landing_page.remote.online.set(true)
+  end
+
+  def when_i_select_face_to_face_advice
+    results_page.criteria.in_person_advice.set(true)
+    results_page.criteria.postcode.set 'G1 5QT'
+  end
+
+  def and_i_submit_the_face_to_face_search_form
+    landing_page.remote.search.click
+  end
+
+  def and_i_submit_the_remote_search_form
+    landing_page.remote.search.click
+  end
+
+  def then_i_am_on_results_page
+    expect(results_page).to be_displayed
+  end
+
+  def and_i_see_remote_advice_method_selected
+    expect(results_page.criteria.remote_advice).to be_checked
+    expect(results_page.criteria.online).to be_checked
+  end
+
+  def and_i_see_face_to_face_advice_method_selected
+    expect(results_page.criteria.in_person_advice).to be_checked
+  end
+
+  def then_i_am_on_the_landing_page
+    expect(landing_page).to be_displayed
+  end
+
+  def and_a_validation_error_message_is_displayed
+    expect(landing_page).to be_invalid_parameters
+  end
+
+  def and_only_remote_firms_are_displayed
+    expect(results_page.firm_names).to contain_exactly(@online_firm.registered_name)
+  end
+
+  def and_only_in_person_firms_are_displayed
+    expect(results_page.firm_names).to contain_exactly(@in_person_firm.registered_name)
+  end
+end

--- a/spec/features/consumer_search_on_results_list_spec.rb
+++ b/spec/features/consumer_search_on_results_list_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Consumer views advice filters on search results page' do
   def and_i_have_performed_a_search_from_the_landing_page
     landing_page.load
     landing_page.in_person.tap do |section|
-      section.postcode.set('G1 5QT')
+      section.postcode.set 'G1 5QT'
       section.equity_release.set(true)
       section.search.click
     end
@@ -67,7 +67,7 @@ RSpec.feature 'Consumer views advice filters on search results page' do
 
   def when_i_search_with_a_reading_postcode
     landing_page.in_person.tap do |section|
-      section.postcode.set('G1 5QT')
+      section.postcode.set 'G1 5QT'
       section.search.click
     end
   end
@@ -81,7 +81,7 @@ RSpec.feature 'Consumer views advice filters on search results page' do
   end
 
   def and_previously_selected_filters_are_selected_by_default
-    expect(results_page.criteria.postcode.value).to eql('G1 5QT')
+    expect(results_page.criteria.postcode.value).to eql 'G1 5QT'
   end
 
   def when_i_amend_some_of_the_filters
@@ -100,7 +100,7 @@ RSpec.feature 'Consumer views advice filters on search results page' do
 
   def when_i_change_postcode
     results_page.criteria.tap do |section|
-      section.postcode.set('RG2 8EE')
+      section.postcode.set 'RG2 8EE'
       section.equity_release.set(false)
       section.search.click
     end

--- a/spec/support/landing_page.rb
+++ b/spec/support/landing_page.rb
@@ -7,4 +7,8 @@ class LandingPage < SitePrism::Page
 
   section :in_person, InPersonSection, '.t-in-person'
   section :remote, RemoteSection, '.t-remote'
+
+  def invalid_parameters?
+    has_css?('.field_with_errors')
+  end
 end

--- a/spec/support/search_criteria_section.rb
+++ b/spec/support/search_criteria_section.rb
@@ -13,4 +13,6 @@ class SearchCriteriaSection < SitePrism::Section
   element :online, '.t-advice-method-2'
 
   element :search, '.button--primary'
+  element :in_person_advice, '.t-face_to_face_advice'
+  element :remote_advice, '.t-phone_or_online'
 end


### PR DESCRIPTION
Note: redirects after submitting invalid search criteria (e.g. no postcode for face2face, neither phone/online for remote advice) will come as a separate story, as validation messages are still pending design and there'll be minor tweaks in functionality

thus: lines 50/51&61/62 are temporary