### PR TITLE
Revert fixes to tests that order by location

### DIFF
--- a/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/landing_face_to_face_filter_for_other_advice_types_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature 'Landing page, consumer requires advice on various topics in perso
   end
 
   def and_they_are_ordered_by_location
-    ordered_results = [@first, @second].map(&:registered_name).sort
+    ordered_results = [@first, @second].map(&:registered_name)
 
     expect(results_page.firm_names).to eql(ordered_results)
   end

--- a/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_face_to_face_filter_for_other_advice_types_spec.rb
@@ -94,7 +94,7 @@ RSpec.feature 'Results page, consumer requires advice on various topics in perso
   end
 
   def and_they_are_ordered_by_location
-    ordered_results = [@first, @second].map(&:registered_name).sort
+    ordered_results = [@first, @second].map(&:registered_name)
 
     expect(results_page.firm_names).to eql(ordered_results)
   end


### PR DESCRIPTION
When fixing the ascii ordering bug before, I applied the same fix to
other tests that looked susceptible to the same error. Except I didn't
read the name of the tests and so didn't notice that 2 of the 4 order by
location and don't need the ordering fix :S

The magic seed that revealed this error was `rspec --seed 52482`