### PR TITLE
Additional feature specs for better coverage

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -211,7 +211,7 @@
         </div>
 
         <% else %>
-          <p><%= t('search.incorrect_search_criteria') %></p>
+          <p class="t-incorrect-criteria"><%= t('search.incorrect_search_criteria') %></p>
         <% end %>
     </div>
 

--- a/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
@@ -1,8 +1,8 @@
-RSpec.feature 'Consumer requires advice on various topics' do
+RSpec.feature 'Landing page, consumer requires advice on various topics in person' do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
-  scenario 'Filter for various types of advice' do
+  scenario 'Filter for various types of advice returns matching firms' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page

--- a/spec/features/landing_face_to_face_filter_for_pension_advice_spec.rb
+++ b/spec/features/landing_face_to_face_filter_for_pension_advice_spec.rb
@@ -1,46 +1,46 @@
-RSpec.feature 'Consumer requires help with their pension over the phone or online' do
+RSpec.feature 'Lading page, consumer requires help with their pension in person' do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
   let(:latitude) { rand(51.428473..55.856191) }
   let(:longitude) { rand(-4.247082..-0.943616) }
 
-  scenario 'Filter for general pension pot advice' do
+  scenario 'Filter for general pension pot advice returns matching firms' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page
-      and_i_select_phone_or_online_advice
-      and_i_select_the_phone_and_or_online_advice_methods
+      and_i_select_face_to_face_advice
+      and_i_enter_a_valid_postcode
       and_i_indicate_that_i_need_help_with_my_pension_pot
       and_i_see_the_default_option_is_i_dont_know_or_wish_to_say
-      when_i_submit_the_phone_or_online_advice_search
+      when_i_submit_the_face_to_face_advice_search
       then_i_am_shown_firms_that_can_advise_on_pension_pots
     end
   end
 
-  scenario 'Filter for advice on a pension pot size' do
+  scenario 'Filter for advice on a pension pot size returns matching firms' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page
-      and_i_select_phone_or_online_advice
-      and_i_select_the_phone_and_or_online_advice_methods
+      and_i_select_face_to_face_advice
+      and_i_enter_a_valid_postcode
       and_i_indicate_that_i_need_help_with_my_pension_pot
       and_i_select_a_pot_size_band_from_the_available_options
-      when_i_submit_the_phone_or_online_advice_search
+      when_i_submit_the_face_to_face_advice_search
       then_i_am_shown_firms_that_can_advise_on_my_pension_pot_size
     end
   end
 
-  scenario 'Filter for advice on pension pot transfers' do
+  scenario 'Filter for advice on pension pot transfers returns matching firms' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page
-      and_i_select_phone_or_online_advice
-      and_i_select_the_phone_and_or_online_advice_methods
+      and_i_select_face_to_face_advice
+      and_i_enter_a_valid_postcode
       and_i_indicate_that_i_need_help_with_my_pension_pot
       and_i_select_a_pot_size_band_from_the_available_options
       and_i_indicate_that_i_would_like_to_transfer_my_pension
-      when_i_submit_the_phone_or_online_advice_search
+      when_i_submit_the_face_to_face_advice_search
       then_i_am_shown_firms_that_can_assist_with_pension_transfers
     end
   end
@@ -52,63 +52,53 @@ RSpec.feature 'Consumer requires help with their pension over the phone or onlin
   def given_firms_with_advisers_were_previously_indexed
     @investment_sizes = create_list(:investment_size, 5)
 
-    other_advice_methods = [
-      create(:other_advice_method, name: 'Advice by telephone', order: 1),
-      create(:other_advice_method, name: 'Advice online (e.g. by video call / conference / email)', order: 2)
-    ]
-
     with_fresh_index! do
-      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 90, other_percent: 10, investment_sizes: @investment_sizes.values_at(0, 1), other_advice_methods: other_advice_methods)
+      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 90, other_percent: 10, investment_sizes: @investment_sizes.values_at(0, 1))
       create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 10, other_percent: 90, investment_sizes: @investment_sizes.values_at(2, 3), other_advice_methods: other_advice_methods)
+      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 10, other_percent: 90, investment_sizes: @investment_sizes.values_at(2, 3))
       create(:adviser, firm: @medium_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 50, pension_transfer_percent: 50, investment_sizes: @investment_sizes, other_advice_methods: other_advice_methods)
+      @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 50, pension_transfer_percent: 50, investment_sizes: @investment_sizes)
       create(:adviser, firm: @pension_transfer_firm, latitude: latitude, longitude: longitude)
 
-      @excluded = create(:firm_with_no_business_split, other_percent: 100, other_advice_methods: other_advice_methods)
+      @excluded = create(:firm_with_no_business_split, other_percent: 100)
       create(:adviser, firm: @excluded, latitude: latitude, longitude: longitude)
     end
   end
 
-  def and_i_select_phone_or_online_advice
+  def and_i_select_face_to_face_advice
     # This is here to help make the feature steps read easier, but also
     # serves as a place-holder for when the search form markup becomes
     # one form and requires the advice method to be selected.
   end
 
-  def and_i_select_the_phone_and_or_online_advice_methods
-    landing_page.remote.by_phone.set true
-    landing_page.remote.online.set true
+  def and_i_enter_a_valid_postcode
+    landing_page.in_person.postcode.set 'RG2 9FL'
   end
 
   def and_i_indicate_that_i_need_help_with_my_pension_pot
-    landing_page.remote.retirement_income_products.set true
+    landing_page.in_person.retirement_income_products.set true
   end
 
   def and_i_see_the_default_option_is_i_dont_know_or_wish_to_say
-    expect(landing_page.remote.pension_pot_size.value).to eql(SearchForm::ANY_SIZE_VALUE)
+    expect(landing_page.in_person.pension_pot_size.value).to eql(SearchForm::ANY_SIZE_VALUE)
   end
 
   def and_i_select_a_pot_size_band_from_the_available_options
-    landing_page.remote.pension_pot_size.select @small_pot_size_firm.investment_sizes.sample.name
+    landing_page.in_person.pension_pot_size.select @small_pot_size_firm.investment_sizes.sample.name
   end
 
   def and_i_indicate_that_i_dont_know_the_size_of_my_pension_pot
-    landing_page.remote.pension_pot_size.select I18n.t('search_filter.pension_pot.any_size_option')
+    landing_page.in_person.pension_pot_size.select I18n.t('search_filter.pension_pot.any_size_option')
   end
 
   def and_i_indicate_that_i_would_like_to_transfer_my_pension
-    landing_page.remote.pension_transfer.set true
+    landing_page.in_person.pension_transfer.set true
   end
 
   def when_i_submit_the_face_to_face_advice_search
-    landing_page.remote.search.click
-  end
-
-  def when_i_submit_the_phone_or_online_advice_search
-    landing_page.remote.search.click
+    landing_page.in_person.search.click
   end
 
   def then_i_am_shown_firms_that_can_advise_on_pension_pots

