### PR TITLE
Add notice on sort order for search results.

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,9 @@
+module SearchHelper
+  def results_order_notice_for_form(form)
+    if form.face_to_face?
+      I18n.t('search.distance_order_notice')
+    elsif form.phone_or_online?
+      I18n.t('search.alphabetical_order_notice')
+    end
+  end
+end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -3,6 +3,9 @@
     <p class="l-results__go-back"><%= link_to(t('search.go_back'), root_path) %></p>
     <div class="l-results__main">
       <%= heading_tag( t('search.page_title'), level: 1, class: 'l-results__heading') %>
+      <p class="t-order-notice">
+        <%= results_order_notice_for_form(@form) %>
+      </p>
     </div>
 
     <div class="l-mobile-only">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -235,6 +235,8 @@ cy:
     page_title: Canlyniadau chwilio
     back_to_top: "Ewch i'r brig"
     no_results_message: Nid oes canlyniadau sy’n cyfateb â meini prawf eich chwiliad. Newidiwch eich meini prawf a rhoi cynnig arall arni.
+    alphabetical_order_notice: Rhestrwyd yn nhrefn yr wyddor.
+    distance_order_notice: Rhestrwyd yn ôl pellter, sef pa mor agos yw cynghorydd cwmni atoch chi.
     summary_of_results:
       showing: Yn dangos
       to: i

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,6 +235,8 @@
     page_title: Search results
     back_to_top: Go to top
     no_results_message: There are no results matching your search criteria. Please amend your criteria and try again.
+    alphabetical_order_notice: Ordered alphabetically.
+    distance_order_notice: Ordered by distance a firm’s nearest adviser is to you.
     summary_of_results:
       showing: Showing
       to: to

--- a/spec/features/channel_filter_on_results_page_spec.rb
+++ b/spec/features/channel_filter_on_results_page_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Consumer views channel filters on search results page' do
       then_i_am_on_results_page
       and_i_see_remote_advice_method_selected
       and_only_remote_firms_are_displayed
+      and_i_see_a_notice_that_the_order_is_alphabetical
     end
   end
 
@@ -38,6 +39,7 @@ RSpec.feature 'Consumer views channel filters on search results page' do
       then_i_am_on_results_page
       and_i_see_face_to_face_advice_method_selected
       and_only_in_person_firms_are_displayed
+      and_i_see_a_notice_that_the_order_is_distance_based
     end
   end
 
@@ -171,5 +173,13 @@ RSpec.feature 'Consumer views channel filters on search results page' do
 
   def and_only_in_person_firms_are_displayed
     expect(results_page.firm_names).to contain_exactly(@in_person_firm.registered_name)
+  end
+
+  def and_i_see_a_notice_that_the_order_is_alphabetical
+    expect(results_page.order_notice).to have_text I18n.t('search.alphabetical_order_notice')
+  end
+
+  def and_i_see_a_notice_that_the_order_is_distance_based
+    expect(results_page.order_notice).to have_text I18n.t('search.distance_order_notice')
   end
 end

--- a/spec/support/results_page.rb
+++ b/spec/support/results_page.rb
@@ -15,7 +15,8 @@ class ResultsPage < SitePrism::Page
   element :total_records, '.t-total-records'
 
   element :errors, '.l-landing-page__validation'
-  element :incorrect_criteria_message , '.t-incorrect-criteria'
+  element :incorrect_criteria_message, '.t-incorrect-criteria'
+  element :order_notice, '.t-order-notice'
 
   def next_page
     first("a[rel='next']").click


### PR DESCRIPTION
Adds a little bit of copy to the top of the search results page that tells you how they're ordered — depending on what kind of search you've done.