### PR TITLE
remove extra div, fix indentation

### DIFF
--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -3,12 +3,11 @@
 <%= firm_map_component(center: {lat: latitude, lng: longitude}) do %>
   <div class="firm__map" data-dough-map></div>
 
-    <ul class="is-hidden">
-      <% firm.advisers.each do |adviser| %>
-        <li data-dough-map-point data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
-          <%= adviser.name %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <ul class="is-hidden">
+    <% firm.advisers.each do |adviser| %>
+      <li data-dough-map-point data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
+        <%= adviser.name %>
+      </li>
+    <% end %>
+  </ul>
 <% end %>


### PR DESCRIPTION
It appears that in the eager refactoring of the profile map into a helper method (`firm_map_component`), a trailing `</div>` was left behind. This was breaking the behaviour of the dough tabs used on the page. Also fixed up the indentation while I was in here.