### PR TITLE
Update remote search to ONLY return firms that offer phone or online advice and NOT face-to-face advice

### DIFF
--- a/app/serializers/search_form_serializer.rb
+++ b/app/serializers/search_form_serializer.rb
@@ -40,7 +40,10 @@ class SearchFormSerializer < ActiveModel::Serializer
 
   def build_filters
     [].tap do |filters|
-      filters << { in: { other_advice_methods: object.remote_advice_method_ids } } if object.phone_or_online?
+      if object.phone_or_online?
+        filters << { in: { other_advice_methods: object.remote_advice_method_ids } }
+        filters << { missing: { field: :in_person_advice_methods } }
+      end
     end
   end
 

--- a/spec/features/consumer_searches_remote_advice_spec.rb
+++ b/spec/features/consumer_searches_remote_advice_spec.rb
@@ -107,6 +107,10 @@ RSpec.feature 'Consumer searches for phone or online advice',
       @online_only.registered_name,
       @online_and_phone.registered_name
     )
+
+    expect(remote_results_page.firm_names).not_to include(
+      @in_person_and_also_remote.registered_name
+    )
   end
 
   def and_they_are_ordered_alphabetically
@@ -132,7 +136,8 @@ RSpec.feature 'Consumer searches for phone or online advice',
 
     expect(names).not_to include(
       @only_in_person.registered_name,
-      @online_only.registered_name
+      @online_only.registered_name,
+      @in_person_and_also_remote.registered_name
     )
   end
 
@@ -147,7 +152,10 @@ RSpec.feature 'Consumer searches for phone or online advice',
   def then_i_am_shown_firms_that_provide_advice_online_and_by_telephone
     expect(remote_results_page).to have_firms(count: 3)
 
-    expect(remote_results_page.firm_names).not_to include(@only_in_person.registered_name)
+    expect(remote_results_page.firm_names).not_to include(
+      @only_in_person.registered_name,
+      @in_person_and_also_remote.registered_name
+    )
   end
 
   def when_i_submit_a_search_without_selecting_advice_methods

--- a/spec/features/consumer_searches_remote_advice_spec.rb
+++ b/spec/features/consumer_searches_remote_advice_spec.rb
@@ -3,6 +3,8 @@ RSpec.feature 'Consumer searches for phone or online advice',
   let(:landing_page) { LandingPage.new }
   let(:remote_results_page) { RemoteResultsPage.new }
 
+  let!(:in_person_advice_methods) { create_list(:in_person_advice_method, 3) }
+
   let!(:phone_advice)  { create(:other_advice_method, name: 'Telephone', order: 1) }
   let!(:online_advice) { create(:other_advice_method, name: 'Online', order: 2) }
 
@@ -58,23 +60,34 @@ RSpec.feature 'Consumer searches for phone or online advice',
     end
   end
 
-
   def and_firms_providing_remote_services_were_previously_indexed
     with_fresh_index! do
