### PR TITLE
Update mas-rad_core to 0.0.73 and fix tests to reflect new changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'dough-ruby',
     ref: 'cf08913'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.0.62'
+gem 'mas-rad_core', '0.0.73'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,14 +98,16 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.3)
+    language_list (1.1.0)
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.62)
+    mas-rad_core (0.0.73)
       active_model_serializers
       geocoder
       httpclient
+      language_list
       pg
       rails (~> 4.2)
       redis
@@ -241,7 +243,7 @@ DEPENDENCIES
   geocoder
   jquery-rails
   kaminari
-  mas-rad_core (= 0.0.62)
+  mas-rad_core (= 0.0.73)
   pg
   pry-rails
   rails (~> 4.2)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150706102943) do
+ActiveRecord::Schema.define(version: 20150817141257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_stat_statements"
 
   create_table "accreditations", force: :cascade do |t|
     t.string   "name",                   null: false
@@ -32,14 +31,13 @@ ActiveRecord::Schema.define(version: 20150706102943) do
   add_index "accreditations_advisers", ["adviser_id", "accreditation_id"], name: "advisers_accreditations_index", unique: true, using: :btree
 
   create_table "advisers", force: :cascade do |t|
-    t.string   "reference_number",                  null: false
-    t.string   "name",                              null: false
-    t.integer  "firm_id",                           null: false
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.boolean  "confirmed_disclaimer",              null: false
-    t.string   "postcode",             default: "", null: false
-    t.integer  "travel_distance",      default: 0,  null: false
+    t.string   "reference_number",              null: false
+    t.string   "name",                          null: false
+    t.integer  "firm_id",                       null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.string   "postcode",         default: "", null: false
+    t.integer  "travel_distance",  default: 0,  null: false
     t.float    "latitude"
     t.float    "longitude"
   end
@@ -103,8 +101,11 @@ ActiveRecord::Schema.define(version: 20150706102943) do
     t.boolean  "equity_release_flag",                      default: false, null: false
     t.boolean  "inheritance_tax_and_estate_planning_flag", default: false, null: false
     t.boolean  "wills_and_probate_flag",                   default: false, null: false
-    t.boolean  "other_flag",                               default: false, null: false
     t.string   "website_address"
+    t.boolean  "ethical_investing_flag",                   default: false, null: false
+    t.boolean  "sharia_investing_flag",                    default: false, null: false
+    t.integer  "status"
+    t.text     "languages",                                default: [],    null: false, array: true
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree
@@ -199,6 +200,20 @@ ActiveRecord::Schema.define(version: 20150706102943) do
   end
 
   add_index "lookup_subsidiaries", ["fca_number"], name: "index_lookup_subsidiaries_on_fca_number", using: :btree
+
+  create_table "offices", force: :cascade do |t|
+    t.string   "address_line_one",                 null: false
+    t.string   "address_line_two"
+    t.string   "address_town",                     null: false
+    t.string   "address_county"
+    t.string   "address_postcode",                 null: false
+    t.string   "email_address"
+    t.string   "telephone_number"
+    t.boolean  "disabled_access",  default: false, null: false
+    t.integer  "firm_id",                          null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+  end
 
   create_table "old_passwords", force: :cascade do |t|
     t.string   "encrypted_password",       null: false

--- a/spec/features/consumer_search_on_results_list_spec.rb
+++ b/spec/features/consumer_search_on_results_list_spec.rb
@@ -3,6 +3,8 @@ RSpec.feature 'Consumer views advice filters on search results page',
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
 
+  let(:phone_advice)  { create(:other_advice_method, name: 'Advice by telephone', order: 1) }
+
   scenario 'Consumer views current filters applied to their search' do
     with_elastic_search! do
       given_some_firms_were_indexed
@@ -50,7 +52,7 @@ RSpec.feature 'Consumer views advice filters on search results page',
       @leicester = create(:adviser, postcode: 'LE1 6SL', firm: @equity_firm,      latitude: 52.633013, longitude: -1.131257)
       @glasgow   = create(:adviser, postcode: 'G1 5QT',  firm: @inheritance_firm, latitude: 55.856191, longitude: -4.247082)
 
-      @missing = create(:firm, in_person_advice_methods: []) do |firm|
+      @missing = create(:firm, in_person_advice_methods: [], other_advice_methods: [phone_advice]) do |firm|
         create(:adviser, firm: firm, latitude: 51.428473, longitude: -0.943616)
       end
     end

--- a/spec/features/consumer_searches_remote_advice_spec.rb
+++ b/spec/features/consumer_searches_remote_advice_spec.rb
@@ -79,15 +79,15 @@ RSpec.feature 'Consumer searches for phone or online advice',
     with_fresh_index! do
       # Remote options only
       @equity = create(:firm_with_no_business_split, registered_name: 'Equity release advisory', pension_transfer_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
-      @wills = create(:firm_with_no_business_split, registered_name: 'Wills advisory', equity_release_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
-      @probate = create(:firm_with_no_business_split, registered_name: 'Probate advisory', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
-      @wills_and_equity = create(:firm_with_no_business_split, registered_name: 'Paying for care and equity advisory', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
+      @wills = create(:firm_with_no_business_split, registered_name: 'Wills advisory', equity_release_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
+      @probate = create(:firm_with_no_business_split, registered_name: 'Probate advisory', equity_release_flag: true, wills_and_probate_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
+      @wills_and_equity = create(:firm_with_no_business_split, registered_name: 'Paying for care and equity advisory', equity_release_flag: true, wills_and_probate_flag: true, in_person_advice_methods: [], other_advice_methods: [online_advice, phone_advice])
 
       # Face to face options only
-      @in_person_and_wills = create(:firm_with_no_business_split, registered_name: 'Wills Face to Face Advice Ltd', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: [])
+      @in_person_and_wills = create(:firm_with_no_business_split, registered_name: 'Wills Face to Face Advice Ltd', equity_release_flag: true, wills_and_probate_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: [])
 
       # Face to face but some of the optional remote options checked too
-      @in_person_and_also_remote = create(:firm_with_no_business_split, registered_name: 'Wills Face to Face or Phone Advice Ltd', equity_release_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: [online_advice, phone_advice])
+      @in_person_and_also_remote = create(:firm_with_no_business_split, registered_name: 'Wills Face to Face or Phone Advice Ltd', equity_release_flag: true, wills_and_probate_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: [online_advice, phone_advice])
     end
   end
 

--- a/spec/features/consumer_views_a_search_result_spec.rb
+++ b/spec/features/consumer_views_a_search_result_spec.rb
@@ -17,7 +17,6 @@ RSpec.feature 'Consumer views a search result',
            equity_release_flag: true,
            inheritance_tax_and_estate_planning_flag: true,
            wills_and_probate_flag: true,
-           other_flag: true,
            in_person_advice_methods: [1, 2].map { |i| create(:in_person_advice_method, order: i) },
            other_advice_methods: [1, 2].map { |i| create(:other_advice_method, order: i) },
            investment_sizes: [1, 2].map { |i| create(:investment_size, id: i, order: i) })

--- a/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
@@ -19,16 +19,18 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
 
   def given_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
+      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true)
       @leicester = create(:adviser, firm: @first, latitude: 52.633013, longitude: -1.131257)
 
-      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
+      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true)
       @glasgow = create(:adviser, firm: @second, latitude: 55.856191, longitude: -4.247082)
 
-      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true)
+      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true)
       create(:adviser, firm: @excluded, latitude: 51.428473, longitude: -0.943616)
 
-      create(:firm_with_no_business_split, other_flag: true) do |f|
+      #  This firm isn't strictly needed here. If something was wrong an extra result (this one)
+      #  would appear and so it would break a results count test somewhere.
+      create(:firm_with_no_business_split, retirement_income_products_flag: true) do |f|
         create(:adviser, firm: f, latitude: 51.428473, longitude: -0.943616)
       end
 
@@ -39,7 +41,6 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
       @remote_advice_only = create(:firm_with_no_business_split,
                                    retirement_income_products_flag: true,
                                    wills_and_probate_flag: true,
-                                   other_flag: true,
                                    in_person_advice_methods: [],
                                    other_advice_methods: other_advice_methods) do |f|
         create(:adviser, firm: f, latitude: 55.856191, longitude: -4.247082)

--- a/spec/features/landing_face_to_face_filter_for_pension_advice_spec.rb
+++ b/spec/features/landing_face_to_face_filter_for_pension_advice_spec.rb
@@ -54,16 +54,16 @@ RSpec.feature 'Landing page, consumer requires help with their pension in person
     @investment_sizes = create_list(:investment_size, 5)
 
     with_fresh_index! do
-      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(0, 1))
+      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, investment_sizes: @investment_sizes.values_at(0, 1))
       create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(2, 3))
