### PR TITLE
[DEV APPROVED]Only show location / map information if it's an 'in-person' search

### DIFF
--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -1,9 +1,9 @@
 class FirmsController < ApplicationController
   def show
-    form   = SearchForm.new(params[:search_form].merge(firm_id: params[:id]))
-    result = FirmRepository.new.search(form.to_query)
+    @search_form = SearchForm.new(params[:search_form].merge(firm_id: params[:id]))
+    result = FirmRepository.new.search(@search_form.to_query)
 
     @firm  = result.firms.first
-    @latitude, @longitude = form.coordinates
+    @latitude, @longitude = @search_form.coordinates
   end
 end

--- a/app/views/firms/partials/_content.html.erb
+++ b/app/views/firms/partials/_content.html.erb
@@ -22,7 +22,7 @@
 
     <div class="tab-selector__target is-active" id="panel-1" data-dough-tab-selector-target="1">
       <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.firm.heading') %></h2>
-      <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude } %>
+      <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude, search_form: @search_form } %>
     </div>
     <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
       <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.office.heading') %></h2>

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -1,13 +1,15 @@
-<%= heading_tag(t('firms.show.panels.firm.locations'), level: 3, class: 'l-firm__heading') %>
+<% if search_form.face_to_face? %>
+  <%= heading_tag(t('firms.show.panels.firm.locations'), level: 3, class: 'l-firm__heading') %>
 
-<%= firm_map_component(center: {lat: latitude, lng: longitude}) do %>
-  <div class="firm__map" data-dough-map></div>
+  <%= firm_map_component(center: {lat: latitude, lng: longitude}) do %>
+    <div class="firm__map" data-dough-map></div>
 
-  <ul class="is-hidden">
-    <% firm.advisers.each do |adviser| %>
-      <li data-dough-map-point data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
-        <%= adviser.name %>
-      </li>
-    <% end %>
-  </ul>
+    <ul class="is-hidden">
+      <% firm.advisers.each do |adviser| %>
+        <li data-dough-map-point data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
+          <%= adviser.name %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
 <% end %>

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -1,9 +1,11 @@
 <div class="firm__header">
   <%= heading_tag(@firm.name, level: 2, class: 'firm__name') %>
-  <div class="firm__adviser-distance">
-    <%= t('search.result.adviser') %>
-    <%= @firm.closest_adviser %>
-  </div>
+  <% if search_form.face_to_face? %>
+    <div class="firm__adviser-distance">
+      <%= t('search.result.adviser') %>
+      <%= @firm.closest_adviser %>
+    </div>
+  <% end %>
 
   <div class="firm__links">
     <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>

--- a/app/views/firms/show.html.erb
+++ b/app/views/firms/show.html.erb
@@ -10,8 +10,8 @@
       </p>
 
       <div class="firm">
-        <%= render partial: 'firms/partials/header' %>
-        <%= render partial: 'firms/partials/content' %>
+        <%= render partial: 'firms/partials/header', locals: { search_form: @search_form } %>
+        <%= render partial: 'firms/partials/content', locals: { search_form: @search_form } %>
       </div>
     </div>
 

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe FirmsController, type: :controller do
       end
     end
 
+    it 'assigns the search form' do
+      VCR.use_cassette(:geocode_search_form_postcode) do
+        search_form = double(SearchForm, to_query: {}, coordinates: [51.5, -0.1])
+        allow(SearchForm).to receive(:new).and_return(search_form)
+
+        get :show, id: firm.id, locale: :en, search_form: search_form_params
+        expect(assigns(:search_form)).to eq(search_form)
+      end
+    end
+
     it 'assigns the first firm result to the view' do
       VCR.use_cassette(:geocode_search_form_postcode) do
         get :show, id: firm.id, locale: :en, search_form: search_form_params


### PR DESCRIPTION
If a user performs a 'remote' search, they haven't provided any location information.

We should only show distance to nearest adviser and the map when viewing a firm's profile if the user performed a search which provides location data.

* Adds assignment to existing `SearchForm` in the controller
* Update views with conditionals to display location information if appropriate search type.