### PR TITLE
[DEV APPROVED] add placeholders for welsh translations / use existing page_title

### DIFF
--- a/app/views/firms/show.html.erb
+++ b/app/views/firms/show.html.erb
@@ -1,7 +1,7 @@
 <div class="l-constrained">
   <div class="l-firm">
     <div class="l-firm__main">
-      <%= heading_tag(t('firms.show.heading'), level: 1, class: 'l-firm__heading') %>
+      <%= heading_tag(t('page_title'), level: 1, class: 'l-firm__heading') %>
       <p>
         <%= link_to search_path(search_form: params[:search_form]) do %>
           <%= svg_icon 'pagination-prev', class: 'firm__back-icon'

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -23,6 +23,22 @@ cy:
       title_tag: 'Cyfeirlyfr Cynghorydd Ymddeoliad | Dod o hyd i gynghorydd ariannol a reoleiddir'
       meta_tag_description: Defnyddiwch y Cyfeirlyfr Cynghorydd Ymddeoliad i ddod o hyd i gynghorwyr ariannol a reoleiddir i helpu gyda chynllunio ymddeoliad, treth etifeddiant, rhyddhau ecwiti, ewyllysiau a phrofebion, gofal hirdymor a throsglwyddo pensiwn.
 
+  firms:
+    show:
+      title_tag: -X-
+      meta_tag_description: -X-
+      go_back: -X-
+      telephone_number: -X-
+      email_address: -X-
+      email_firm: -X-
+      website_address: -X-
+      panels:
+        firm:
+          heading: -X-
+          locations: -X-
+        offices:
+          heading: -X-
+
   skip_links:
     to_main: Skip to main content
     to_accessibility: Accessibility Statement

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,6 @@
 
   firms:
     show:
-      heading: 'Find a retirement adviser'
       title_tag: 'Retirement Adviser Directory | Find a retirement adviser'
       meta_tag_description: 'Use the Retirement Adviser Directory to find FCA regulated financial advisers for help with retirement planning, inheritance tax, equity release, wills and probate, long-term care and pension transfers.'
       go_back: 'Back to results'


### PR DESCRIPTION
This PR reuses an existing translation key for page titles, as it consistent across all the pages. I've also added missing Welsh keys for the firm profile page, as they appear to have been missed off when the profile was previously started. We've not requested translations yet, but it seemed a good idea to at least have the placeholders in the codebase so they aren't forgotten about.