### PR TITLE
Add Rubocop and fix things

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,50 @@
+Documentation:
+  Enabled: false
+Metrics/LineLength:
+  Max: 120
+Metrics/MethodLength:
+  Max: 15
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/CollectionMethods:
+  Enabled: false
+Style/DotPosition:
+  EnforcedStyle: leading
+Style/FormatString:
+  Enabled: false
+Style/AndOr:
+  EnforcedStyle: conditionals
+Style/Not:
+  Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/RaiseArgs:
+  Enabled: false
+Style/RegexpLiteral:
+  Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: single_quotes
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+AllCops:
+  RunRailsCops: true
+  Exclude:
+  - 'bin/**/*'
+  - 'config/**/*'
+  - 'db/schema.rb'
+  - 'node_modules/**/*'
+  - 'tmp/**/*'
+  - 'vendor/**/*'
+
+#
+# Project specific settings
+#
+
+# If someone can provide a good explanation of how to satisfy this, we can turn
+# it on.
+Metrics/AbcSize:
+  Enabled: false
+
+# Separating every 3 digits of FCA numbers with '_' is not helpful
+Style/NumericLiterals:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,12 @@ Documentation:
   Enabled: false
 Metrics/LineLength:
   Max: 120
+  Exclude:
+  - 'spec/features/**/*'
 Metrics/MethodLength:
   Max: 15
+  Exclude:
+  - 'spec/features/**/*'
 Style/ClassAndModuleChildren:
   Enabled: false
 Style/CollectionMethods:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ before_script:
 script:
   - bundle exec rspec
   - npm test
+  - bundle exec rubocop -DS

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'pry-rails'
   gem 'rspec-rails'
+  gem 'rubocop'
   gem 'site_prism'
   gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     arel (6.0.0)
+    ast (2.0.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     autoprefixer-rails (5.1.10)
       execjs
       json
@@ -115,7 +118,10 @@ GEM
     multi_json (1.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    parser (2.2.2.6)
+      ast (>= 1.1, < 3.0)
     pg (0.18.1)
+    powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -149,6 +155,7 @@ GEM
       activesupport (= 4.2.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.0.0)
     raindrops (0.13.0)
     rake (10.4.2)
     redis (3.2.1)
@@ -171,6 +178,13 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    rubocop (0.32.1)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.2.5, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     sass (3.2.19)
     sass-rails (4.0.5)
@@ -233,6 +247,7 @@ DEPENDENCIES
   rails (~> 4.2)
   rollbar
   rspec-rails
+  rubocop
   sass-rails
   site_prism
   spring

--- a/Rakefile
+++ b/Rakefile
@@ -28,5 +28,7 @@ end
 if Rails.env.production?
   task :default
 else
-  task default: [:spec, :npm_test]
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+  task default: [:spec, :rubocop, :npm_test]
 end

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -17,12 +17,12 @@ class SearchForm
   ]
 
   attr_accessor :checkbox,
-    :advice_method,
-    :postcode,
-    :coordinates,
-    :pension_pot_size,
-    :advice_methods,
-    *TYPES_OF_ADVICE
+                :advice_method,
+                :postcode,
+                :coordinates,
+                :pension_pot_size,
+                :advice_methods,
+                *TYPES_OF_ADVICE
 
   before_validation :upcase_postcode, if: :face_to_face?
 
@@ -97,6 +97,6 @@ class SearchForm
   end
 
   def upcase_postcode
-    self.postcode.try(:upcase!)
+    postcode.try(:upcase!)
   end
 end

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -79,9 +79,8 @@ class SearchForm
   end
 
   def advice_methods_present
-    if remote_advice_method_ids.empty?
-      errors.add(:advice_methods, I18n.t('search.errors.missing_advice_method'))
-    end
+    return if remote_advice_method_ids.present?
+    errors.add(:advice_methods, I18n.t('search.errors.missing_advice_method'))
   end
 
   def to_query
@@ -91,9 +90,8 @@ class SearchForm
   private
 
   def geocode_postcode
-    unless postcode =~ /\A[A-Z\d]{1,4} ?[A-Z\d]{1,3}\z/ && coordinates
-      errors.add(:postcode, I18n.t('search.errors.geocode_failure'))
-    end
+    return if postcode =~ /\A[A-Z\d]{1,4} ?[A-Z\d]{1,3}\z/ && coordinates
+    errors.add(:postcode, I18n.t('search.errors.geocode_failure'))
   end
 
   def upcase_postcode

--- a/app/serializers/search_form_serializer.rb
+++ b/app/serializers/search_form_serializer.rb
@@ -22,16 +22,8 @@ class SearchFormSerializer < ActiveModel::Serializer
   def query
     {
       filtered: {
-        filter: {
-          bool: {
-            must: build_filters
-          }
-        },
-        query: {
-          bool: {
-            must: build_queries
-          }
-        }
+        filter: { bool: { must: build_filters } },
+        query:  { bool: { must: build_queries } }
       }
     }
   end
@@ -56,11 +48,7 @@ class SearchFormSerializer < ActiveModel::Serializer
 
   def postcode_queries
     [
-      {
-        match: {
-          postcode_searchable: true
-        }
-      },
+      { match: { postcode_searchable: true } },
       advisers_geo_query
     ]
   end

--- a/app/serializers/search_form_serializer.rb
+++ b/app/serializers/search_form_serializer.rb
@@ -61,33 +61,45 @@ class SearchFormSerializer < ActiveModel::Serializer
           postcode_searchable: true
         }
       },
