### PR TITLE
Order by geo distance and/or registered name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.42)
+    mas-rad_core (0.0.43)
       active_model_serializers
       geocoder
       httpclient

--- a/app/serializers/search_form_serializer.rb
+++ b/app/serializers/search_form_serializer.rb
@@ -5,10 +5,6 @@ class SearchFormSerializer < ActiveModel::Serializer
 
   def sort
     [].tap do |options|
-      if object.phone_or_online?
-        options << 'registered_name'
-      end
-
       if object.face_to_face?
         options << {
           _geo_distance: {
@@ -18,6 +14,8 @@ class SearchFormSerializer < ActiveModel::Serializer
           }
         }
       end
+
+      options << 'registered_name'
     end
   end
 

--- a/spec/features/landing_face_to_face_search_spec.rb
+++ b/spec/features/landing_face_to_face_search_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Landing page, consumer requires general advice in person' do
       when_i_search_with_a_reading_postcode
       then_i_am_shown_firms_with_advisers_covering_my_postcode
       and_i_am_not_shown_non_postcode_searchable_firms
-      and_the_firms_are_ordered_by_distance_in_miles_to_me
+      and_the_firms_are_ordered_by_distance_and_name
     end
   end
 
@@ -68,7 +68,22 @@ RSpec.feature 'Landing page, consumer requires general advice in person' do
 
   def and_firms_with_advisers_covering_my_postcode_were_previously_indexed
     with_fresh_index! do
-      @reading   = create(:adviser, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616, travel_distance: 100)
+      @second = create(:adviser,
+        firm: create(:firm, registered_name: 'ZZZ'),
+        postcode: 'RG2 8EE',
+        latitude: 51.428473,
+        longitude: -0.943616,
+        travel_distance: 100
+      )
+
+      @first = create(:adviser,
+        firm: create(:firm, registered_name: 'AAA'),
+        postcode: 'RG2 8EE',
+        latitude: 51.428473,
+        longitude: -0.943616,
+        travel_distance: 100
+      )
+
       @leicester = create(:adviser, postcode: 'LE1 6SL', latitude: 52.633013, longitude: -1.131257, travel_distance: 650)
       @glasgow   = create(:adviser, postcode: 'G1 5QT', latitude: 55.856191, longitude: -4.247082, travel_distance: 10)
 
@@ -95,10 +110,11 @@ RSpec.feature 'Landing page, consumer requires general advice in person' do
     ).to_not include(@missing.registered_name)
   end
 
-  def and_the_firms_are_ordered_by_distance_in_miles_to_me
+  def and_the_firms_are_ordered_by_distance_and_name
     expect(results_page.firm_names).to eql([
-      @reading.firm.registered_name,
-      @leicester.firm.registered_name,
+      @first.firm.registered_name,
+      @second.firm.registered_name,
+      @leicester.firm.registered_name
     ])
   end
 


### PR DESCRIPTION
* Bumps core for distance retrieval changes
* Ensures we always order by `registered_name` at least