### PR TITLE
[DEV APPROVED] Firm email and tpnum have been removed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'dough-ruby',
     ref: 'cf08913'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.0.81'
+gem 'mas-rad_core', '0.0.82'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.81)
+    mas-rad_core (0.0.82)
       active_model_serializers
       geocoder
       httpclient
@@ -248,7 +248,7 @@ DEPENDENCIES
   geocoder
   jquery-rails
   kaminari
-  mas-rad_core (= 0.0.81)
+  mas-rad_core (= 0.0.82)
   pg
   pry-rails
   rails (~> 4.2)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150817141257) do
+ActiveRecord::Schema.define(version: 20150930140851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,15 +80,8 @@ ActiveRecord::Schema.define(version: 20150817141257) do
   create_table "firms", force: :cascade do |t|
     t.integer  "fca_number",                                               null: false
     t.string   "registered_name",                                          null: false
-    t.string   "email_address"
-    t.string   "telephone_number"
     t.datetime "created_at",                                               null: false
     t.datetime "updated_at",                                               null: false
-    t.string   "address_line_one"
-    t.string   "address_line_two"
-    t.string   "address_town"
-    t.string   "address_county"
-    t.string   "address_postcode"
     t.boolean  "free_initial_meeting"
     t.integer  "initial_meeting_duration_id"
     t.integer  "minimum_fixed_fee"
@@ -104,8 +97,8 @@ ActiveRecord::Schema.define(version: 20150817141257) do
     t.string   "website_address"
     t.boolean  "ethical_investing_flag",                   default: false, null: false
     t.boolean  "sharia_investing_flag",                    default: false, null: false
-    t.integer  "status"
     t.text     "languages",                                default: [],    null: false, array: true
+    t.integer  "status"
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree

--- a/spec/features/consumer_views_a_search_result_spec.rb
+++ b/spec/features/consumer_views_a_search_result_spec.rb
@@ -4,9 +4,9 @@ RSpec.feature 'Consumer views a search result',
   let(:results_page) { ResultsPage.new }
 
   let(:principal) { create(:principal) }
-  let(:firm) do
+  let(:firm_without_offices) do
     create(:firm_with_no_business_split,
-           telephone_number: '02082524727',
+           :without_offices,
            website_address: 'http://www.example.com',
            principal: principal,
            free_initial_meeting: true,
@@ -20,6 +20,9 @@ RSpec.feature 'Consumer views a search result',
            in_person_advice_methods: [1, 2].map { |i| create(:in_person_advice_method, order: i) },
            other_advice_methods: [1, 2].map { |i| create(:other_advice_method, order: i) },
            investment_sizes: [1, 2].map { |i| create(:investment_size, id: i, order: i) })
+  end
+  let(:firm) do
+    firm_without_offices.tap { |f| create(:office, telephone_number: '02082524727', firm: f) }
   end
 
   scenario 'Viewing a single Firm result in English' do

--- a/spec/features/consumer_views_a_search_result_spec.rb
+++ b/spec/features/consumer_views_a_search_result_spec.rb
@@ -79,11 +79,13 @@ RSpec.feature 'Consumer views a search result',
     expect(@displayed_firm.address_town).to eq(firm.address_town)
     expect(@displayed_firm.address_county).to eq(firm.address_county)
     expect(@displayed_firm.address_postcode).to eq(firm.address_postcode)
-
-    expect(@displayed_firm.telephone_number).to include firm.registered_name
-    expect(@displayed_firm.telephone_number).to include '020 8252 4727'
     expect(@displayed_firm.website_address).to be
     expect(@displayed_firm.email_address).to be
+
+    # telephone_number is a sentence containing the name and phone number
+    expect(@displayed_firm.telephone_number)
+      .to include(firm.registered_name)
+      .and include('020 8252 4727')
   end
 
   def and_i_see_the_where_the_firm_offers_advice


### PR DESCRIPTION
This change fixes tests broken as a consequence of https://github.com/moneyadviceservice/rad/pull/318.