-      @online_only = create(:firm, registered_name: 'The End Advisory', other_advice_methods: [online_advice])
-      @online_and_phone = create(:firm, registered_name: 'Remoteley Advisory', other_advice_methods: [online_advice, phone_advice])
-      @phone_only = create(:firm, registered_name: 'Cold Callers Limited', other_advice_methods: [phone_advice])
-      @only_in_person = create(:firm, registered_name: 'ACME Retirement Advice', other_advice_methods: [])
+      # Remote options only
+      @online_only = create(:firm, registered_name: 'The End Advisory', in_person_advice_methods: [], other_advice_methods: [online_advice])
+      @online_and_phone = create(:firm, registered_name: 'Remoteley Advisory', in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
+      @phone_only = create(:firm, registered_name: 'Cold Callers Limited', in_person_advice_methods: [], other_advice_methods: [phone_advice])
+
+      # Face to face options only
+      @only_in_person = create(:firm, registered_name: 'ACME Retirement Advice', in_person_advice_methods: in_person_advice_methods, other_advice_methods: [])
+
+      # Face to face but some of the optional remote options checked too
+      @in_person_and_also_remote = create(:firm, registered_name: 'ACME Retirement Advice', in_person_advice_methods: in_person_advice_methods, other_advice_methods: [online_advice, phone_advice])
     end
   end
 
   def and_firms_providing_various_types_of_remote_services_were_indexed
     with_fresh_index! do
-      @equity = create(:firm_with_no_business_split, registered_name: 'Equity release advisory', pension_transfer_flag: true, other_advice_methods: [online_advice, phone_advice])
-      @wills = create(:firm_with_no_business_split, registered_name: 'Wills advisory', equity_release_flag: true, other_flag: true, other_advice_methods: [online_advice, phone_advice])
-      @probate = create(:firm_with_no_business_split, registered_name: 'Probate advisory', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, other_advice_methods: [online_advice, phone_advice])
-      @wills_and_equity = create(:firm_with_no_business_split, registered_name: 'Paying for care and equity advisory', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, other_advice_methods: [online_advice, phone_advice])
-      @offline_and_wills = create(:firm_with_no_business_split, registered_name: 'Wills Offliney Advisory Ltd', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, other_advice_methods: [])
+      # Remote options only
+      @equity = create(:firm_with_no_business_split, registered_name: 'Equity release advisory', pension_transfer_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
+      @wills = create(:firm_with_no_business_split, registered_name: 'Wills advisory', equity_release_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
+      @probate = create(:firm_with_no_business_split, registered_name: 'Probate advisory', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
+      @wills_and_equity = create(:firm_with_no_business_split, registered_name: 'Paying for care and equity advisory', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
+
+      # Face to face options only
+      @in_person_and_wills = create(:firm_with_no_business_split, registered_name: 'Wills Face to Face Advice Ltd', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: [])
+
+      # Face to face but some of the optional remote options checked too
+      @in_person_and_also_remote = create(:firm_with_no_business_split, registered_name: 'Wills Face to Face or Phone Advice Ltd', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: [online_advice, phone_advice])
     end
   end
 
@@ -169,7 +182,7 @@ RSpec.feature 'Consumer searches for phone or online advice',
   end
 
   def and_the_list_does_not_include_offline_only_advisories
-    expect(remote_results_page.firm_names).not_to include(@offline_and_wills.registered_name)
+    expect(remote_results_page.firm_names).not_to include(@in_person_and_wills.registered_name)
   end
 
   def and_i_am_not_shown_the_advisers_distance

--- a/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
@@ -18,7 +18,6 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
   end
 
   def given_firms_with_advisers_were_previously_indexed
-
     with_fresh_index! do
       @first= create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
       @leicester = create(:adviser, firm: @first, latitude: 52.633013, longitude: -1.131257)

--- a/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
@@ -12,11 +12,13 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
       and_i_indicate_i_need_advice_on_various_topics
       when_i_submit_the_face_to_face_advice_search
       then_i_am_shown_firms_that_provide_the_selected_types_of_advice
+      and_i_am_not_shown_firms_that_provide_remote_only_advice
       and_they_are_ordered_by_location
     end
   end
 
   def given_firms_with_advisers_were_previously_indexed
+
     with_fresh_index! do
       @first= create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
       @leicester = create(:adviser, firm: @first, latitude: 52.633013, longitude: -1.131257)
@@ -29,6 +31,19 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
 
       create(:firm_with_no_business_split, other_flag: true) do |f|
         create(:adviser, firm: f, latitude: 51.428473, longitude: -0.943616)
+      end
+
+      other_advice_methods = [
+        create(:other_advice_method, name: 'Phone', order: 1),
+        create(:other_advice_method, name: 'Online', order: 2)
+      ]
+      @remote_advice_only = create(:firm_with_no_business_split,
+                                   retirement_income_products_flag: true,
+                                   wills_and_probate_flag: true,
+                                   other_flag: true,
+                                   in_person_advice_methods: [],
+                                   other_advice_methods: other_advice_methods) do |f|
+        create(:adviser, firm: f, latitude: 55.856191, longitude: -4.247082)
       end
     end
   end
@@ -59,6 +74,10 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
   def then_i_am_shown_firms_that_provide_the_selected_types_of_advice
     expect(results_page).to be_displayed
     expect(results_page).to have_firms(count: 2)
+  end
+
+  def and_i_am_not_shown_firms_that_provide_remote_only_advice
+    expect(results_page.firm_names).not_to include(@remote_advice_only.registered_name)
   end
 
   def and_they_are_ordered_by_location

--- a/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -22,17 +22,19 @@ RSpec.feature 'Landing page, consumer requires various types of advice over the 
       create(:other_advice_method, name: 'Advice online (e.g. by video call / conference / email)', order: 2)
     ]
 
+    in_person_advice_methods = create_list(:in_person_advice_method, 3)
+
     with_fresh_index! do
-      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, other_advice_methods: other_advice_methods)
+      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       @glasgow = create(:adviser, firm: @first, latitude: 55.856191, longitude: -4.247082)
 
-      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, other_advice_methods: other_advice_methods)
+      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       @leicester = create(:adviser, firm: @second, latitude: 52.633013, longitude: -1.131257)
 
-      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, other_advice_methods: other_advice_methods)
+      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       create(:adviser, firm: @excluded, latitude: 51.428473, longitude: -0.943616)
 
-      create(:firm_with_no_business_split, other_flag: true, other_advice_methods: other_advice_methods) do |f|
+      create(:firm_with_no_business_split, other_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: other_advice_methods) do |f|
         create(:adviser, firm: f, latitude: 51.428473, longitude: -0.943616)
       end
     end

--- a/spec/features/landing_phone_or_online_filter_for_pension_advice_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_pension_advice_spec.rb
@@ -58,17 +58,19 @@ RSpec.feature 'Landing page, consumer requires help with their pension over the 
       create(:other_advice_method, name: 'Advice online (e.g. by video call / conference / email)', order: 2)
     ]
 