+      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, investment_sizes: @investment_sizes.values_at(2, 3))
       create(:adviser, firm: @medium_pot_size_firm, latitude: latitude, longitude: longitude)
 
       @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, pension_transfer_flag: true, investment_sizes: @investment_sizes)
       create(:adviser, firm: @pension_transfer_firm, latitude: latitude, longitude: longitude)
 
-      @excluded = create(:firm_with_no_business_split, other_flag: true)
+      @excluded = create(:firm_with_no_business_split, wills_and_probate_flag: true)
       create(:adviser, firm: @excluded, latitude: latitude, longitude: longitude)
     end
   end

--- a/spec/features/landing_face_to_face_search_spec.rb
+++ b/spec/features/landing_face_to_face_search_spec.rb
@@ -2,6 +2,7 @@ RSpec.feature 'Landing page, consumer requires general advice in person',
               vcr: vcr_options_for_feature(:landing_face_to_face_search) do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
+  let(:phone_advice)  { create(:other_advice_method, name: 'Advice by telephone', order: 1) }
 
   scenario 'Using a valid postcode' do
     with_elastic_search! do
@@ -85,7 +86,7 @@ RSpec.feature 'Landing page, consumer requires general advice in person',
       @leicester = create(:adviser, postcode: 'LE1 6SL', latitude: 52.633013, longitude: -1.131257, travel_distance: 650)
       @glasgow   = create(:adviser, postcode: 'G1 5QT', latitude: 55.856191, longitude: -4.247082, travel_distance: 10)
 
