### PR TITLE
6175 Postcode spaces

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.25)
+    mas-rad_core (0.0.27)
       active_model_serializers
       geocoder
       http

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -87,7 +87,7 @@ class SearchForm
   private
 
   def geocode_postcode
-    unless postcode =~ /\A[A-Z\d]{1,4} [A-Z\d]{1,3}\z/ && coordinates
+    unless postcode =~ /\A[A-Z\d]{1,4} ?[A-Z\d]{1,3}\z/ && coordinates
       errors.add(:postcode, I18n.t('search.errors.geocode_failure'))
     end
   end

--- a/lib/geocode.rb
+++ b/lib/geocode.rb
@@ -1,7 +1,5 @@
 class Geocode
   def self.call(postcode)
-    normalised_postcode = postcode.delete(' ')
-
-    Geocoder.coordinates("#{normalised_postcode}, United Kingdom")
+    Geocoder.coordinates("#{postcode}, United Kingdom")
   end
 end

--- a/spec/features/consumer_searches_by_postcode_only_spec.rb
+++ b/spec/features/consumer_searches_by_postcode_only_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature 'Consumer searches by postcode only' do
 
   def when_i_submit_a_invalid_postcode_search
     landing_page.in_person.tap do |section|
-      section.postcode.set 'B4D'
+      section.postcode.set 'Z'
       section.search.click
     end
   end

--- a/spec/fixtures/vcr_cassettes/postcode_cannot_be_geocoded.yml
+++ b/spec/fixtures/vcr_cassettes/postcode_cannot_be_geocoded.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=ZZ11ZZ,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=ZZ1%201ZZ,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 19 Feb 2015 21:32:21 GMT
+      - Fri, 27 Mar 2015 14:21:36 GMT
       Expires:
-      - Fri, 20 Feb 2015 21:32:21 GMT
+      - Sat, 28 Mar 2015 14:21:36 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
@@ -35,7 +35,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Alternate-Protocol:
-      - 80:quic,p=0.08
+      - 80:quic,p=0.5
       Accept-Ranges:
       - none
       Vary:
@@ -50,5 +50,5 @@ http_interactions:
            "status" : "ZERO_RESULTS"
         }
     http_version: 
-  recorded_at: Thu, 19 Feb 2015 21:32:28 GMT
+  recorded_at: Fri, 27 Mar 2015 14:21:35 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/rg2_1aa.yml
+++ b/spec/fixtures/vcr_cassettes/rg2_1aa.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://maps.googleapis.com/maps/api/geocode/json?address=RG21AA,%20United%20Kingdom&language=en&sensor=false
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=RG2%201AA,%20United%20Kingdom&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 19 Feb 2015 21:23:32 GMT
+      - Fri, 27 Mar 2015 14:18:34 GMT
       Expires:
-      - Fri, 20 Feb 2015 21:23:32 GMT
+      - Sat, 28 Mar 2015 14:18:34 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
@@ -35,7 +35,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Alternate-Protocol:
-      - 80:quic,p=0.08
+      - 80:quic,p=0.5
       Accept-Ranges:
       - none
       Vary:
@@ -93,6 +93,7 @@ http_interactions:
                        }
                     }
                  },
+                 "partial_match" : true,
                  "place_id" : "ChIJJ-zUf1OCdkgRhlweI7vWAN0",
                  "types" : [ "postal_code_prefix", "postal_code" ]
               }
@@ -100,5 +101,5 @@ http_interactions:
            "status" : "OK"
         }
     http_version: 
-  recorded_at: Thu, 19 Feb 2015 21:23:40 GMT
+  recorded_at: Fri, 27 Mar 2015 14:18:33 GMT
 recorded_with: VCR 2.9.3

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe SearchForm do
       end
 
       context 'and a badly formatted postcode is present' do
-        before { form.postcode = 'ABC' }
+        before { form.postcode = 'Z' }
 
         it 'is not valid' do
           expect(form).to_not be_valid

--- a/spec/lib/geocode_spec.rb
+++ b/spec/lib/geocode_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Geocode, '#call' do
-  it 'normalises the postcode' do
-    expect(Geocoder).to receive(:coordinates).with('RG11GG, United Kingdom')
+  it 'ensures the postcode is scoped to the United Kingdom' do
+    expect(Geocoder).to receive(:coordinates).with('RG1 1GG, United Kingdom')
 
     Geocode.call('RG1 1GG')
   end


### PR DESCRIPTION
Allows the space in postcodes to be optional, and does not remove any spaces before the postcode is geocoded. This intentionally does not change the existing validation.

@benlovell