--- a/spec/features/landing_face_to_face_search_spec.rb
+++ b/spec/features/landing_face_to_face_search_spec.rb
@@ -1,24 +1,10 @@
-RSpec.feature 'Consumer searches by postcode only' do
+RSpec.feature 'Landing page, consumer requires general advice in person' do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
-  scenario 'Consumer enters a invalid postcode' do
-    given_i_am_on_the_rad_landing_page
-    when_i_submit_a_invalid_postcode_search
-    then_i_am_told_the_postcode_is_incorrect
-  end
-
-  scenario 'Postcode cannot be geocoded' do
-    VCR.use_cassette(:postcode_cannot_be_geocoded) do
-      given_i_am_on_the_rad_landing_page
-      when_i_submit_a_postcode_that_cannot_be_geocoded
-      then_i_am_told_the_postcode_is_incorrect
-    end
-  end
-
-  scenario 'Consumer enters a valid postcode' do
+  scenario 'Using a valid postcode returns firms ordered by distance' do
     with_elastic_search! do
-      given_i_am_on_the_rad_landing_page
+      given_i_am_on_the_landing_page
       and_firms_with_advisers_covering_my_postcode_were_previously_indexed
       when_i_search_with_a_reading_postcode
       then_i_am_shown_firms_with_advisers_covering_my_postcode
@@ -27,9 +13,23 @@ RSpec.feature 'Consumer searches by postcode only' do
     end
   end
 
+  scenario 'Using an invalid postcode shows an error message' do
+    given_i_am_on_the_landing_page
+    when_i_submit_a_invalid_postcode_search
+    then_i_am_told_the_postcode_is_incorrect
+  end
+
+  scenario 'Using a postcode that cannot be geocoded shows an error message' do
+    VCR.use_cassette(:postcode_cannot_be_geocoded) do
+      given_i_am_on_the_landing_page
+      when_i_submit_a_postcode_that_cannot_be_geocoded
+      then_i_am_told_the_postcode_is_incorrect
+    end
+  end
+
   scenario 'Paginating through 21 results' do
     with_elastic_search! do
-      given_i_am_on_the_rad_landing_page
+      given_i_am_on_the_landing_page
       and_multiple_firms_were_created_and_indexed
       when_i_search_with_a_reading_postcode
       then_i_see_ten_results
@@ -40,7 +40,7 @@ RSpec.feature 'Consumer searches by postcode only' do
   end
 
 
-  def given_i_am_on_the_rad_landing_page
+  def given_i_am_on_the_landing_page
     landing_page.load
   end
 

--- a/spec/features/landing_face_to_face_search_spec.rb
+++ b/spec/features/landing_face_to_face_search_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature 'Landing page, consumer requires general advice in person' do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
-  scenario 'Using a valid postcode returns firms ordered by distance' do
+  scenario 'Using a valid postcode' do
     with_elastic_search! do
       given_i_am_on_the_landing_page
       and_firms_with_advisers_covering_my_postcode_were_previously_indexed
@@ -13,13 +13,13 @@ RSpec.feature 'Landing page, consumer requires general advice in person' do
     end
   end
 
-  scenario 'Using an invalid postcode shows an error message' do
+  scenario 'Using an invalid postcode' do
     given_i_am_on_the_landing_page
     when_i_submit_a_invalid_postcode_search
     then_i_am_told_the_postcode_is_incorrect
   end
 
-  scenario 'Using a postcode that cannot be geocoded shows an error message' do
+  scenario 'Using a postcode that cannot be geocoded' do
     VCR.use_cassette(:postcode_cannot_be_geocoded) do
       given_i_am_on_the_landing_page
       when_i_submit_a_postcode_that_cannot_be_geocoded

--- a/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -2,7 +2,7 @@ RSpec.feature 'Landing page, consumer requires various types of advice over the 
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
-  scenario 'Filter for various types of advice returns matching firms' do
+  scenario 'Filter for various types of advice' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page

--- a/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -1,8 +1,8 @@
-RSpec.feature 'Consumer requires various types of advice' do
+RSpec.feature 'Landing page, consumer requires various types of advice over the phone or online' do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
-  scenario 'Filter for various types of advice' do
+  scenario 'Filter for various types of advice returns matching firms' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page

--- a/spec/features/landing_phone_or_online_filter_for_pension_advice_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_pension_advice_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Landing page, consumer requires help with their pension over the 
   let(:latitude) { rand(51.428473..55.856191) }
   let(:longitude) { rand(-4.247082..-0.943616) }
 
-  scenario 'Filter for general pension pot advice returns matching firms' do
+  scenario 'Filter for general pension pot advice' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page
@@ -18,7 +18,7 @@ RSpec.feature 'Landing page, consumer requires help with their pension over the 
     end
   end
 
-  scenario 'Filter for advice on a pension pot size returns matching firms' do
+  scenario 'Filter for advice on a pension pot size' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page
@@ -31,7 +31,7 @@ RSpec.feature 'Landing page, consumer requires help with their pension over the 
     end
   end
 
-  scenario 'Filter for advice on pension pot transfers returns matching firms' do
+  scenario 'Filter for advice on pension pot transfers' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page

--- a/spec/features/landing_phone_or_online_filter_for_pension_advice_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_pension_advice_spec.rb
@@ -1,46 +1,46 @@
-RSpec.feature 'Consumer requires help with their pension in person' do
+RSpec.feature 'Landing page, consumer requires help with their pension over the phone or online' do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
   let(:latitude) { rand(51.428473..55.856191) }
   let(:longitude) { rand(-4.247082..-0.943616) }
 
-  scenario 'Filter for general pension pot advice' do
+  scenario 'Filter for general pension pot advice returns matching firms' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page
-      and_i_select_face_to_face_advice
-      and_i_enter_a_valid_postcode
+      and_i_select_phone_or_online_advice
+      and_i_select_the_phone_and_or_online_advice_methods
       and_i_indicate_that_i_need_help_with_my_pension_pot
       and_i_see_the_default_option_is_i_dont_know_or_wish_to_say
-      when_i_submit_the_face_to_face_advice_search
+      when_i_submit_the_phone_or_online_advice_search
       then_i_am_shown_firms_that_can_advise_on_pension_pots
     end
   end
 
-  scenario 'Filter for advice on a pension pot size' do
+  scenario 'Filter for advice on a pension pot size returns matching firms' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page
-      and_i_select_face_to_face_advice
-      and_i_enter_a_valid_postcode
+      and_i_select_phone_or_online_advice
+      and_i_select_the_phone_and_or_online_advice_methods
       and_i_indicate_that_i_need_help_with_my_pension_pot
       and_i_select_a_pot_size_band_from_the_available_options
-      when_i_submit_the_face_to_face_advice_search
+      when_i_submit_the_phone_or_online_advice_search
       then_i_am_shown_firms_that_can_advise_on_my_pension_pot_size
     end
   end
 
-  scenario 'Filter for advice on pension pot transfers' do
+  scenario 'Filter for advice on pension pot transfers returns matching firms' do
     with_elastic_search! do
       given_firms_with_advisers_were_previously_indexed
       and_i_am_on_the_landing_page