-      @missing = create(:firm, in_person_advice_methods: []) do |firm|
+      @missing = create(:firm, in_person_advice_methods: [], other_advice_methods: [phone_advice]) do |firm|
         create(:adviser, firm: firm, latitude: 51.428473, longitude: -0.943616)
       end
     end

--- a/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -22,19 +22,23 @@ RSpec.feature 'Landing page, consumer requires various types of advice over the 
       create(:other_advice_method, name: 'Advice online (e.g. by video call / conference / email)', order: 2)
     ]
 
-    in_person_advice_methods = create_list(:in_person_advice_method, 3)
+    in_person_advice_methods = [
+      create(:in_person_advice_method, name: 'Home Visit', order: 1)
+    ]
 
     with_fresh_index! do
-      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
+      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       @glasgow = create(:adviser, firm: @first, latitude: 55.856191, longitude: -4.247082)
 
-      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
+      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       @leicester = create(:adviser, firm: @second, latitude: 52.633013, longitude: -1.131257)
 
-      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
+      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       create(:adviser, firm: @excluded, latitude: 51.428473, longitude: -0.943616)
 
-      create(:firm_with_no_business_split, other_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: other_advice_methods) do |f|
+      #  This firm isn't strictly needed here. If something was wrong an extra result (this one)
+      #  would appear and so it would break a results count test somewhere.
+      create(:firm_with_no_business_split, retirement_income_products_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: other_advice_methods) do |f|
         create(:adviser, firm: f, latitude: 51.428473, longitude: -0.943616)
       end
     end

