### PR TITLE
Fix tests. Ensure travis runs js specs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ before_script:
   - cp config/example.database.yml config/database.yml
   - psql -c "create database rad_test;" -U postgres
   - bundle exec rake db:migrate
-  - npm install -g bower
+  - npm install
+  - npm install -g bower karma-cli
   - bundle exec bowndler update
 script:
   - bundle exec rspec
+  - npm test

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 "name": "rad",
   "version": "1.0.0",
   "description": "Retirement Adviser Directory",
+  "scripts": {
+    "test": "./node_modules/.bin/karma start spec/javascripts/karma.conf.js --single-run=true"
+  },
   "devDependencies": {
     "chai": "^1.9.1",
     "chai-jquery": "^1.2.3",

--- a/spec/javascripts/tests/NestedOptions_spec.js
+++ b/spec/javascripts/tests/NestedOptions_spec.js
@@ -2,35 +2,72 @@ describe('show hidden options on checkbox change', function () {
 
   'use strict';
 
-  describe('', function() {
+  beforeEach(function(done){
+    this.$html = $(window.__html__['spec/javascripts/fixtures/NestedOptions.html']).appendTo('body');
+    this.$nestedOptionsComponent = $('[data-nested-options-component]');
+    this.$nestedOptionsTrigger = $('[data-nested-options-trigger]');
+    this.$nestedOptions = $('[data-nested-options]');
+    done();
+  });
 
-    beforeEach(function (done) {
-      var self = this;
+  afterEach(function() {
+    this.$html.remove();
+  });
 
-      requirejs(['jquery', 'NestedOptions'], function ($, NestedOptions) {
-        self.$html = $(window.__html__['spec/javascripts/fixtures/NestedOptions.html']).appendTo('body');
-        self.$nestedOptionsComponent = $('[data-nested-options-component]');
-        self.$nestedOptionsTrigger = $('[data-nested-options-trigger]');
-        self.$nestedOptions = $('[data-nested-options]');
-
-        done();
-      }, done);
-    });
-
-    it('page elements exist', function() {
+  describe('NestedOptions is not loaded', function(){
+    it('page elements exist', function(done) {
       expect(this.$nestedOptionsComponent).to.exist;
       expect(this.$nestedOptions).to.exist;
       expect(this.$nestedOptionsTrigger).to.exist;
+      done();
     });
 
-    it('is hidden on default', function() {
+    it('is hidden on default', function(done) {
       expect(this.$nestedOptions).to.have.class('is-hidden');
+      done();
     });
 
-    it('hidden options are shown on checkbox change', function() {
-     this.$nestedOptionsTrigger.trigger('click');
-     expect(this.$nestedOptionsTrigger).to.be.checked;
-     expect(this.$nestedOptions).to.not.have.class('is-hidden');
+    it('hidden options are not shown when checkbox is checked', function(done) {
+      this.$nestedOptionsTrigger.trigger('click');
+      expect(this.$nestedOptionsTrigger).to.be.checked;
+      expect(this.$nestedOptions).to.have.class('is-hidden');
+      done();
+    });
+  });
+
+  describe('NestedOptions is loaded', function() {
+    it('page elements exist', function(done) {
+      var self = this;
+
+      requirejs(['NestedOptions'], function (NestedOptions) {
+        expect(self.$nestedOptionsComponent).to.exist;
+        expect(self.$nestedOptions).to.exist;
+        expect(self.$nestedOptionsTrigger).to.exist;
+      }, done);
+
+      done();
+    });
+
+    it('is hidden on default', function(done) {
+      var self = this;
+
+      requirejs(['NestedOptions'], function (NestedOptions) {
+        expect(self.$nestedOptions).to.have.class('is-hidden');
+      }, done);
+
+      done();
+    });
+
+    it('hidden options are shown on checkbox change', function(done) {
+      var self = this;
+
+      requirejs(['NestedOptions'], function (NestedOptions) {
+        self.$nestedOptionsTrigger.trigger('click');
+        expect(self.$nestedOptionsTrigger).to.be.checked;
+        expect(self.$nestedOptions).to.not.have.class('is-hidden');
+      }, done);
+
+      done();
     });
   });
 });


### PR DESCRIPTION
We discovered yesterday that a JS spec was failing in this codebase. It appears to have never actually worked, but Travis CI hasn't been running the JS test suite and no new JS functionality has been added in the last few months so it has gone unnoticed.

The functionality is around showing / hiding content when checkboxes are selected (you can see it working on https://directory.moneyadviceservice.org.uk/en). This PR does 3 things:

* Fixes the setup of existing tests, and adds some more just to emphasise the current behaviour
* Updates `package.json` so we can simply invoke `npm test` to run the js tests.
* Updates `.travis.yml` to ensure we're always running the JS test suite.