-      {
-        nested: {
-          path: 'advisers',
-          filter: {
-            bool: {
-              must: {
-                geo_shape: {
-                  range_location: {
-                    relation: 'intersects',
-                    shape: {
-                      type: 'point',
-                      coordinates: object.coordinates.reverse
-                    }
-                  }
-                }
-              },
-              should: {
-                geo_distance: {
-                  distance: '750miles',
-                  location: object.coordinates.reverse
-                }
-              }
-            }
+      advisers_geo_query
+    ]
+  end
+
+  def advisers_geo_query
+    {
+      nested: {
+        path: 'advisers',
+        filter: {
+          bool: {
+            must: range_intersects_consumer_location,
+            should: reasonable_distance_from_consumer_location
           }
         }
       }
-    ]
+    }
+  end
+
+  def range_intersects_consumer_location
+    {
+      geo_shape: {
+        range_location: {
+          relation: 'intersects',
+          shape: {
+            type: 'point',
+            coordinates: object.coordinates.reverse
+          }
+        }
+      }
+    }
+  end
+
+  def reasonable_distance_from_consumer_location
+    {
+      geo_distance: {
+        distance: '750miles',
+        location: object.coordinates.reverse
+      }
+    }
   end
 
   def investment_size_queries

--- a/spec/features/channel_filter_on_results_page_spec.rb
+++ b/spec/features/channel_filter_on_results_page_spec.rb
@@ -66,13 +66,12 @@ RSpec.feature 'Consumer views channel filters on search results page',
     end
   end
 
-
   def given_some_firms_were_indexed
     with_fresh_index! do
-      @phone_firm = create(:firm, registered_name: 'The Willers Ltd', in_person_advice_methods: [], other_advice_methods: [ phone_advice ])
+      @phone_firm = create(:firm, registered_name: 'The Willers Ltd', in_person_advice_methods: [], other_advice_methods: [phone_advice])
       create(:adviser, postcode: 'RG2 8EE', firm: @phone_firm, latitude: 51.428473, longitude: -0.943616)
 
-      @online_firm = create(:firm, registered_name: 'The Equiters Ltd', in_person_advice_methods: [], other_advice_methods: [ online_advice ])
+      @online_firm = create(:firm, registered_name: 'The Equiters Ltd', in_person_advice_methods: [], other_advice_methods: [online_advice])
       create(:adviser, postcode: 'LE1 6SL', firm: @online_firm, latitude: 52.633013, longitude: -1.131257)
 
       @in_person_firm = create(:firm, registered_name: 'Estate Traders Ltd', other_advice_methods: [])

--- a/spec/features/consumer_search_on_results_list_spec.rb
+++ b/spec/features/consumer_search_on_results_list_spec.rb
@@ -36,7 +36,6 @@ RSpec.feature 'Consumer views advice filters on search results page',
     end
   end
 
-
   def and_i_am_on_the_rad_landing_page
     landing_page.load
   end

--- a/spec/features/consumer_views_a_search_result_spec.rb
+++ b/spec/features/consumer_views_a_search_result_spec.rb
@@ -3,6 +3,26 @@ RSpec.feature 'Consumer views a search result',
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
+  let(:principal) { create(:principal) }
+  let(:firm) do
+    create(:firm_with_no_business_split,
+           telephone_number: '02082524727',
+           website_address: 'http://www.example.com',
+           principal: principal,
+           free_initial_meeting: true,
+           minimum_fixed_fee: 1000,
+           retirement_income_products_flag: true,
+           pension_transfer_flag: true,
+           long_term_care_flag: true,
+           equity_release_flag: true,
+           inheritance_tax_and_estate_planning_flag: true,
+           wills_and_probate_flag: true,
+           other_flag: true,
+           in_person_advice_methods: [1, 2].map { |i| create(:in_person_advice_method, order: i) },
+           other_advice_methods: [1, 2].map { |i| create(:other_advice_method, order: i) },
+           investment_sizes: [1, 2].map { |i| create(:investment_size, id: i, order: i) })
+  end
+
   scenario 'Viewing a single Firm result in English' do
     with_elastic_search! do
       given_an_indexed_firm_and_associated_adviser
@@ -53,12 +73,12 @@ RSpec.feature 'Consumer views a search result',
   end
 
   def and_i_see_the_firms_contact_details
-    expect(@displayed_firm.address_line_one).to eq(@firm.address_line_one)
-    expect(@displayed_firm.address_town).to eq(@firm.address_town)
-    expect(@displayed_firm.address_county).to eq(@firm.address_county)
-    expect(@displayed_firm.address_postcode).to eq(@firm.address_postcode)
+    expect(@displayed_firm.address_line_one).to eq(firm.address_line_one)
+    expect(@displayed_firm.address_town).to eq(firm.address_town)
+    expect(@displayed_firm.address_county).to eq(firm.address_county)
+    expect(@displayed_firm.address_postcode).to eq(firm.address_postcode)
 
-    expect(@displayed_firm.telephone_number).to include @firm.registered_name
+    expect(@displayed_firm.telephone_number).to include firm.registered_name
     expect(@displayed_firm.telephone_number).to include '020 8252 4727'
     expect(@displayed_firm.website_address).to be
     expect(@displayed_firm.email_address).to be
@@ -104,28 +124,8 @@ RSpec.feature 'Consumer views a search result',
   end
 
   def create_firm_and_adviser(qualifications: [], accreditations: [])
-    @principal = create(:principal)
-
-    @firm = create(:firm_with_no_business_split,
-                   telephone_number: '02082524727',
-                   website_address: 'http://www.example.com',
-                   principal: @principal,
-                   free_initial_meeting: true,
-                   minimum_fixed_fee: 1000,
-                   retirement_income_products_flag: true,
-                   pension_transfer_flag: true,
-                   long_term_care_flag: true,
-                   equity_release_flag: true,
-                   inheritance_tax_and_estate_planning_flag: true,
-                   wills_and_probate_flag: true,
-                   other_flag: true,
-                   in_person_advice_methods: [1, 2].map { |i| create(:in_person_advice_method, order: i) },
-                   other_advice_methods: [1, 2].map { |i| create(:other_advice_method, order: i) },
-                   investment_sizes: [1, 2].map { |i| create(:investment_size, id: i, order: i) }
-                  )
-
     create(:adviser,
-           firm: @firm,
+           firm: firm,
            latitude: 51.428473,
            longitude: -0.943616,
            accreditations: accreditations.map { |i| create(:accreditation, order: i) },

--- a/spec/features/consumer_views_a_search_result_spec.rb
+++ b/spec/features/consumer_views_a_search_result_spec.rb
@@ -29,7 +29,6 @@ RSpec.feature 'Consumer views a search result',
     end
   end
 
-
   def given_an_indexed_firm_and_associated_adviser_without_qualifications_and_accreditations
     with_fresh_index! { create_firm_and_adviser }
   end
@@ -108,29 +107,29 @@ RSpec.feature 'Consumer views a search result',
     @principal = create(:principal)
 
     @firm = create(:firm_with_no_business_split,
-      telephone_number: '02082524727',
-      website_address: 'http://www.example.com',
-      principal: @principal,
-      free_initial_meeting: true,
-      minimum_fixed_fee: 1000,
-      retirement_income_products_flag: true,
-      pension_transfer_flag: true,
-      long_term_care_flag: true,
-      equity_release_flag: true,
-      inheritance_tax_and_estate_planning_flag: true,
-      wills_and_probate_flag: true,
-      other_flag: true,
-      in_person_advice_methods: [1, 2].map { |i| create(:in_person_advice_method, order: i) },
-      other_advice_methods: [1, 2].map { |i| create(:other_advice_method, order: i) },
-      investment_sizes: [1, 2].map { |i| create(:investment_size, id: i, order: i) }
-    )
+                   telephone_number: '02082524727',
+                   website_address: 'http://www.example.com',
+                   principal: @principal,
+                   free_initial_meeting: true,
+                   minimum_fixed_fee: 1000,
+                   retirement_income_products_flag: true,
+                   pension_transfer_flag: true,
+                   long_term_care_flag: true,
+                   equity_release_flag: true,
+                   inheritance_tax_and_estate_planning_flag: true,
+                   wills_and_probate_flag: true,
+                   other_flag: true,
+                   in_person_advice_methods: [1, 2].map { |i| create(:in_person_advice_method, order: i) },
+                   other_advice_methods: [1, 2].map { |i| create(:other_advice_method, order: i) },
+                   investment_sizes: [1, 2].map { |i| create(:investment_size, id: i, order: i) }
+                  )
 
     create(:adviser,
-      firm: @firm,
-      latitude: 51.428473,
-      longitude: -0.943616,
-      accreditations: accreditations.map { |i| create(:accreditation, order: i) },
-      qualifications: qualifications.map { |i| create(:qualification, order: i) }
-    )
+           firm: @firm,
+           latitude: 51.428473,
+           longitude: -0.943616,
+           accreditations: accreditations.map { |i| create(:accreditation, order: i) },
+           qualifications: qualifications.map { |i| create(:qualification, order: i) }
+          )
   end
 end

