### PR TITLE
DAC fixes 1

### DIFF
--- a/app/assets/javascripts/modules/ResultsModule.js
+++ b/app/assets/javascripts/modules/ResultsModule.js
@@ -9,9 +9,48 @@ define(['jquery'], function($) {
       $buttonElement = $('<button type="button" class="education__button unstyled-button" data-results-module-trigger></button>'),
       $iconElement = $('<span class="education__icon education__icon--plus" data-results-module-icon></span>'),
       statusHidden = 'is-hidden-on-mobile',
-      $targetClosed = $('[data-results-module-target="closed"]');
+      $targetClosed = $('[data-results-module-target="closed"]'),
+      iconSelector = '[data-results-module-icon]',
+      triggerSelector = '[data-results-module-trigger]',
+      mobileApplied = false;
 
-  if ($(window).width() <= 720) {
+  function bindResultsModuleEventHandlers() {
+    $element.each(function(_, resultsModule) {
+      $(resultsModule).on('click', triggerSelector, function() {
+        var $elementTrigger = $(resultsModule).find(triggerSelector),
+            $elementTriggerIcon = $(resultsModule).find(iconSelector),
+            $elementTarget = $(resultsModule).find($target),
+            $icons = $(iconSelector);
+
+        $icons.removeClass('education__icon--minus');
+        $icons.addClass('education__icon--plus');
+
+        if ($elementTarget.hasClass(statusHidden)) {
+          $target.addClass(statusHidden);
+          $elementTriggerIcon.removeClass('education__icon--plus');
+          $elementTriggerIcon.addClass('education__icon--minus');
+          $elementTarget.removeClass(statusHidden);
+        } else {
+          $elementTarget.addClass(statusHidden);
+          $elementTriggerIcon.addClass('education__icon--plus');
+          $elementTriggerIcon.removeClass('education__icon--minus');
+        }
+      });
+    });
+  }
+
+  function applyMobileElementsIfWindowSizeMatches() {
+    var windowWidth = $(window).width();
+    if (mobileApplied === false && windowWidth <= 720) {
+      mobileApplied = true;
+      addMobileElements();
+    } else if (mobileApplied === true && windowWidth > 720) {
+      mobileApplied = false;
+      removeMobileElements();
+    }
+  }
+
+  function addMobileElements() {
     $heading.wrap($buttonElement);
     $heading.prepend($iconElement);
 
@@ -23,28 +62,19 @@ define(['jquery'], function($) {
     }
   }
 
-  var $icon = $('[data-results-module-icon]'),
-      $button = $('[data-results-module-trigger]');
+  function removeMobileElements() {
+    $heading.unwrap();
+    $heading.find('.education__icon').remove();
 
-  $element.each(function(indexInArray, objectInArray) {
-    var $elementTrigger = $(objectInArray).find($button),
-        $elementTriggerIcon = $(objectInArray).find($icon),
-        $elementTarget = $(objectInArray).find($target);
+    if ($targetClosed.find('.form__row').hasClass('is-errored') === true) {
+      $target.removeClass(statusHidden);
+      $targetClosed.addClass(statusHidden);
+    } else {
+      $targetClosed.removeClass(statusHidden);
+    }
+  }
 
-    $elementTrigger.click(function() {
-      $icon.removeClass('education__icon--minus');
-      $icon.addClass('education__icon--plus');
-
-      if ($elementTarget.hasClass(statusHidden)) {
-        $target.addClass(statusHidden);
-        $elementTriggerIcon.removeClass('education__icon--plus');
-        $elementTriggerIcon.addClass('education__icon--minus');
-        $elementTarget.removeClass(statusHidden);
-      } else {
-        $elementTarget.addClass(statusHidden);
-        $elementTriggerIcon.addClass('education__icon--plus');
-        $elementTriggerIcon.removeClass('education__icon--minus');
-      }
-    });
-  });
+  bindResultsModuleEventHandlers();
+  applyMobileElementsIfWindowSizeMatches();
+  $(window).bind('orientationchange resize', applyMobileElementsIfWindowSizeMatches);
 });

--- a/app/assets/stylesheets/components/_further_info.scss
+++ b/app/assets/stylesheets/components/_further_info.scss
@@ -6,6 +6,7 @@
   @include body(14, 24);
   border-left: 5px solid $further-info-border-color;
   padding-left: $baseline-unit*2;
+  margin-left: $baseline-unit*4;
   margin-bottom: $baseline-unit*6;
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,8 @@ module ApplicationHelper
       end
     end
   end
+
+  def required_label(text)
+    "#{text} <span class='visually-hidden'>#{t('global.required')}</span>*".html_safe
+  end
 end

--- a/app/views/landing_page/_search_filter.html.erb
+++ b/app/views/landing_page/_search_filter.html.erb
@@ -19,7 +19,7 @@
       <div class="search-filter__section search-filter__section--padded">
         <%= f.form_row(:postcode) do %>
           <%= f.errors_for :postcode %>
-          <%= f.label :postcode, t('search_filter.in_person.postcode_label'), class: 'form__label-heading search-filter__label' %>
+          <%= f.label :postcode, required_label(t('search_filter.in_person.postcode_label')), class: 'form__label-heading search-filter__label' %>
           <%= f.text_field :postcode, class: 'search-filter__field t-postcode', placeholder: 'e.g. EC1N 2TD', maxlength: 8, required: true %>
         <% end %>
 

--- a/app/views/landing_page/_search_filter.html.erb
+++ b/app/views/landing_page/_search_filter.html.erb
@@ -1,5 +1,5 @@
 <div class="search-filter">
-  <%= form_for @form, url: search_path, method: :get, namespace: 'in_person', html: { class: 'search-filter__form form t-in-person' }, data: { search_filter: '' }, builder: Dough::Forms::Builders::Validation do |f| %>
+  <%= form_for @form, url: search_path, method: :get, namespace: 'in_person', html: { class: 'search-filter__form form t-in-person', novalidate: true }, data: { search_filter: '' }, builder: Dough::Forms::Builders::Validation do |f| %>
     <%= f.hidden_field :advice_method, value: SearchForm::ADVICE_METHOD_FACE_TO_FACE %>
 
     <%= content_for :validation_summary do %>

--- a/app/views/landing_page/_search_filter.html.erb
+++ b/app/views/landing_page/_search_filter.html.erb
@@ -20,7 +20,7 @@
         <%= f.form_row(:postcode) do %>
           <%= f.errors_for :postcode %>
           <%= f.label :postcode, t('search_filter.in_person.postcode_label'), class: 'form__label-heading search-filter__label' %>
-          <%= f.text_field :postcode, class: 'search-filter__field t-postcode', placeholder: 'e.g. EC1N 2TD', maxlength: 8 %>
+          <%= f.text_field :postcode, class: 'search-filter__field t-postcode', placeholder: 'e.g. EC1N 2TD', maxlength: 8, required: true %>
         <% end %>
 
         <%= search_filter_options(f, 'landing_page') %>

--- a/app/views/landing_page/_search_filter_options.html.erb
+++ b/app/views/landing_page/_search_filter_options.html.erb
@@ -25,8 +25,8 @@
           <%= f.label :pension_transfer, class: 'search-filter__option' do %>
             <%= t('search_filter.pension_pot.pension_transfer.heading') %>
             <a href="" class="further-info__trigger" data-further-info-trigger><%= t('learn_more') %></a>
-            <p class="is-hidden further-info__content" data-further-info-target><%= t('search_filter.pension_pot.pension_transfer.tooltip') %></p>
           <% end %>
+          <p class="is-hidden further-info__content" data-further-info-target><%= t('search_filter.pension_pot.pension_transfer.tooltip') %></p>
         </div>
       </div>
     </div>
@@ -37,8 +37,8 @@
         <%= f.label key, class: 'search-filter__option' do %>
           <%= raw item[:title] %>
           <a href="" class="further-info__trigger" data-further-info-trigger><%= t('learn_more') %></a>
-          <p class="is-hidden further-info__content" data-further-info-target><%= raw item[:tooltip] %></p>
         <% end %>
+        <p class="is-hidden further-info__content" data-further-info-target><%= raw item[:tooltip] %></p>
       </div>
     <% end %>
   <% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -38,7 +38,7 @@
 
                     <div class="form__group-item search-filter__item-inset is-hidden" data-results-filter-target="2">
                       <%= f.label :postcode, t('search.filter.receive_advice.postcode_label'), class: 'form__label-heading' %>
-                      <%= f.text_field :postcode, class: 'search-filter__field search-filter__field--padded t-postcode', maxlength: 8 %>
+                      <%= f.text_field :postcode, class: 'search-filter__field search-filter__field--padded t-postcode', maxlength: 8, required: true %>
                     </div>
                   <% end %>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -3,6 +3,8 @@ cy:
     attributes:
       search_form:
         postcode: Cod post
+  global:
+    required: Gofynnol
 
   mas: Y Gwasanaeth Cynghori Ariannol
   mas_home_url: https://www.moneyadviceservice.org.uk/cy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,8 @@
       search_form:
         advice_methods: ''
         postcode: Postcode
+  global:
+    required: Required
 
   mas: The Money Advice Service
   mas_home_url: https://www.moneyadviceservice.org.uk/en


### PR DESCRIPTION
There's a huge raft of DAC fixes in this project so I'm going to PR them in chunks.

https://github.com/moneyadviceservice/rad_consumer/commit/78edb8c90839b4b329901d7b2c6b87a83c182529 — DAC wanted this marked up as required. I considered using the dough frontend validator but I thought it'd be easier to use the browser validation and let older browsers fall back to seeing the existing server-side validation messages.

https://github.com/moneyadviceservice/rad_consumer/commit/8435dfb272d7c73f13088d2ac0dffaea4e5f751d — For a few reasons the expandable sections needed to be applied and remove on resize events, for instance because increasing the text size in the browser actually changes the resolution of the window. I:

* Added an event to trigger a function with the applying code in.
* Added some code to reverse the apply process.
* Changed the click binding code to listen for events on elements regardless of whether they exist or not.

@alexwllms, wyt?