-      and_i_select_face_to_face_advice
-      and_i_enter_a_valid_postcode
+      and_i_select_phone_or_online_advice
+      and_i_select_the_phone_and_or_online_advice_methods
       and_i_indicate_that_i_need_help_with_my_pension_pot
       and_i_select_a_pot_size_band_from_the_available_options
       and_i_indicate_that_i_would_like_to_transfer_my_pension
-      when_i_submit_the_face_to_face_advice_search
+      when_i_submit_the_phone_or_online_advice_search
       then_i_am_shown_firms_that_can_assist_with_pension_transfers
     end
   end
@@ -52,53 +52,59 @@ RSpec.feature 'Consumer requires help with their pension in person' do
   def given_firms_with_advisers_were_previously_indexed
     @investment_sizes = create_list(:investment_size, 5)
 
+    other_advice_methods = [
+      create(:other_advice_method, name: 'Advice by telephone', order: 1),
+      create(:other_advice_method, name: 'Advice online (e.g. by video call / conference / email)', order: 2)
+    ]
+
     with_fresh_index! do
-      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 90, other_percent: 10, investment_sizes: @investment_sizes.values_at(0, 1))
+      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 90, other_percent: 10, investment_sizes: @investment_sizes.values_at(0, 1), other_advice_methods: other_advice_methods)
       create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 10, other_percent: 90, investment_sizes: @investment_sizes.values_at(2, 3))
+      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 10, other_percent: 90, investment_sizes: @investment_sizes.values_at(2, 3), other_advice_methods: other_advice_methods)
       create(:adviser, firm: @medium_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 50, pension_transfer_percent: 50, investment_sizes: @investment_sizes)
+      @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 50, pension_transfer_percent: 50, investment_sizes: @investment_sizes, other_advice_methods: other_advice_methods)
       create(:adviser, firm: @pension_transfer_firm, latitude: latitude, longitude: longitude)
 
-      @excluded = create(:firm_with_no_business_split, other_percent: 100)
+      @excluded = create(:firm_with_no_business_split, other_percent: 100, other_advice_methods: other_advice_methods)
       create(:adviser, firm: @excluded, latitude: latitude, longitude: longitude)
     end
   end
 
-  def and_i_select_face_to_face_advice
+  def and_i_select_phone_or_online_advice
     # This is here to help make the feature steps read easier, but also
     # serves as a place-holder for when the search form markup becomes
     # one form and requires the advice method to be selected.
   end
 
-  def and_i_enter_a_valid_postcode
-    landing_page.in_person.postcode.set 'RG2 9FL'
+  def and_i_select_the_phone_and_or_online_advice_methods
+    landing_page.remote.by_phone.set true
+    landing_page.remote.online.set true
   end
 
   def and_i_indicate_that_i_need_help_with_my_pension_pot
-    landing_page.in_person.retirement_income_products.set true
+    landing_page.remote.retirement_income_products.set true
   end
 
   def and_i_see_the_default_option_is_i_dont_know_or_wish_to_say
-    expect(landing_page.in_person.pension_pot_size.value).to eql(SearchForm::ANY_SIZE_VALUE)
+    expect(landing_page.remote.pension_pot_size.value).to eql(SearchForm::ANY_SIZE_VALUE)
   end
 
   def and_i_select_a_pot_size_band_from_the_available_options
-    landing_page.in_person.pension_pot_size.select @small_pot_size_firm.investment_sizes.sample.name
+    landing_page.remote.pension_pot_size.select @small_pot_size_firm.investment_sizes.sample.name
   end
 
   def and_i_indicate_that_i_dont_know_the_size_of_my_pension_pot
-    landing_page.in_person.pension_pot_size.select I18n.t('search_filter.pension_pot.any_size_option')
+    landing_page.remote.pension_pot_size.select I18n.t('search_filter.pension_pot.any_size_option')
   end
 
   def and_i_indicate_that_i_would_like_to_transfer_my_pension
-    landing_page.in_person.pension_transfer.set true
+    landing_page.remote.pension_transfer.set true
   end
 
-  def when_i_submit_the_face_to_face_advice_search
-    landing_page.in_person.search.click
+  def when_i_submit_the_phone_or_online_advice_search
+    landing_page.remote.search.click
   end
 
   def then_i_am_shown_firms_that_can_advise_on_pension_pots

--- a/spec/features/landing_phone_or_online_search_spec.rb
+++ b/spec/features/landing_phone_or_online_search_spec.rb
@@ -1,0 +1,118 @@
+RSpec.feature 'Landing page, consumer requires general advice over the phone or online' do
+  let(:landing_page) { LandingPage.new }
+  let(:results_page) { ResultsPage.new }
+
+  scenario 'Using only the phone advice method returns matching firms ordered by name that provide only advice by phone' do
+    with_elastic_search! do
+      given_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_landing_page
+      and_i_select_phone_or_online_advice
+      and_i_select_the_phone_advice_method
+      when_i_submit_the_phone_or_online_advice_search
+      then_i_see_firms_that_provide_advice_over_the_phone
+    end
+  end
+
+  scenario 'Using only the online advice method returns matching firms ordered by name that provide only advice online' do
+    with_elastic_search! do
+      given_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_landing_page
+      and_i_select_phone_or_online_advice
+      and_i_select_the_online_advice_method
+      when_i_submit_the_phone_or_online_advice_search
+      then_i_see_firms_that_provide_advice_online
+    end
+  end
+
+  scenario 'Using both the phone and online advice methods returns matching firms ordered by name that provide advice by phone or online' do
+    with_elastic_search! do
+      given_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_landing_page
+      and_i_select_phone_or_online_advice
+      and_i_select_both_the_phone_and_online_advice_methods
+      when_i_submit_the_phone_or_online_advice_search
+      then_i_see_firms_that_provide_advice_over_the_phone_or_online
+    end
+  end
+
+  scenario 'Using no advice method shows an error message' do
+    with_elastic_search! do
+      given_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_landing_page
+      and_i_select_phone_or_online_advice
+      when_i_submit_the_phone_or_online_advice_search
+      then_i_see_an_error_message
+    end
+  end
+
+  def given_firms_with_advisers_were_previously_indexed
+    other_advice_methods = [
+      create(:other_advice_method, name: 'Phone', order: 1),
+      create(:other_advice_method, name: 'Online', order: 2)
+    ]
+
+    with_fresh_index! do
+      @phone_firm = create(:firm, other_advice_methods: [other_advice_methods.first])
+      create(:adviser, firm: @phone_firm)
+
+      @online_firm = create(:firm, other_advice_methods: [other_advice_methods.second])
+      create(:adviser, firm: @online_firm)
+
+      @excluded = create(:firm, other_advice_methods: [])
+      create(:adviser, firm: @excluded)
+    end
+  end
+
+  def and_i_am_on_the_landing_page
+    landing_page.load
+  end
+
+  def and_i_select_phone_or_online_advice
+    # This is here to help make the feature steps read easier, but also
+    # serves as a place-holder for when the search form markup becomes
+    # one form and requires the advice method to be selected.
+  end
+
+  def and_i_select_the_phone_advice_method
+    landing_page.remote.by_phone.set true
+  end
+
+  def and_i_select_the_online_advice_method
+    landing_page.remote.online.set true
+  end
+
+  def and_i_select_both_the_phone_and_online_advice_methods
+    landing_page.remote.by_phone.set true
+    landing_page.remote.online.set true
+  end
+
+  def when_i_submit_the_phone_or_online_advice_search
+    landing_page.remote.search.click
+  end
+
+  def then_i_see_firms_that_provide_advice_over_the_phone
+    expect(results_page).to be_displayed
+    expect(results_page).to have_firms(count: 1)
+    expect(results_page.firm_names).to include(@phone_firm.registered_name)
+  end
+
+  def then_i_see_firms_that_provide_advice_online
+    expect(results_page).to be_displayed
+    expect(results_page).to have_firms(count: 1)
+    expect(results_page.firm_names).to include(@online_firm.registered_name)
+  end
+
+  def then_i_see_firms_that_provide_advice_over_the_phone_or_online
+    expect(results_page).to be_displayed
+    expect(results_page).to have_firms(count: 2)
+    expect(results_page.firm_names).to include(
+      @phone_firm.registered_name,
+      @online_firm.registered_name
+    )
+  end
+
+  def then_i_see_an_error_message
+    expect(landing_page).to be_displayed
+    expect(landing_page).to have_errors
+  end
+end

