### PR TITLE
[DEV APPROVED] Remove 'Advisers' tab

### DIFF
--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -1,1 +1,0 @@
-<p>Adviser details will go here.</p>

--- a/app/views/firms/partials/_content.html.erb
+++ b/app/views/firms/partials/_content.html.erb
@@ -12,11 +12,6 @@
             <%= t('firms.show.panels.offices.heading') %>
           </a>
         </div>
-        <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
-          <a class="tab-selector__trigger" href="#panel-3" data-dough-tab-selector-trigger="3">
-            <%= t('firms.show.panels.advisers.heading') %>
-          </a>
-        </div>
       </div>
     </div>
 
@@ -27,10 +22,6 @@
     <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
       <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.office.heading') %></h2>
       <%= render partial: 'firms/partials/offices' %>
-    </div>
-    <div class="tab-selector__target is-inactive" id="panel-3" data-dough-tab-selector-target="3">
-      <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.advisers.heading') %></h2>
-      <%= render partial: 'firms/partials/advisers' %>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,8 +40,6 @@
           locations: 'Adviser & office locations'
         offices:
           heading: 'Offices'
-        advisers:
-          heading: 'Advisers'
 
   skip_links:
     to_main: Skip to main content


### PR DESCRIPTION
This PR removes a dough tab from the firm profile page. The 'Adviser' tab was in previous designs when the profile was first worked on before being shelved for a period of time. Current designs no longer include this tab.

**Before**
![screen shot 2015-10-13 at 15 55 39](https://cloud.githubusercontent.com/assets/32398/10458522/179f7d00-71c3-11e5-91a7-a10af4120e42.png)

**After**
![screen shot 2015-10-13 at 15 55 29](https://cloud.githubusercontent.com/assets/32398/10458521/176eff4a-71c3-11e5-86db-fd0eb2190a41.png)

