### PR TITLE
Makes missing logos explicit

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,15 @@ module ApplicationHelper
   def search_filter_options(form, page_name)
     render partial: 'landing_page/search_filter_options', locals: { f: form, page_name: page_name }
   end
+
+  def render_logo(id, kind)
+    key = kind.to_s.titleize.constantize.friendly_name(id)
+
+    unless key == 'ignored'
+      info = t("search.accreditations.items.#{key}")
+      link_to "glossary/##{key}", target: '_blank', class: "accreditation t-#{kind}" do
+        image_tag "#{key}.png", alt: info[:title], class: 'accreditation__img'
+      end
+    end
+  end
 end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -166,21 +166,11 @@
 
               <div class="result__qualifications-logos">
                 <% firm.adviser_qualification_ids.each do |id| %>
-                  <% if key = Qualification.friendly_name(id) %>
-                    <% info = t("search.accreditations.items.#{key}") %>
-                    <a href="glossary/#<%= id %>" target="_blank" class="accreditation t-qualification">
-                      <%= image_tag("#{id}.png", alt: info[:title], class: 'accreditation__img') %>
-                    </a>
-                  <% end %>
+                  <%= render_logo(id, :qualification) %>
                 <% end %>
 
                 <% firm.adviser_accreditation_ids.each do |id| %>
-                  <% if key = Accreditation.friendly_name(id) %>
-                    <% info = t("search.accreditations.items.#{key}") %>
-                    <a href="glossary/#<%= id %>" target="_blank" class="accreditation t-accreditation">
-                      <%= image_tag("#{id}.png", alt: info[:title], class: 'accreditation__img') %>
-                    </a>
-                  <% end %>
+                  <%= render_logo(id, :accreditation) %>
                 <% end %>
               </div>
             </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,13 +329,20 @@
       '3': 'At agreed location'
   qualification:
     ordinal:
+      '1': ignored
+      '2': ignored
       '3': chartered_fp
       '4': certified_fp
+      '5': ignored
+      '6': ignored
+      '7': ignored
   accreditation:
     ordinal:
       '1': solla
       '2': later_life_academy
       '3': iso_22222
+      '4': ignored
+      '5': ignored
 
   glossary:
     show:


### PR DESCRIPTION
When they're listed as `ignored` in the translations lookup they'll not
be outputted in the search results.