--- a/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
@@ -1,21 +1,28 @@
-RSpec.feature 'Landing page, consumer requires advice on various topics in person' do
+RSpec.feature 'Results page, consumer requires advice on various topics in person' do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
   scenario 'Filter for various types of advice' do
     with_elastic_search! do
-      given_firms_with_advisers_were_previously_indexed
-      and_i_am_on_the_landing_page
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
       and_i_select_face_to_face_advice
       and_i_enter_a_valid_postcode
       and_i_indicate_i_need_advice_on_various_topics
-      when_i_submit_the_face_to_face_advice_search
+      when_i_submit_the_search
       then_i_am_shown_firms_that_provide_the_selected_types_of_advice
       and_they_are_ordered_by_business_split_and_location
     end
   end
 
-  def given_firms_with_advisers_were_previously_indexed
+  def given_reference_data_has_been_populated
+    create(:other_advice_method, name: 'Phone', order: 1)
+    create(:other_advice_method, name: 'Online', order: 2)
+  end
+
+  def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
       @first = create(:firm_with_no_business_split, retirement_income_products_percent: 30, wills_and_probate_percent: 20, other_percent: 50)
       @glasgow = create(:adviser, firm: @first, latitude: 55.856191, longitude: -4.247082)
@@ -32,27 +39,50 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
     end
   end
 
-  def and_i_am_on_the_landing_page
+  def and_i_am_on_the_results_page_after_a_previous_search
     landing_page.load
+    landing_page.in_person.tap do |f|
+      f.postcode.set 'RG2 9FL'
+      f.search.click
+    end
+
+    expect(results_page).to be_displayed
+  end
+
+  def and_i_clear_any_filters_from_the_previous_search
+    results_page.search_form.tap do |f|
+      f.face_to_face.set false
+      f.phone_or_online.set false
+
+      f.postcode.set nil
+      f.phone.set false
+      f.online.set false
+
+      f.retirement_income_products.set false
+      f.pension_pot_size.set SearchForm::ANY_SIZE_VALUE
+      f.pension_transfer.set false
+      f.options_when_paying_for_care.set false
+      f.equity_release.set false
+      f.inheritance_tax_planning.set false
+      f.wills_and_probate.set false
+    end
   end
 
   def and_i_select_face_to_face_advice
-    # This is here to help make the feature steps read easier, but also
-    # serves as a place-holder for when the search form markup becomes
-    # one form and requires the advice method to be selected.
+    results_page.search_form.face_to_face.set true
   end
 
   def and_i_enter_a_valid_postcode
-    landing_page.in_person.postcode.set 'RG2 9FL'
+    results_page.search_form.postcode.set 'RG2 9FL'
   end
 
   def and_i_indicate_i_need_advice_on_various_topics
-    landing_page.in_person.retirement_income_products.set true
-    landing_page.in_person.wills_and_probate.set true
+    results_page.search_form.retirement_income_products.set true
+    results_page.search_form.wills_and_probate.set true
   end
 
-  def when_i_submit_the_face_to_face_advice_search
-    landing_page.in_person.search.click
+  def when_i_submit_the_search
+    results_page.search_form.search.click
   end
 
   def then_i_am_shown_firms_that_provide_the_selected_types_of_advice

--- a/spec/features/results_face_to_face_filter_for_pension_advice_spec.rb
+++ b/spec/features/results_face_to_face_filter_for_pension_advice_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature 'Landing page, consumer requires help with their pension in person' do
+RSpec.feature 'Results page, consumer requires help with their pension in person' do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
@@ -7,51 +7,57 @@ RSpec.feature 'Landing page, consumer requires help with their pension in person
 
   scenario 'Filter for general pension pot advice' do
     with_elastic_search! do
-      given_firms_with_advisers_were_previously_indexed
-      and_i_am_on_the_landing_page
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
       and_i_select_face_to_face_advice
       and_i_enter_a_valid_postcode
       and_i_indicate_that_i_need_help_with_my_pension_pot
-      and_i_see_the_default_option_is_i_dont_know_or_wish_to_say
-      when_i_submit_the_face_to_face_advice_search
+      when_i_submit_the_search
       then_i_am_shown_firms_that_can_advise_on_pension_pots
     end
   end
 
   scenario 'Filter for advice on a pension pot size' do
     with_elastic_search! do
-      given_firms_with_advisers_were_previously_indexed
-      and_i_am_on_the_landing_page
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
       and_i_select_face_to_face_advice
       and_i_enter_a_valid_postcode
       and_i_indicate_that_i_need_help_with_my_pension_pot
       and_i_select_a_pot_size_band_from_the_available_options
-      when_i_submit_the_face_to_face_advice_search
+      when_i_submit_the_search
       then_i_am_shown_firms_that_can_advise_on_my_pension_pot_size
     end
   end
 
   scenario 'Filter for advice on pension pot transfers' do
     with_elastic_search! do
-      given_firms_with_advisers_were_previously_indexed
-      and_i_am_on_the_landing_page
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
       and_i_select_face_to_face_advice
       and_i_enter_a_valid_postcode
       and_i_indicate_that_i_need_help_with_my_pension_pot
       and_i_select_a_pot_size_band_from_the_available_options
       and_i_indicate_that_i_would_like_to_transfer_my_pension
-      when_i_submit_the_face_to_face_advice_search
+      when_i_submit_the_search
       then_i_am_shown_firms_that_can_assist_with_pension_transfers
     end
   end
 
-  def and_i_am_on_the_landing_page
-    landing_page.load
+  def given_reference_data_has_been_populated
+    create(:other_advice_method, name: 'Phone', order: 1)
+    create(:other_advice_method, name: 'Online', order: 2)
+
+    @investment_sizes = create_list(:investment_size, 5)
   end
 
-  def given_firms_with_advisers_were_previously_indexed
-    @investment_sizes = create_list(:investment_size, 5)
-
+  def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
       @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 90, other_percent: 10, investment_sizes: @investment_sizes.values_at(0, 1))
       create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