--- a/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
 
   def given_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @first= create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
+      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
       @leicester = create(:adviser, firm: @first, latitude: 52.633013, longitude: -1.131257)
 
       @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)

--- a/spec/features/landing_face_to_face_search_spec.rb
+++ b/spec/features/landing_face_to_face_search_spec.rb
@@ -38,7 +38,6 @@ RSpec.feature 'Landing page, consumer requires general advice in person',
     end
   end
 
-
   def given_i_am_on_the_landing_page
     landing_page.load
   end
@@ -68,20 +67,20 @@ RSpec.feature 'Landing page, consumer requires general advice in person',
   def and_firms_with_advisers_covering_my_postcode_were_previously_indexed
     with_fresh_index! do
       @second = create(:adviser,
-        firm: create(:firm, registered_name: 'ZZZ'),
-        postcode: 'RG2 8EE',
-        latitude: 51.428473,
-        longitude: -0.943616,
-        travel_distance: 100
-      )
+                       firm: create(:firm, registered_name: 'ZZZ'),
+                       postcode: 'RG2 8EE',
+                       latitude: 51.428473,
+                       longitude: -0.943616,
+                       travel_distance: 100
+                      )
 
       @first = create(:adviser,
-        firm: create(:firm, registered_name: 'AAA'),
-        postcode: 'RG2 8EE',
-        latitude: 51.428473,
-        longitude: -0.943616,
-        travel_distance: 100
-      )
+                      firm: create(:firm, registered_name: 'AAA'),
+                      postcode: 'RG2 8EE',
+                      latitude: 51.428473,
+                      longitude: -0.943616,
+                      travel_distance: 100
+                     )
 
       @leicester = create(:adviser, postcode: 'LE1 6SL', latitude: 52.633013, longitude: -1.131257, travel_distance: 650)
       @glasgow   = create(:adviser, postcode: 'G1 5QT', latitude: 55.856191, longitude: -4.247082, travel_distance: 10)

