### PR TITLE
[DEV APPROVED] Fix test failure due to string sorting '10' before '9'

### DIFF
--- a/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
   end
 
   def and_they_are_ordered_by_location
-    ordered_results = [@first, @second].map(&:registered_name)
+    ordered_results = [@first, @second].map(&:registered_name).sort
 
     expect(results_page.firm_names).to eql(ordered_results)
   end

--- a/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -74,8 +74,6 @@ RSpec.feature 'Landing page, consumer requires various types of advice over the 
   end
 
   def and_they_are_ordered_by_name
-    # Note string sort order may not be the same as record creation order.
-    # E.g. 'Firm 100' will appear before 'Firm 99' in a character based sort
     ordered_results = [@first, @second].map(&:registered_name).sort
 
     expect(results_page.firm_names).to eql(ordered_results)

--- a/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -74,7 +74,9 @@ RSpec.feature 'Landing page, consumer requires various types of advice over the 
   end
 
   def and_they_are_ordered_by_name
-    ordered_results = [@first, @second].map(&:registered_name)
+    # Note string sort order may not be the same as record creation order.
+    # E.g. 'Firm 100' will appear before 'Firm 99' in a character based sort
+    ordered_results = [@first, @second].map(&:registered_name).sort
 
     expect(results_page.firm_names).to eql(ordered_results)
   end

--- a/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'Results page, consumer requires advice on various topics in perso
   end
 
   def and_they_are_ordered_by_location
-    ordered_results = [@first, @second].map(&:registered_name)
+    ordered_results = [@first, @second].map(&:registered_name).sort
 
     expect(results_page.firm_names).to eql(ordered_results)
   end

--- a/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -99,8 +99,6 @@ RSpec.feature 'Results page, consumer requires various types of advice over the 
   end
 
   def and_they_are_ordered_by_name
-    # Note string sort order may not be the same as record creation order.
-    # E.g. 'Firm 100' will appear before 'Firm 99' in a character based sort
     ordered_results = [@first, @second].map(&:registered_name).sort
 
     expect(results_page.firm_names).to eql(ordered_results)


### PR DESCRIPTION
Found another instance of this failure by accident. Also spotted 2 other tests which would be susceptible so fixed them too.