### PR TITLE
Add ERB toggle to hide adviser distance on remote results page

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -102,7 +102,10 @@
           <li class="result t-firm">
             <div class="result__heading">
               <%= heading_tag(firm.name, level: 2, class: 'result__heading-text t-name') %>
-              <p class="result__adviser-distance"><%= t('search.result.adviser') %> <%= number_to_human(firm.closest_adviser, significant: true) %> <%= t('search.result.miles_away') %></p>
+
+              <% if firm.closest_adviser %>
+                <p class="result__adviser-distance"><%= t('search.result.adviser') %> <%= number_to_human(firm.closest_adviser, significant: true) %> <%= t('search.result.miles_away') %></p>
+              <% end %>
             </div>
 
             <div class="result__address">


### PR DESCRIPTION
@benlovell @lshepstone 

Not sure if this also requires tests? Also there may be a more elegant way of achieving this but hey ho.