+    in_person_advice_methods = create_list(:in_person_advice_method, 3)
+
     with_fresh_index! do
-      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(0, 1), other_advice_methods: other_advice_methods)
+      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(0, 1), in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(2, 3), other_advice_methods: other_advice_methods)
+      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(2, 3), in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       create(:adviser, firm: @medium_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, pension_transfer_flag: true, investment_sizes: @investment_sizes, other_advice_methods: other_advice_methods)
+      @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, pension_transfer_flag: true, investment_sizes: @investment_sizes, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       create(:adviser, firm: @pension_transfer_firm, latitude: latitude, longitude: longitude)
 
-      @excluded = create(:firm_with_no_business_split, other_flag: true, other_advice_methods: other_advice_methods)
+      @excluded = create(:firm_with_no_business_split, other_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: other_advice_methods)
       create(:adviser, firm: @excluded, latitude: latitude, longitude: longitude)
     end
   end

--- a/spec/features/landing_phone_or_online_search_spec.rb
+++ b/spec/features/landing_phone_or_online_search_spec.rb
@@ -52,14 +52,16 @@ RSpec.feature 'Landing page, consumer requires general advice over the phone or 
       create(:other_advice_method, name: 'Online', order: 2)
     ]
 
+    in_person_advice_methods = create_list(:in_person_advice_method, 3)
+
     with_fresh_index! do
-      @phone_firm = create(:firm, other_advice_methods: [other_advice_methods.first])
+      @phone_firm = create(:firm, in_person_advice_methods: [], other_advice_methods: [other_advice_methods.first])
       create(:adviser, firm: @phone_firm)
 
-      @online_firm = create(:firm, other_advice_methods: [other_advice_methods.second])
+      @online_firm = create(:firm, in_person_advice_methods: [], other_advice_methods: [other_advice_methods.second])
       create(:adviser, firm: @online_firm)
 
-      @excluded = create(:firm, other_advice_methods: [])
+      @excluded = create(:firm, in_person_advice_methods: in_person_advice_methods, other_advice_methods: [])
       create(:adviser, firm: @excluded)
     end
   end

--- a/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -97,7 +97,9 @@ RSpec.feature 'Results page, consumer requires various types of advice over the 
   end
 
   def and_they_are_ordered_by_name
-    ordered_results = [@first, @second].map(&:registered_name)
+    # Note string sort order may not be the same as record creation order.
+    # E.g. 'Firm 100' will appear before 'Firm 99' in a character based sort
+    ordered_results = [@first, @second].map(&:registered_name).sort
 
     expect(results_page.firm_names).to eql(ordered_results)
   end

--- a/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -23,20 +23,22 @@ RSpec.feature 'Results page, consumer requires various types of advice over the 
       create(:other_advice_method, name: 'Phone', order: 1),
       create(:other_advice_method, name: 'Online', order: 2)
     ]
+
+    @in_person_advice_methods = create_list(:in_person_advice_method, 3)
   end
 
   def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, other_advice_methods: @other_advice_methods)
+      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       @glasgow = create(:adviser, firm: @first, latitude: 55.856191, longitude: -4.247082)
 
-      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, other_advice_methods: @other_advice_methods)
+      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       @leicester = create(:adviser, firm: @second, latitude: 52.633013, longitude: -1.131257)
 
-      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, other_advice_methods: @other_advice_methods)
+      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @excluded, latitude: 51.428473, longitude: -0.943616)
 