--- a/spec/features/landing_phone_or_online_filter_for_pension_advice_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_pension_advice_spec.rb
@@ -61,16 +61,16 @@ RSpec.feature 'Landing page, consumer requires help with their pension over the 
     in_person_advice_methods = create_list(:in_person_advice_method, 3)
 
     with_fresh_index! do
-      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(0, 1), in_person_advice_methods: [], other_advice_methods: other_advice_methods)
+      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, investment_sizes: @investment_sizes.values_at(0, 1), in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(2, 3), in_person_advice_methods: [], other_advice_methods: other_advice_methods)
+      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, investment_sizes: @investment_sizes.values_at(2, 3), in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       create(:adviser, firm: @medium_pot_size_firm, latitude: latitude, longitude: longitude)
 
       @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, pension_transfer_flag: true, investment_sizes: @investment_sizes, in_person_advice_methods: [], other_advice_methods: other_advice_methods)
       create(:adviser, firm: @pension_transfer_firm, latitude: latitude, longitude: longitude)
 
-      @excluded = create(:firm_with_no_business_split, other_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: other_advice_methods)
+      @excluded = create(:firm_with_no_business_split, wills_and_probate_flag: true, in_person_advice_methods: in_person_advice_methods, other_advice_methods: other_advice_methods)
       create(:adviser, firm: @excluded, latitude: latitude, longitude: longitude)
     end
   end

--- a/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
@@ -25,16 +25,18 @@ RSpec.feature 'Results page, consumer requires advice on various topics in perso
 
   def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
+      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true)
       @leicester = create(:adviser, firm: @first, latitude: 52.633013, longitude: -1.131257)
 
-      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true)
+      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true)
       @glasgow = create(:adviser, firm: @second, latitude: 55.856191, longitude: -4.247082)
 
-      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true)
+      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true)
       create(:adviser, firm: @excluded, latitude: 51.428473, longitude: -0.943616)
 
-      create(:firm_with_no_business_split, other_flag: true) do |f|
+      #  This firm isn't strictly needed here. If something was wrong an extra result (this one)
+      #  would appear and so it would break a results count test somewhere.
+      create(:firm_with_no_business_split, retirement_income_products_flag: true) do |f|
         create(:adviser, firm: f, latitude: 51.428473, longitude: -0.943616)
       end
     end

--- a/spec/features/results_face_to_face_filter_for_pension_advice_spec.rb
+++ b/spec/features/results_face_to_face_filter_for_pension_advice_spec.rb
@@ -60,16 +60,16 @@ RSpec.feature 'Results page, consumer requires help with their pension in person
 
   def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(0, 1))
+      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, investment_sizes: @investment_sizes.values_at(0, 1))
       create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(2, 3))
+      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, investment_sizes: @investment_sizes.values_at(2, 3))
       create(:adviser, firm: @medium_pot_size_firm, latitude: latitude, longitude: longitude)
 
       @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, pension_transfer_flag: true, investment_sizes: @investment_sizes)
       create(:adviser, firm: @pension_transfer_firm, latitude: latitude, longitude: longitude)
 
-      @excluded = create(:firm_with_no_business_split, other_flag: true)
+      @excluded = create(:firm_with_no_business_split, wills_and_probate_flag: true)
       create(:adviser, firm: @excluded, latitude: latitude, longitude: longitude)
     end
   end

--- a/spec/features/results_face_to_face_search_spec.rb
+++ b/spec/features/results_face_to_face_search_spec.rb
@@ -2,6 +2,8 @@ RSpec.feature 'Results page, consumer requires help with their pension in person
               vcr: vcr_options_for_feature(:results_face_to_face_search) do
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
+  let(:phone_advice)  { create(:other_advice_method, name: 'Phone', order: 1) }
+  let(:online_advice)  { create(:other_advice_method, name: 'Online', order: 2) }
 
   scenario 'Using only a valid postcode' do
     with_elastic_search! do
@@ -46,8 +48,7 @@ RSpec.feature 'Results page, consumer requires help with their pension in person
   end
 
   def given_reference_data_has_been_populated
