### PR TITLE
[DEV APPROVED] only render telephone, email, and website if they exist

### DIFF
--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -6,19 +6,25 @@
   </div>
 
   <div class="firm__links">
-    <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>
-      <%= svg_icon :phone, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
-      %><%= @firm.telephone_number %>
+    <% if @firm.telephone_number.present? %>
+      <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>
+        <%= svg_icon :phone, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
+        %><%= @firm.telephone_number %>
+      <% end %>
     <% end %>
 
-    <%= mail_to @firm.email_address, class: 'outline-button' do %>
-      <%= svg_icon :email, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
-      %><%= t('firms.show.email_firm') %>
+    <% if @firm.email_address.present? %>
+      <%= mail_to @firm.email_address, class: 'outline-button' do %>
+        <%= svg_icon :email, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
+        %><%= t('firms.show.email_firm') %>
+      <% end %>
     <% end %>
 
-    <%= link_to @firm.website_address, class: 'outline-button' do %>
-      <%= svg_icon :url, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
-      %><%= t('firms.show.website_address') %>
+    <% if @firm.website_address.present? %>
+      <%= link_to @firm.website_address, class: 'outline-button' do %>
+        <%= svg_icon :url, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
+        %><%= t('firms.show.website_address') %>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
Wrap each of the methods of contacting a firm in a conditional to only render them if there is actually data for the contact method.

e.g. Having removed the website for a firm, before this change all three contact links would appear: 

![screen shot 2015-10-13 at 15 25 02](https://cloud.githubusercontent.com/assets/32398/10457530/bbdca668-71be-11e5-9caa-f3b2d2733c1d.png)

When in reality, the user should only see two:

![screen shot 2015-10-13 at 15 24 50](https://cloud.githubusercontent.com/assets/32398/10457529/bb82f320-71be-11e5-981e-89295c6d2674.png)