--- a/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature 'Results page, consumer requires advice on various topics in perso
       @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
       @leicester = create(:adviser, firm: @first, latitude: 52.633013, longitude: -1.131257)
 
-      @second= create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
+      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
       @glasgow = create(:adviser, firm: @second, latitude: 55.856191, longitude: -4.247082)
 
       @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true)

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -169,7 +169,9 @@ RSpec.describe SearchForm do
     end
 
     it 'returns the any size option as the last element' do
-      expect(form.pension_pot_sizes.last).to eql([I18n.t('search_filter.pension_pot.any_size_option'), SearchForm::ANY_SIZE_VALUE])
+      expect(form.pension_pot_sizes.last).to eql([
+        I18n.t('search_filter.pension_pot.any_size_option'), SearchForm::ANY_SIZE_VALUE
+      ])
     end
   end
 

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe SearchHelper, type: :helper do
     it 'calls friendly_name on classified `kind`' do
       Fred = double
       expect(Fred).to receive(:friendly_name)
-                       .with(1).and_return(:something)
+        .with(1).and_return(:something)
       return_value = helper.qualification_or_accreditation_key(1, :fred)
       expect(return_value).to eq(:something)
     end

--- a/spec/lib/geocode_spec.rb
+++ b/spec/lib/geocode_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Geocode, '#call' do
     VCR.use_cassette(:rg11gg) do
       latitude, longitude = Geocode.call('RG11GG')
 
-      expect(latitude).to  eql(51.45326439999999)
+      expect(latitude).to eql(51.45326439999999)
       expect(longitude).to eql(-0.9634222000000001)
     end
   end

--- a/spec/support/elastic_search_helper.rb
+++ b/spec/support/elastic_search_helper.rb
@@ -17,12 +17,10 @@ module ElasticSearchHelper
   end
 
   def with_elastic_search!
-    begin
-      WebMock.allow_net_connect!
-      yield
-    ensure
-      WebMock.disable_net_connect!
-    end
+    WebMock.allow_net_connect!
+    yield
+  ensure
+    WebMock.disable_net_connect!
   end
 
   def index_all!


### PR DESCRIPTION
Adds Rubocop.

Rules seeded form the rad project.

Bulky fixture creation methods under `spec/features` are excluded from Metrics/LineLength and Metrics/MethodLength checks. But all other checks run as per rad.