### PR TITLE
add a note about rake task needed to be run

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Push the index. For the production environment replace `rad_development` with
 $ curl -XPOST http://127.0.0.1:9200/rad_development -d @elastic_search_mapping.json
 ```
 
+Once you've pushed the index, run the following rake task to populate it:
+```sh
+rake firms:index
+```
+
 ## Usage
 
 Start the application:


### PR DESCRIPTION
Tiny PR to add a note to the readme about running a rake task to populate the elastic search index, otherwise you won't see any search results.