### PR TITLE
Removes white space from the firm telephone number.

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -95,7 +95,7 @@
                   <span class="address__line post-code"><%= firm.address_postcode %></span>
                 </p>
 
-                <a href="tel:<%= firm.telephone_number.strip %>" class="address__link phone">
+                <a href="tel:<%= firm.telephone_number.gsub(/\s+/, '') %>" class="address__link phone">
                   <svg title="" xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon-phone">
                     <use xlink:href="#icon-phone"></use>
                   </svg>


### PR DESCRIPTION
This is so that the `tel:` links work properly.

@alexwllms @benlovell @amansinghb 