-      create(:firm_with_no_business_split, other_flag: true, other_advice_methods: @other_advice_methods) do |f|
+      create(:firm_with_no_business_split, other_flag: true, in_person_advice_methods: @in_person_advice_methods, other_advice_methods: @other_advice_methods) do |f|
         create(:adviser, firm: f, latitude: 51.428473, longitude: -0.943616)
       end
     end

--- a/spec/features/results_phone_or_online_filter_for_pension_advice_spec.rb
+++ b/spec/features/results_phone_or_online_filter_for_pension_advice_spec.rb
@@ -58,20 +58,22 @@ RSpec.feature 'Results page, consumer requires help with their pension over the 
       create(:other_advice_method, name: 'Phone', order: 1),
       create(:other_advice_method, name: 'Online', order: 2)
     ]
+
+    @in_person_advice_methods = create_list(:in_person_advice_method, 3)
   end
 
   def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(0, 1), other_advice_methods: @other_advice_methods)
+      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(0, 1), in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(2, 3), other_advice_methods: @other_advice_methods)
+      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(2, 3), in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @medium_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, pension_transfer_flag: true, investment_sizes: @investment_sizes, other_advice_methods: @other_advice_methods)
+      @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, pension_transfer_flag: true, investment_sizes: @investment_sizes, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @pension_transfer_firm, latitude: latitude, longitude: longitude)
 
-      @excluded = create(:firm_with_no_business_split, other_flag: true, other_advice_methods: @other_advice_methods)
+      @excluded = create(:firm_with_no_business_split, other_flag: true, in_person_advice_methods: @in_person_advice_methods, other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @excluded, latitude: latitude, longitude: longitude)
     end
   end

--- a/spec/features/results_phone_or_online_search_spec.rb
+++ b/spec/features/results_phone_or_online_search_spec.rb
@@ -59,17 +59,19 @@ RSpec.feature 'Results page, consumer requires general advice over the phone or 
       create(:other_advice_method, name: 'Phone', order: 1),
       create(:other_advice_method, name: 'Online', order: 2)
     ]
+
+    @in_person_advice_methods = create_list(:in_person_advice_method, 3)
   end
 
   def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @phone_firm = create(:firm, other_advice_methods: [@other_advice_methods.first])
+      @phone_firm = create(:firm, in_person_advice_methods: [], other_advice_methods: [@other_advice_methods.first])
       create(:adviser, firm: @phone_firm)
 
-      @online_firm = create(:firm, other_advice_methods: [@other_advice_methods.second])
+      @online_firm = create(:firm, in_person_advice_methods: [], other_advice_methods: [@other_advice_methods.second])
       create(:adviser, firm: @online_firm)
 
-      @excluded = create(:firm, other_advice_methods: [])
+      @excluded = create(:firm, in_person_advice_methods: @in_person_advice_methods, other_advice_methods: [])
       create(:adviser, firm: @excluded)
     end
   end


### PR DESCRIPTION
This change accompanies the back-end data collection change in https://github.com/moneyadviceservice/rad/pull/275.

# Background

The rules for whether a firm should appear in location/postcode or remote-advice-only based searches are now as follows:

## Firms included in location based searches

Should only be firms who have ticked:
* 1..* face-to-face advice types and 
* 0..* remote advice types (i.e. ticking any of these is **optional** if a face-to-face option is checked)

## Firms included in remote advice searches

Should only be firms who have ticked:

* 0 face-to-face advice types and
* 1..* remote advice types

# So what changed?

There are currently only about 11 firms who are really remote only. The remote search currently returns these plus any face-to-face firms who also offer some remote options (which is circa 2000 results).

So we changed the ElasticSearch query for the remote-advice search to filter-out firms that have checked both face-to-face options AND remote-advice options, as these should only be included in the location search.

# How to test?

Go to: https://directory.moneyadviceservice.org.uk/en

Do a remote search selecting both phone and online advice types:

![screen shot 2015-08-03 at 15 36 54](https://cloud.githubusercontent.com/assets/306583/9039772/922ab860-39f5-11e5-8ea9-635c29a2901c.png)

Note the number of results returned is circa 2000:

![screen shot 2015-08-03 at 15 37 58](https://cloud.githubusercontent.com/assets/306583/9039913/8b1a2604-39f6-11e5-93dc-b2f5929edf92.png)

Take a dump of the current production database and restore it so you can run against this branch (this would also require you to run `rake firms:index` to get the data loaded into ElasticSearch). Running the same search as above should result in:

![screen shot 2015-08-03 at 15 39 26](https://cloud.githubusercontent.com/assets/306583/9039918/91ee2c14-39f6-11e5-95a0-05941fcafb44.png)