@@ -67,38 +73,61 @@ RSpec.feature 'Landing page, consumer requires help with their pension in person
     end
   end
 
+  def and_i_am_on_the_results_page_after_a_previous_search
+    landing_page.load
+    landing_page.in_person.tap do |f|
+      f.postcode.set 'RG2 9FL'
+      f.search.click
+    end
+
+    expect(results_page).to be_displayed
+  end
+
+  def and_i_clear_any_filters_from_the_previous_search
+    results_page.search_form.tap do |f|
+      f.face_to_face.set false
+      f.phone_or_online.set false
+
+      f.postcode.set nil
+      f.phone.set false
+      f.online.set false
+
+      f.retirement_income_products.set false
+      f.pension_pot_size.set SearchForm::ANY_SIZE_VALUE
+      f.pension_transfer.set false
+      f.options_when_paying_for_care.set false
+      f.equity_release.set false
+      f.inheritance_tax_planning.set false
+      f.wills_and_probate.set false
+    end
+  end
+
   def and_i_select_face_to_face_advice
-    # This is here to help make the feature steps read easier, but also
-    # serves as a place-holder for when the search form markup becomes
-    # one form and requires the advice method to be selected.
+    results_page.search_form.face_to_face.set true
   end
 
   def and_i_enter_a_valid_postcode
-    landing_page.in_person.postcode.set 'RG2 9FL'
+    results_page.search_form.postcode.set 'RG2 9FL'
   end
 
   def and_i_indicate_that_i_need_help_with_my_pension_pot
-    landing_page.in_person.retirement_income_products.set true
-  end
-
-  def and_i_see_the_default_option_is_i_dont_know_or_wish_to_say
-    expect(landing_page.in_person.pension_pot_size.value).to eql(SearchForm::ANY_SIZE_VALUE)
+    results_page.search_form.retirement_income_products.set true
   end
 
   def and_i_select_a_pot_size_band_from_the_available_options
-    landing_page.in_person.pension_pot_size.select @small_pot_size_firm.investment_sizes.sample.name
+    results_page.search_form.pension_pot_size.select @small_pot_size_firm.investment_sizes.sample.name
   end
 
   def and_i_indicate_that_i_dont_know_the_size_of_my_pension_pot
-    landing_page.in_person.pension_pot_size.select I18n.t('search_filter.pension_pot.any_size_option')
+    results_page.search_form.pension_pot_size.select I18n.t('search_filter.pension_pot.any_size_option')
   end
 
   def and_i_indicate_that_i_would_like_to_transfer_my_pension
-    landing_page.in_person.pension_transfer.set true
+    results_page.search_form.pension_transfer.set true
   end
 
-  def when_i_submit_the_face_to_face_advice_search
-    landing_page.in_person.search.click
+  def when_i_submit_the_search
+    results_page.search_form.search.click
   end
 
   def then_i_am_shown_firms_that_can_advise_on_pension_pots

--- a/spec/features/results_face_to_face_search_spec.rb
+++ b/spec/features/results_face_to_face_search_spec.rb
@@ -1,0 +1,131 @@
+RSpec.feature 'Results page, consumer requires help with their pension in person' do
+  let(:landing_page) { LandingPage.new }
+  let(:results_page) { ResultsPage.new }
+
+  scenario 'Using only a valid postcode' do
+    with_elastic_search! do
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
+      and_i_select_face_to_face_advice
+      and_i_enter_a_valid_postcode
+      when_i_submit_the_search
+      then_i_see_firms_that_cover_my_postcode
+    end
+  end
+
+  scenario 'Using an invalid postcode' do
+    with_elastic_search! do
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
+      and_i_select_face_to_face_advice
+      and_i_enter_an_invalid_postcode
+      when_i_submit_the_search
+      then_i_see_an_error_message_for_the_postcode_field
+      and_i_see_a_message_in_place_of_the_results
+    end
+  end
+
+  scenario 'Using a postcode that cannot be geocoded' do
+    given_reference_data_has_been_populated
+
+    with_elastic_search! do
+      with_fresh_index!
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
+      and_i_select_face_to_face_advice
+      and_i_enter_a_postcode_that_cannot_be_geocoded
+    end
+
+    VCR.use_cassette(:postcode_cannot_be_geocoded) do
+      when_i_submit_the_search
+    end
+
+    with_elastic_search! do
+      then_i_see_an_error_message_for_the_postcode_field
+      and_i_see_a_message_in_place_of_the_results
+    end
+  end
+
+  def given_reference_data_has_been_populated
+    create(:other_advice_method, name: 'Phone', order: 1)
+    create(:other_advice_method, name: 'Online', order: 2)
+  end
+
+  def and_firms_with_advisers_were_previously_indexed
+    with_fresh_index! do
+      @reading = create(:adviser, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616, travel_distance: 100)
+      @leicester = create(:adviser, postcode: 'LE1 6SL', latitude: 52.633013, longitude: -1.131257, travel_distance: 650)
+      @glasgow = create(:adviser, postcode: 'G1 5QT', latitude: 55.856191, longitude: -4.247082, travel_distance: 10)
+
+      @missing = create(:firm, in_person_advice_methods: []) do |firm|
+        create(:adviser, firm: firm, latitude: 51.428473, longitude: -0.943616)
+      end
+    end
+  end
+
+  def and_i_am_on_the_results_page_after_a_previous_search
+    landing_page.load
+    landing_page.in_person.tap do |f|
+      f.postcode.set 'RG2 9FL'
+      f.search.click
+    end
+
+    expect(results_page).to be_displayed
+  end
+
+  def and_i_clear_any_filters_from_the_previous_search
+    results_page.search_form.tap do |f|
+      f.face_to_face.set false
+      f.phone_or_online.set false
+
+      f.postcode.set nil
+      f.phone.set false
+      f.online.set false
+
+      f.retirement_income_products.set false
+      f.pension_pot_size.set SearchForm::ANY_SIZE_VALUE
+      f.pension_transfer.set false
+      f.options_when_paying_for_care.set false
+      f.equity_release.set false
+      f.inheritance_tax_planning.set false
+      f.wills_and_probate.set false
+    end
+  end
+
+  def and_i_select_face_to_face_advice
+    results_page.search_form.face_to_face.set true
+  end
+
+  def and_i_enter_a_valid_postcode
+    results_page.search_form.postcode.set 'RG2 9FL'
+  end
+
+  def and_i_enter_an_invalid_postcode
+    results_page.search_form.postcode.set 'B4D'
+  end
+
+  def and_i_enter_a_postcode_that_cannot_be_geocoded
+    results_page.search_form.postcode.set 'ZZ1 1ZZ'
+  end
+
+  def when_i_submit_the_search
+    results_page.search_form.search.click
+  end
+
+  def then_i_see_firms_that_cover_my_postcode
+    expect(results_page).to be_displayed
+    expect(results_page.firms).to be_present
+  end
+
+  def then_i_see_an_error_message_for_the_postcode_field
+    expect(results_page).to have_errors
+  end
+
+  def and_i_see_a_message_in_place_of_the_results
+    expect(results_page.incorrect_criteria_message).to be_present
+  end
+end

