### PR TITLE
Change to results decided text

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -297,12 +297,10 @@
     education_module_one:
       heading: How were these results decided?
       content:
-        - text: Our Retirement Adviser Directory matches you with firms based on the information you give us.
-        - text: If your search is based on postcode only, the search results are ordered by distance.
-        - text: If you told us that you need a certain type of advice, only firms that offer that type of advice will appear in the search results. Firms are then ordered by distance. Some firms might seem to be a long distance from the postcode you entered but don’t worry, these firms have told us that they offer the advice you are looking for and have advisers who cover your area and will travel to you.
-        - text: If you’ve searched for a firm that provides phone or online advice only, the search results will be ordered alphabetically.
-        - text: If two firms offer the same type of service, they will be ordered alphabetically.
-        - text: All the firms shown will be able to help you but some will suit you better than others. We recommend that you contact several firms and talk through your requirements and the services they offer you before deciding on the best match for you.
+        - text: Our Retirement Adviser Directory matches you with firms which provide the type of advice you need in the way you want it delivered.
+        - text: If you want to see an adviser face-to-face, enter your postcode and select the type of advice you need. You’ll see a list of firms offering that type of advice with advisers located near to you.
+        - text: If you’ve searched for a firm that provides phone or online advice and selected the type of advice you need, you’ll see a list of firms offering that type of advice remotely, but ordered alphabetically.
+        - text: It’s always a good idea contact several firms and talk through your requirements and the services they offer you before deciding on the best match for you.
 
     education_module_two:
       heading:  Online / telephone based advice


### PR DESCRIPTION
As a result of changing the types of advice ranking for search results
the ‘how were these results decided’ text needed to be changed