### PR TITLE
Disable dead link to firm profile from result heading

### DIFF
--- a/app/views/search/partials/_firm.html.erb
+++ b/app/views/search/partials/_firm.html.erb
@@ -1,7 +1,7 @@
 <li class="result t-firm" data-results-module>
   <%= heading_tag(level: 2, class: 'result__heading', data: { results_module_heading: '' }) do %>
     <span class="result__heading-text t-name">
-      <%= link_to firm.name, firm_path(firm.id, search_form: params[:search_form]) %>
+      <%= firm.name %>
     </span>
     <% if @form.face_to_face? %>
       <span class="result__adviser-distance t-adviser-distance"><%= t('search.result.adviser') %> <%= firm.closest_adviser %></span>


### PR DESCRIPTION
Little PR to remove the hyperlink to a firm's currently non-existant profile page.