--- a/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -1,0 +1,101 @@
+RSpec.feature 'Results page, consumer requires various types of advice over the phone or online' do
+  let(:landing_page) { LandingPage.new }
+  let(:results_page) { ResultsPage.new }
+
+  scenario 'Filter for various types of advice' do
+    with_elastic_search! do
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
+      and_i_select_phone_or_online_advice
+      and_i_select_the_phone_and_or_online_advice_methods
+      and_i_indicate_i_need_advice_on_various_topics
+      when_i_submit_the_search
+      then_i_am_shown_firms_that_provide_the_selected_types_of_advice
+      and_they_are_ordered_by_business_split_and_name
+    end
+  end
+
+  def given_reference_data_has_been_populated
+    @other_advice_methods = [
+      create(:other_advice_method, name: 'Phone', order: 1),
+      create(:other_advice_method, name: 'Online', order: 2)
+    ]
+  end
+
+  def and_firms_with_advisers_were_previously_indexed
+    with_fresh_index! do
+      @first = create(:firm_with_no_business_split, retirement_income_products_percent: 30, wills_and_probate_percent: 20, other_percent: 50, other_advice_methods: @other_advice_methods)
+      @glasgow = create(:adviser, firm: @first, latitude: 55.856191, longitude: -4.247082)
+
+      @second = create(:firm_with_no_business_split, retirement_income_products_percent: 29, wills_and_probate_percent: 20, other_percent: 51, other_advice_methods: @other_advice_methods)
+      @leicester = create(:adviser, firm: @second, latitude: 52.633013, longitude: -1.131257)
+
+      @excluded = create(:firm_with_no_business_split, retirement_income_products_percent: 49, other_percent: 51, other_advice_methods: @other_advice_methods)
+      create(:adviser, firm: @excluded, latitude: 51.428473, longitude: -0.943616)
+
+      create(:firm_with_no_business_split, other_percent: 100, other_advice_methods: @other_advice_methods) do |f|
+        create(:adviser, firm: f, latitude: 51.428473, longitude: -0.943616)
+      end
+    end
+  end
+
+  def and_i_am_on_the_results_page_after_a_previous_search
+    landing_page.load
+    landing_page.in_person.tap do |f|
+      f.postcode.set 'RG2 9FL'
+      f.search.click
+    end
+
+    expect(results_page).to be_displayed
+  end
+
+  def and_i_clear_any_filters_from_the_previous_search
+    results_page.search_form.tap do |f|
+      f.face_to_face.set false
+      f.phone_or_online.set false
+
+      f.postcode.set nil
+      f.phone.set false
+      f.online.set false
+
+      f.retirement_income_products.set false
+      f.pension_pot_size.set SearchForm::ANY_SIZE_VALUE
+      f.pension_transfer.set false
+      f.options_when_paying_for_care.set false
+      f.equity_release.set false
+      f.inheritance_tax_planning.set false
+      f.wills_and_probate.set false
+    end
+  end
+
+  def and_i_select_phone_or_online_advice
+    results_page.search_form.phone_or_online.set true
+  end
+
+  def and_i_select_the_phone_and_or_online_advice_methods
+    results_page.search_form.phone.set true
+    results_page.search_form.online.set true
+  end
+
+  def and_i_indicate_i_need_advice_on_various_topics
+    results_page.search_form.retirement_income_products.set true
+    results_page.search_form.wills_and_probate.set true
+  end
+
+  def when_i_submit_the_search
+    results_page.search_form.search.click
+  end
+
+  def then_i_am_shown_firms_that_provide_the_selected_types_of_advice
+    expect(results_page).to be_displayed
+    expect(results_page).to have_firms(count: 2)
+  end
+
+  def and_they_are_ordered_by_business_split_and_name
+    ordered_results = [@first, @second].map(&:registered_name)
+
+    expect(results_page.firm_names).to eql(ordered_results)
+  end
+end

--- a/spec/features/results_phone_or_online_filter_for_pension_advice_spec.rb
+++ b/spec/features/results_phone_or_online_filter_for_pension_advice_spec.rb
@@ -1,0 +1,157 @@
+RSpec.feature 'Results page, consumer requires help with their pension over the phone or online' do
+  let(:landing_page) { LandingPage.new }
+  let(:results_page) { ResultsPage.new }
+
+  let(:latitude) { rand(51.428473..55.856191) }
+  let(:longitude) { rand(-4.247082..-0.943616) }
+
+  scenario 'Filter for general pension pot advice' do
+    with_elastic_search! do
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
+      and_i_select_phone_or_online_advice
+      and_i_select_the_phone_and_or_online_advice_methods
+      and_i_indicate_that_i_need_help_with_my_pension_pot
+      when_i_submit_the_search
+      then_i_am_shown_firms_that_can_advise_on_pension_pots
+    end
+  end
+
+  scenario 'Filter for advice on a pension pot size' do
+    with_elastic_search! do
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
+      and_i_select_phone_or_online_advice
+      and_i_select_the_phone_and_or_online_advice_methods
+      and_i_indicate_that_i_need_help_with_my_pension_pot
+      and_i_select_a_pot_size_band_from_the_available_options
+      when_i_submit_the_search
+      then_i_am_shown_firms_that_can_advise_on_my_pension_pot_size
+    end
+  end
+
+  scenario 'Filter for advice on pension pot transfers' do
+    with_elastic_search! do
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
+      and_i_select_phone_or_online_advice
+      and_i_select_the_phone_and_or_online_advice_methods
+      and_i_indicate_that_i_need_help_with_my_pension_pot
+      and_i_select_a_pot_size_band_from_the_available_options
+      and_i_indicate_that_i_would_like_to_transfer_my_pension
+      when_i_submit_the_search
+      then_i_am_shown_firms_that_can_assist_with_pension_transfers
+    end
+  end
+
+  def given_reference_data_has_been_populated
+    @investment_sizes = create_list(:investment_size, 5)
+
+    @other_advice_methods = [
+      create(:other_advice_method, name: 'Phone', order: 1),
+      create(:other_advice_method, name: 'Online', order: 2)
+    ]
+  end
+
+  def and_firms_with_advisers_were_previously_indexed
+    with_fresh_index! do
+      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 90, other_percent: 10, investment_sizes: @investment_sizes.values_at(0, 1), other_advice_methods: @other_advice_methods)
+      create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
+
+      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 10, other_percent: 90, investment_sizes: @investment_sizes.values_at(2, 3), other_advice_methods: @other_advice_methods)
+      create(:adviser, firm: @medium_pot_size_firm, latitude: latitude, longitude: longitude)
+
+      @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_percent: 50, pension_transfer_percent: 50, investment_sizes: @investment_sizes, other_advice_methods: @other_advice_methods)
+      create(:adviser, firm: @pension_transfer_firm, latitude: latitude, longitude: longitude)
+
+      @excluded = create(:firm_with_no_business_split, other_percent: 100, other_advice_methods: @other_advice_methods)
+      create(:adviser, firm: @excluded, latitude: latitude, longitude: longitude)
+    end
+  end
+
+  def and_i_am_on_the_results_page_after_a_previous_search
+    landing_page.load
+    landing_page.in_person.tap do |f|
+      f.postcode.set 'RG2 9FL'
+      f.search.click
+    end
+
+    expect(results_page).to be_displayed
+  end
+
+  def and_i_clear_any_filters_from_the_previous_search
+    results_page.search_form.tap do |f|
+      f.face_to_face.set false
+      f.phone_or_online.set false
+
+      f.postcode.set nil
+      f.phone.set false
+      f.online.set false
+
+      f.retirement_income_products.set false
+      f.pension_pot_size.set SearchForm::ANY_SIZE_VALUE
+      f.pension_transfer.set false
+      f.options_when_paying_for_care.set false
+      f.equity_release.set false
+      f.inheritance_tax_planning.set false
+      f.wills_and_probate.set false
+    end
+  end
+
+  def and_i_select_phone_or_online_advice
+    results_page.search_form.phone_or_online.set true
+  end
+
+  def and_i_select_the_phone_and_or_online_advice_methods
+    results_page.search_form.phone.set true
+    results_page.search_form.online.set true
+  end
+
+  def and_i_indicate_that_i_need_help_with_my_pension_pot
+    results_page.search_form.retirement_income_products.set true
+  end
+
+  def and_i_select_a_pot_size_band_from_the_available_options
+    results_page.search_form.pension_pot_size.select @small_pot_size_firm.investment_sizes.sample.name
+  end
+
+  def and_i_indicate_that_i_dont_know_the_size_of_my_pension_pot
+    results_page.search_form.pension_pot_size.select I18n.t('search_filter.pension_pot.any_size_option')
+  end
+
+  def and_i_indicate_that_i_would_like_to_transfer_my_pension
+    results_page.search_form.pension_transfer.set true
+  end
+
+  def when_i_submit_the_search
+    results_page.search_form.search.click
+  end
+
+  def then_i_am_shown_firms_that_can_advise_on_pension_pots
+    expect(results_page).to be_displayed
+    expect(results_page).to have_firms(count: 3)
+    expect(results_page.firm_names).to include(
+      @small_pot_size_firm.registered_name,
+      @medium_pot_size_firm.registered_name,
+      @pension_transfer_firm.registered_name
+    )
+  end
+
+  def then_i_am_shown_firms_that_can_advise_on_my_pension_pot_size
+    expect(results_page).to be_displayed
+    expect(results_page).to have_firms(count: 2)
+    expect(results_page.firm_names).to include(@small_pot_size_firm.registered_name)
+  end
+
+  def then_i_am_shown_firms_that_can_assist_with_pension_transfers
+    expect(results_page).to be_displayed
+    expect(results_page).to have_firms(count: 1)
+    expect(results_page.firm_names).to include(@pension_transfer_firm.registered_name)
+  end
+end

