### PR TITLE
Adds adviser range filtering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     globalid (0.3.3)
       activesupport (>= 4.1.0)
     hike (1.2.3)
-    http (0.7.2)
+    http (0.7.3)
       http-form_data (~> 1.0.0)
       http_parser.rb (~> 0.6.0)
     http-form_data (1.0.0)
@@ -100,7 +100,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.24)
+    mas-rad_core (0.0.25)
       active_model_serializers
       geocoder
       http

--- a/app/serializers/search_form_serializer.rb
+++ b/app/serializers/search_form_serializer.rb
@@ -74,9 +74,24 @@ class SearchFormSerializer < ActiveModel::Serializer
         nested: {
           path: 'advisers',
           filter: {
-            geo_distance: {
-              distance: '650miles',
-              location: object.coordinates.reverse
+            bool: {
+              must: {
+                geo_shape: {
+                  range_location: {
+                    relation: 'intersects',
+                    shape: {
+                      type: 'point',
+                      coordinates: object.coordinates.reverse
+                    }
+                  }
+                }
+              },
+              should: {
+                geo_distance: {
+                  distance: '750miles',
+                  location: object.coordinates.reverse
+                }
+              }
             }
           }
         }

--- a/elastic_search_mapping.json
+++ b/elastic_search_mapping.json
@@ -38,6 +38,7 @@
           "type": "nested",
           "properties": {
             "location": { "type": "geo_point" },
+            "range_location": { "type": "geo_shape" },
             "range": { "type": "integer" },
             "name": { "type": "string", "index": "not_analyzed" }
           }

--- a/spec/features/consumer_searches_by_postcode_only_spec.rb
+++ b/spec/features/consumer_searches_by_postcode_only_spec.rb
@@ -68,9 +68,9 @@ RSpec.feature 'Consumer searches by postcode only' do
 
   def and_firms_with_advisers_covering_my_postcode_were_previously_indexed
     with_fresh_index! do
-      @reading   = create(:adviser, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616)
-      @leicester = create(:adviser, postcode: 'LE1 6SL', latitude: 52.633013, longitude: -1.131257)
-      @glasgow   = create(:adviser, postcode: 'G1 5QT', latitude: 55.856191, longitude: -4.247082)
+      @reading   = create(:adviser, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616, travel_distance: 100)
+      @leicester = create(:adviser, postcode: 'LE1 6SL', latitude: 52.633013, longitude: -1.131257, travel_distance: 650)
+      @glasgow   = create(:adviser, postcode: 'G1 5QT', latitude: 55.856191, longitude: -4.247082, travel_distance: 10)
 
       @missing = create(:firm, in_person_advice_methods: []) do |firm|
         create(:adviser, firm: firm, latitude: 51.428473, longitude: -0.943616)
@@ -99,7 +99,6 @@ RSpec.feature 'Consumer searches by postcode only' do
     expect(results_page.firm_names).to eql([
       @reading.firm.registered_name,
       @leicester.firm.registered_name,
-      @glasgow.firm.registered_name
     ])
   end
 


### PR DESCRIPTION
Now filters based on proper adviser radius. Also orders by geographic
distance. The distance filter is essentially a fudge to provide range
ordering as shapes do not support this behaviour. It works, and seems
to be reasonably performant. We could certainly trade some accuracy for
speed, if necessary.