### PR TITLE
Resolves ordering issues with spec

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -182,10 +182,9 @@
                     <% if firm.free_initial_meeting? %>
                       <p class="keyword t-free-initial-meeting"><%= t('search.keywords.free_initial_meeting.title') %></p>
                     <% end %>
-                    <p class="keyword">
+                    <p class="keyword t-minimum-pot-size">
                       <% if firm.minimum_pot_size? %>
-                        <%= t('search.keywords.minimum_pot_size.title') %>
-                        <span class="t-minimum-pot-size"><%= InvestmentSize.friendly_name(firm.minimum_pot_size_id) %></span>
+                        <%= t('search.keywords.minimum_pot_size.title') %> <%= InvestmentSize.friendly_name(firm.minimum_pot_size_id) %>
                       <% else %>
                         <%= t('search.keywords.minimum_pot_size.none') %>
                       <% end %>

--- a/spec/features/consumer_views_a_search_result_spec.rb
+++ b/spec/features/consumer_views_a_search_result_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature 'Consumer views a search result' do
   end
 
   def and_i_see_the_firms_minimum_pot_size
-    expect(@displayed_firm.minimum_pot_size).to eq('Under £50,000')
+    expect(@displayed_firm.minimum_pot_size).to match(/No minimum/)
   end
 
   def and_i_see_the_firms_minimum_fee
@@ -114,7 +114,7 @@ RSpec.feature 'Consumer views a search result' do
       other_percent: 40,
       in_person_advice_methods: [1, 2].map { |i| create(:in_person_advice_method, order: i) },
       other_advice_methods: [1, 2].map { |i| create(:other_advice_method, order: i) },
-      investment_sizes: [1, 2].map { |i| create(:investment_size, order: i) }
+      investment_sizes: [1, 2].map { |i| create(:investment_size, id: i, order: i) }
     )
 
     create(:adviser,


### PR DESCRIPTION
Depending on the seed, this spec was failing due to an ordering issue.
If many `InvestmentSize` options had been created in prior specs, the
numbering wasn't starting from `1` thus throwing out the logic around
determining whether the firm has a minimum pot size.