--- a/spec/features/results_phone_or_online_search_spec.rb
+++ b/spec/features/results_phone_or_online_search_spec.rb
@@ -1,61 +1,71 @@
-RSpec.feature 'Landing page, consumer requires general advice over the phone or online' do
+RSpec.feature 'Results page, consumer requires general advice over the phone or online' do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
   scenario 'Using only the phone advice method' do
     with_elastic_search! do
-      given_firms_with_advisers_were_previously_indexed
-      and_i_am_on_the_landing_page
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
       and_i_select_phone_or_online_advice
       and_i_select_the_phone_advice_method
-      when_i_submit_the_phone_or_online_advice_search
+      when_i_submit_the_search
       then_i_see_firms_that_provide_advice_over_the_phone
     end
   end
 
   scenario 'Using only the online advice method' do
     with_elastic_search! do
-      given_firms_with_advisers_were_previously_indexed
-      and_i_am_on_the_landing_page
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
       and_i_select_phone_or_online_advice
       and_i_select_the_online_advice_method
-      when_i_submit_the_phone_or_online_advice_search
+      when_i_submit_the_search
       then_i_see_firms_that_provide_advice_online
     end
   end
 
   scenario 'Using both the phone and online advice methods' do
     with_elastic_search! do
-      given_firms_with_advisers_were_previously_indexed
-      and_i_am_on_the_landing_page
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
       and_i_select_phone_or_online_advice
       and_i_select_both_the_phone_and_online_advice_methods
-      when_i_submit_the_phone_or_online_advice_search
+      when_i_submit_the_search
       then_i_see_firms_that_provide_advice_over_the_phone_or_online
     end
   end
 
   scenario 'Using no advice method' do
     with_elastic_search! do
-      given_firms_with_advisers_were_previously_indexed
-      and_i_am_on_the_landing_page
+      given_reference_data_has_been_populated
+      and_firms_with_advisers_were_previously_indexed
+      and_i_am_on_the_results_page_after_a_previous_search
+      and_i_clear_any_filters_from_the_previous_search
       and_i_select_phone_or_online_advice
-      when_i_submit_the_phone_or_online_advice_search
+      when_i_submit_the_search
       then_i_see_an_error_message
     end
   end
 
-  def given_firms_with_advisers_were_previously_indexed
-    other_advice_methods = [
+  def given_reference_data_has_been_populated
+    @other_advice_methods = [
       create(:other_advice_method, name: 'Phone', order: 1),
       create(:other_advice_method, name: 'Online', order: 2)
     ]
+  end
 
+  def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @phone_firm = create(:firm, other_advice_methods: [other_advice_methods.first])
+      @phone_firm = create(:firm, other_advice_methods: [@other_advice_methods.first])
       create(:adviser, firm: @phone_firm)
 
-      @online_firm = create(:firm, other_advice_methods: [other_advice_methods.second])
+      @online_firm = create(:firm, other_advice_methods: [@other_advice_methods.second])
       create(:adviser, firm: @online_firm)
 
       @excluded = create(:firm, other_advice_methods: [])
@@ -63,31 +73,54 @@ RSpec.feature 'Landing page, consumer requires general advice over the phone or 
     end
   end
 
-  def and_i_am_on_the_landing_page
+  def and_i_am_on_the_results_page_after_a_previous_search
     landing_page.load
+    landing_page.in_person.tap do |f|
+      f.postcode.set 'RG2 9FL'
+      f.search.click
+    end
+
+    expect(results_page).to be_displayed
+  end
+
+  def and_i_clear_any_filters_from_the_previous_search
+    results_page.search_form.tap do |f|
+      f.face_to_face.set false
+      f.phone_or_online.set false
+
+      f.postcode.set nil
+      f.phone.set false
+      f.online.set false
+
+      f.retirement_income_products.set false
+      f.pension_pot_size.set SearchForm::ANY_SIZE_VALUE
+      f.pension_transfer.set false
+      f.options_when_paying_for_care.set false
+      f.equity_release.set false
+      f.inheritance_tax_planning.set false
+      f.wills_and_probate.set false
+    end
   end
 
   def and_i_select_phone_or_online_advice
-    # This is here to help make the feature steps read easier, but also
-    # serves as a place-holder for when the search form markup becomes
-    # one form and requires the advice method to be selected.
+    results_page.search_form.phone_or_online.set true
   end
 
   def and_i_select_the_phone_advice_method
-    landing_page.remote.by_phone.set true
+    results_page.search_form.phone.set true
   end
 
   def and_i_select_the_online_advice_method
-    landing_page.remote.online.set true
+    results_page.search_form.online.set true
   end
 
   def and_i_select_both_the_phone_and_online_advice_methods
-    landing_page.remote.by_phone.set true
-    landing_page.remote.online.set true
+    results_page.search_form.phone.set true
+    results_page.search_form.online.set true
   end
 
-  def when_i_submit_the_phone_or_online_advice_search
-    landing_page.remote.search.click
+  def when_i_submit_the_search
+    results_page.search_form.search.click
   end
 
   def then_i_see_firms_that_provide_advice_over_the_phone

--- a/spec/fixtures/vcr_cassettes/postcode_cannot_be_geocoded.yml
+++ b/spec/fixtures/vcr_cassettes/postcode_cannot_be_geocoded.yml
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 27 Mar 2015 14:21:36 GMT
+      - Fri, 27 Mar 2015 16:19:48 GMT
       Expires:
-      - Sat, 28 Mar 2015 14:21:36 GMT
+      - Sat, 28 Mar 2015 16:19:48 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
@@ -50,5 +50,56 @@ http_interactions:
            "status" : "ZERO_RESULTS"
         }
     http_version: 