-    create(:other_advice_method, name: 'Phone', order: 1)
-    create(:other_advice_method, name: 'Online', order: 2)
+    phone_advice && online_advice
   end
 
   def and_firms_with_advisers_were_previously_indexed
@@ -56,7 +57,7 @@ RSpec.feature 'Results page, consumer requires help with their pension in person
       @leicester = create(:adviser, postcode: 'LE1 6SL', latitude: 52.633013, longitude: -1.131257, travel_distance: 650)
       @glasgow = create(:adviser, postcode: 'G1 5QT', latitude: 55.856191, longitude: -4.247082, travel_distance: 10)
 
-      @missing = create(:firm, in_person_advice_methods: []) do |firm|
+      @missing = create(:firm, in_person_advice_methods: [], other_advice_methods: [phone_advice]) do |firm|
         create(:adviser, firm: firm, latitude: 51.428473, longitude: -0.943616)
       end
     end

--- a/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -29,16 +29,18 @@ RSpec.feature 'Results page, consumer requires various types of advice over the 
 
   def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
+      @first = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       @glasgow = create(:adviser, firm: @first, latitude: 55.856191, longitude: -4.247082)
 
-      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
+      @second = create(:firm_with_no_business_split, retirement_income_products_flag: true, wills_and_probate_flag: true, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       @leicester = create(:adviser, firm: @second, latitude: 52.633013, longitude: -1.131257)
 
-      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
+      @excluded = create(:firm_with_no_business_split, retirement_income_products_flag: true, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @excluded, latitude: 51.428473, longitude: -0.943616)
 
-      create(:firm_with_no_business_split, other_flag: true, in_person_advice_methods: @in_person_advice_methods, other_advice_methods: @other_advice_methods) do |f|
+      #  This firm isn't strictly needed here. If something was wrong an extra result (this one)
+      #  would appear and so it would break a results count test somewhere.
+      create(:firm_with_no_business_split, retirement_income_products_flag: true, in_person_advice_methods: @in_person_advice_methods, other_advice_methods: @other_advice_methods) do |f|
         create(:adviser, firm: f, latitude: 51.428473, longitude: -0.943616)
       end
     end

--- a/spec/features/results_phone_or_online_filter_for_pension_advice_spec.rb
+++ b/spec/features/results_phone_or_online_filter_for_pension_advice_spec.rb
@@ -64,16 +64,16 @@ RSpec.feature 'Results page, consumer requires help with their pension over the 
 
   def and_firms_with_advisers_were_previously_indexed
     with_fresh_index! do
-      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(0, 1), in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
+      @small_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, investment_sizes: @investment_sizes.values_at(0, 1), in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @small_pot_size_firm, latitude: latitude, longitude: longitude)
 
-      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, other_flag: true, investment_sizes: @investment_sizes.values_at(2, 3), in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
+      @medium_pot_size_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, investment_sizes: @investment_sizes.values_at(2, 3), in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @medium_pot_size_firm, latitude: latitude, longitude: longitude)
 
       @pension_transfer_firm = create(:firm_with_no_business_split, retirement_income_products_flag: true, pension_transfer_flag: true, investment_sizes: @investment_sizes, in_person_advice_methods: [], other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @pension_transfer_firm, latitude: latitude, longitude: longitude)
 
-      @excluded = create(:firm_with_no_business_split, other_flag: true, in_person_advice_methods: @in_person_advice_methods, other_advice_methods: @other_advice_methods)
+      @excluded = create(:firm_with_no_business_split, wills_and_probate_flag: true, in_person_advice_methods: @in_person_advice_methods, other_advice_methods: @other_advice_methods)
       create(:adviser, firm: @excluded, latitude: latitude, longitude: longitude)
     end
   end


### PR DESCRIPTION
* Bumps mas-rad_core to 0.0.73
* Migrate the schema to reflect rad_core changes
* Updates a number of specs to reflect modelling changes in firms
  * Added comments above factory generated firms that appear to be superfluous, but may be intentionally there to highlight counting errors when things don't work correctly.