-  recorded_at: Fri, 27 Mar 2015 14:21:35 GMT
+  recorded_at: Fri, 27 Mar 2015 16:19:47 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=ZZ1%201ZZ,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 27 Mar 2015 17:15:24 GMT
+      Expires:
+      - Sat, 28 Mar 2015 17:15:24 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Alternate-Protocol:
+      - 80:quic,p=0.5
+      Accept-Ranges:
+      - none
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+           "results" : [],
+           "status" : "ZERO_RESULTS"
+        }
+    http_version: 
+  recorded_at: Fri, 27 Mar 2015 17:15:23 GMT
 recorded_with: VCR 2.9.3

--- a/spec/support/elastic_search_helper.rb
+++ b/spec/support/elastic_search_helper.rb
@@ -1,7 +1,7 @@
 module ElasticSearchHelper
   def with_fresh_index!
     rebuild_index!
-    yield
+    yield if block_given?
     index_all!
     refresh_index!
   end

--- a/spec/support/landing_page.rb
+++ b/spec/support/landing_page.rb
@@ -8,6 +8,8 @@ class LandingPage < SitePrism::Page
   section :in_person, InPersonSection, '.t-in-person'
   section :remote, RemoteSection, '.t-remote'
 
+  element :errors, '.l-landing-page__validation'
+
   def invalid_parameters?
     has_css?('.field_with_errors')
   end

--- a/spec/support/results_page.rb
+++ b/spec/support/results_page.rb
@@ -12,6 +12,8 @@ class ResultsPage < SitePrism::Page
   element :last_record, '.t-last-record'
   element :total_records, '.t-total-records'
 
+  element :incorrect_criteria_message , '.t-incorrect-criteria'
+
   def next_page
     first("a[rel='next']").click
   end

--- a/spec/support/results_page.rb
+++ b/spec/support/results_page.rb
@@ -12,6 +12,7 @@ class ResultsPage < SitePrism::Page
   element :last_record, '.t-last-record'
   element :total_records, '.t-total-records'
 
+  element :errors, '.l-landing-page__validation'
   element :incorrect_criteria_message , '.t-incorrect-criteria'
 
   def next_page

--- a/spec/support/results_page.rb
+++ b/spec/support/results_page.rb
@@ -1,10 +1,12 @@
 require_relative 'firm_section'
 require_relative 'search_criteria_section'
+require_relative 'search_form_section'
 
 class ResultsPage < SitePrism::Page
   set_url '/en/search{?params*}'
   set_url_matcher %r{/(en|cy)/search}
 
+  section :search_form, SearchFormSection, '.form'
   section :criteria, SearchCriteriaSection, '.t-criteria'
   sections :firms, FirmSection, 'li.t-firm'
 

--- a/spec/support/search_form_section.rb
+++ b/spec/support/search_form_section.rb
@@ -1,0 +1,17 @@
+class SearchFormSection < SitePrism::Section
+  element :search, '.button--primary'
+  element :face_to_face, '.t-face_to_face_advice'
+  element :phone_or_online, '.t-phone_or_online'
+
+  element :postcode, '.t-postcode'
+  element :phone, '.t-advice-method-1'
+  element :online, '.t-advice-method-2'
+
+  element :retirement_income_products, '.t-retirement-income-products'
+  element :pension_pot_size, '.t-pension-pot-size'
+  element :pension_transfer, '.t-pension-transfer'
+  element :options_when_paying_for_care, '.t-options_when_paying_for_care'
+  element :equity_release, '.t-equity_release'
+  element :inheritance_tax_planning, '.t-inheritance_tax_planning'
+  element :wills_and_probate, '.t-wills_and_probate'
+end


### PR DESCRIPTION
This adds a number of specs that cover search scenarios for both face to face and phone and online channels, including error scenarios. For the specs in question, they now read as follows

    Landing page, consumer requires general advice over the phone or online
      Using only the phone advice method
      Using only the online advice method
      Using no advice method
      Using both the phone and online advice methods
    
    Results page, consumer requires various types of advice over the phone or online
      Filter for various types of advice
    
    Results page, consumer requires advice on various topics in person
      Filter for various types of advice
    
    Results page, consumer requires general advice over the phone or online
      Using only the phone advice method
      Using only the online advice method
      Using no advice method
      Using both the phone and online advice methods
    
    Landing page, consumer requires various types of advice over the phone or online
      Filter for various types of advice
    
    Landing page, consumer requires advice on various topics in person
      Filter for various types of advice
    
    Results page, consumer requires help with their pension in person
      Using an invalid postcode
      Using only a valid postcode
      Using a postcode that cannot be geocoded
    
    Landing page, consumer requires help with their pension over the phone or online
      Filter for advice on a pension pot size
      Filter for general pension pot advice
      Filter for advice on pension pot transfers
    
    Results page, consumer requires help with their pension over the phone or online
      Filter for advice on a pension pot size
      Filter for general pension pot advice
      Filter for advice on pension pot transfers
    
    Landing page, consumer requires help with their pension in person
      Filter for advice on a pension pot size
      Filter for general pension pot advice
      Filter for advice on pension pot transfers
    
    Results page, consumer requires help with their pension in person
      Filter for advice on a pension pot size
      Filter for general pension pot advice
      Filter for advice on pension pot transfers
    
    Landing page, consumer requires general advice in person
      Using a valid postcode
      Using an invalid postcode
      Paginating through 21 results
      Using a postcode that cannot be geocoded

Note: There is some duplication of existing specs, but further refactoring efforts should see those specs either removed or becoming more focused. Also, a lot of this can be dried up once the landing page forms are merged into one, allowing for instance the `SearchFormSection` page object to be reused.

@benlovell @alexwllms @amansinghb