### PR TITLE
[DEV APPROVED] Qualification accreditation filters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 Documentation:
   Enabled: false
+Metrics/ClassLength:
+  Max: 120
 Metrics/LineLength:
   Max: 120
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'dough-ruby',
     ref: 'cf08913'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.0.82'
+gem 'mas-rad_core', '0.0.83'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.82)
+    mas-rad_core (0.0.83)
       active_model_serializers
       geocoder
       httpclient
@@ -251,7 +251,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
-  mas-rad_core (= 0.0.82)
+  mas-rad_core (= 0.0.83)
   pg
   pry-rails
   rails (~> 4.2)

--- a/app/assets/stylesheets/components/_search_filter.scss
+++ b/app/assets/stylesheets/components/_search_filter.scss
@@ -137,6 +137,6 @@
   margin: $baseline-unit*4 0;
 }
 
-.search-filter__pension_pot {
+.search-filter__last-filter {
   margin-bottom: $baseline-unit*4;
 }

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -22,7 +22,7 @@ class SearchForm
                 :coordinates,
                 :pension_pot_size,
                 :firm_id,
-                :qualifications_and_accreditations,
+                :qualification_or_accreditation,
                 *TYPES_OF_ADVICE
 
   before_validation :upcase_postcode, if: :face_to_face?
@@ -126,7 +126,7 @@ class SearchForm
     extract_id = ->(item) { item[1..-1] }
     type_prefix = prefix_for(model)
 
-    [qualifications_and_accreditations]
+    [qualification_or_accreditation]
       .compact
       .select(&is_desired_type.curry[type_prefix])
       .map(&extract_id)

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -43,7 +43,7 @@ class SearchForm
     @coordinates ||= Geocode.call(postcode)
   end
 
-  def pension_pot_sizes
+  def options_for_pension_pot_sizes
     InvestmentSize.all.map do |investment_size|
       [investment_size.localized_name, investment_size.id]
     end << [I18n.t('search_filter.pension_pot.any_size_option'), ANY_SIZE_VALUE]

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -22,6 +22,7 @@ class SearchForm
                 :coordinates,
                 :pension_pot_size,
                 :firm_id,
+                :qualifications_and_accreditations,
                 *TYPES_OF_ADVICE
 
   before_validation :upcase_postcode, if: :face_to_face?
@@ -48,7 +49,7 @@ class SearchForm
     end << [I18n.t('search_filter.pension_pot.any_size_option'), ANY_SIZE_VALUE]
   end
 
-  def qualifications_accreditations
+  def options_for_qualifications_and_accreditations
     (options_for(Qualification) + options_for(Accreditation)).sort
   end
 

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -96,13 +96,17 @@ class SearchForm
     postcode.try(:upcase!)
   end
 
+  def filters_for(model)
+    key_to_i = -> (k, v) { [k.to_s.to_i, v] }
+    I18n.t("search.filter.#{model.model_name.i18n_key}.ordinal").map(&key_to_i).to_h
+  end
+
   def options_for(model)
-    trans_root = model.model_name.i18n_key
-    trans = I18n.t("search.filter.#{trans_root}.ordinal")
-    trans_keys = trans.keys.map(&:to_s).map(&:to_i)
+    filters = filters_for(model)
+    prefix = model.model_name.singular[0]
     model
-      .where(order: trans_keys)
+      .where(order: filters.keys)
       .pluck(:order, :id)
-      .map { |order, id| [trans[order.to_s.to_sym], "#{trans_root[0]}#{id}"] }
+      .map { |order, id| [filters[order], "#{prefix}#{id}"] }
   end
 end

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -77,6 +77,14 @@ class SearchForm
     end
   end
 
+  def selected_qualification_id
+    selected_filter_id_for(Qualification)
+  end
+
+  def selected_accreditation_id
+    selected_filter_id_for(Accreditation)
+  end
+
   def postcode
     @postcode if face_to_face?
   end
@@ -96,6 +104,10 @@ class SearchForm
     postcode.try(:upcase!)
   end
 
+  def prefix_for(model)
+    model.model_name.singular[0]
+  end
+
   def filters_for(model)
     key_to_i = -> (k, v) { [k.to_s.to_i, v] }
     I18n.t("search.filter.#{model.model_name.i18n_key}.ordinal").map(&key_to_i).to_h
@@ -103,10 +115,22 @@ class SearchForm
 
   def options_for(model)
     filters = filters_for(model)
-    prefix = model.model_name.singular[0]
     model
       .where(order: filters.keys)
       .pluck(:order, :id)
-      .map { |order, id| [filters[order], "#{prefix}#{id}"] }
+      .map { |order, id| [filters[order], "#{prefix_for(model)}#{id}"] }
+  end
+
+  def selected_filter_id_for(model)
+    is_desired_type = ->(prefix, item) { !!item[/^#{prefix}/] }
+    extract_id = ->(item) { item[1..-1] }
+    type_prefix = prefix_for(model)
+
+    [qualifications_and_accreditations]
+      .compact
+      .select(&is_desired_type.curry[type_prefix])
+      .map(&extract_id)
+      .map(&:to_i)
+      .first
   end
 end

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -48,6 +48,10 @@ class SearchForm
     end << [I18n.t('search_filter.pension_pot.any_size_option'), ANY_SIZE_VALUE]
   end
 
+  def qualifications_accreditations
+    [['Hello', '1']]
+  end
+
   def any_pension_pot_size?
     pension_pot_size && pension_pot_size == ANY_SIZE_VALUE
   end

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -49,7 +49,7 @@ class SearchForm
   end
 
   def qualifications_accreditations
-    [['Hello', '1']]
+    (options_for(Qualification) + options_for(Accreditation)).sort
   end
 
   def any_pension_pot_size?
@@ -93,5 +93,15 @@ class SearchForm
 
   def upcase_postcode
     postcode.try(:upcase!)
+  end
+
+  def options_for(model)
+    trans_root = model.model_name.i18n_key
+    trans = I18n.t("search.filter.#{trans_root}.ordinal")
+    trans_keys = trans.keys.map(&:to_s).map(&:to_i)
+    model
+      .where(order: trans_keys)
+      .pluck(:order, :id)
+      .map { |order, id| [trans[order.to_s.to_sym], "#{trans_root[0]}#{id}"] }
   end
 end

--- a/app/serializers/search_form_serializer.rb
+++ b/app/serializers/search_form_serializer.rb
@@ -36,6 +36,14 @@ class SearchFormSerializer < ActiveModel::Serializer
         filters << { in: { other_advice_methods: object.remote_advice_method_ids } }
         filters << { missing: { field: :in_person_advice_methods } }
       end
+
+      if object.selected_qualification_id.present?
+        filters << { in: { adviser_qualification_ids: [object.selected_qualification_id] } }
+      end
+
+      if object.selected_accreditation_id.present?
+        filters << { in: { adviser_accreditation_ids: [object.selected_accreditation_id] } }
+      end
     end
   end
 

--- a/app/views/search/partials/_search_filter.html.erb
+++ b/app/views/search/partials/_search_filter.html.erb
@@ -34,6 +34,11 @@
           <%= render 'search/partials/filters/pension_pots', f: f, form: @form %>
         </div>
 
+        <div class="l-results__filter search-filter__section">
+          <hr class="search-filter__divider">
+          <%= render 'search/partials/filters/qualifications_and_accreditations', f: f, form: @form  %>
+        </div>
+
         <div class="l-results__filter-button-container search-filter__section">
           <%= render 'shared/search_button', button_class: "l-results__filter-button" %>
         </div>

--- a/app/views/search/partials/filters/_pension_pots.html.erb
+++ b/app/views/search/partials/filters/_pension_pots.html.erb
@@ -10,6 +10,6 @@
 
   <div class="form__group-item">
     <%= f.label :pension_pot_size, t('search_filter.pension_pot.pension_pot_size'), class: 'form__label-heading is-hidden' %>
-    <%= f.select :pension_pot_size, form.pension_pot_sizes, { include_blank: false }, { class: 't-pension-pot-size search-filter__inset search-filter__constrained' } %>
+    <%= f.select :pension_pot_size, form.options_for_pension_pot_sizes, { include_blank: false }, { class: 't-pension-pot-size search-filter__inset search-filter__constrained' } %>
   </div>
 </fieldset>

--- a/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
+++ b/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
@@ -9,7 +9,7 @@
                 class: 'form__label-heading is-hidden' %>
     <%= f.select :qualifications_and_accreditations,
                  form.options_for_qualifications_and_accreditations,
-                 { include_blank: false },
+                 { include_blank: t('search.filter.select_prompt') },
                  { class: 't-qualifications-and-accreditations search-filter__inset search-filter__constrained' } %>
   </div>
 </fieldset>

--- a/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
+++ b/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
@@ -4,12 +4,12 @@
   </legend>
 
   <div class="form__group-item">
-    <%= f.label :qualifications_accreditations,
+    <%= f.label :qualifications_and_accreditations,
                 t('search.filter.qualifications_and_accreditations.label'),
                 class: 'form__label-heading is-hidden' %>
-    <%= f.select :qualifications_accreditations,
-                 form.qualifications_accreditations,
+    <%= f.select :qualifications_and_accreditations,
+                 form.options_for_qualifications_and_accreditations,
                  { include_blank: false },
-                 { class: 't-qualifications_and_accreditations search-filter__inset search-filter__constrained' } %>
+                 { class: 't-qualifications-and-accreditations search-filter__inset search-filter__constrained' } %>
   </div>
 </fieldset>

--- a/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
+++ b/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
@@ -1,0 +1,15 @@
+<fieldset class="search-filter__qualifications_accreditations search-filter__last-filter">
+  <legend class="search-filter__label">
+    <%= t('search.filter.qualifications_and_accreditations.heading') %>
+  </legend>
+
+  <div class="form__group-item">
+    <%= f.label :qualifications_accreditations,
+                t('search.filter.qualifications_and_accreditations.label'),
+                class: 'form__label-heading is-hidden' %>
+    <%= f.select :qualifications_accreditations,
+                 form.qualifications_accreditations,
+                 { include_blank: false },
+                 { class: 't-qualifications_and_accreditations search-filter__inset search-filter__constrained' } %>
+  </div>
+</fieldset>

--- a/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
+++ b/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
@@ -4,10 +4,10 @@
   </legend>
 
   <div class="form__group-item">
-    <%= f.label :qualifications_and_accreditations,
+    <%= f.label :qualification_or_accreditation,
                 t('search.filter.qualifications_and_accreditations.label'),
                 class: 'form__label-heading is-hidden' %>
-    <%= f.select :qualifications_and_accreditations,
+    <%= f.select :qualification_or_accreditation,
                  form.options_for_qualifications_and_accreditations,
                  { include_blank: t('search.filter.select_prompt') },
                  { class: 't-qualifications-and-accreditations search-filter__inset search-filter__constrained' } %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -245,19 +245,19 @@ cy:
         label: -X-
       qualification:
         ordinal:
-          '3': -X-
-          '4': -X-
-          '5': -X-
-          '6': -X-
-          '7': -X-
-          '8': -X-
-          '9': -X-
+          '3': Chartered Financial Planner
+          '4': Certified Financial Planner
+          '5': Pension transfers
+          '6': Equity release
+          '7': Long term care planning
+          '8': Holder of Trust and Estate Practitioner
+          '9': Fellow of the Chartered Insurance Institute
       accreditation:
         ordinal:
-          '1': -X-
-          '2': -X-
-          '3': -X-
-          '4': -X-
+          '1': SOLLA
+          '2': Later Life Academy
+          '3': ISO 22222
+          '4': British Standard in Financial Planning BS8577
       select_prompt: -X-
       button_text: Chwilio
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -243,6 +243,21 @@ cy:
       qualifications_and_accreditations:
         heading: -X-
         label: -X-
+      qualification:
+        ordinal:
+          '3': -X-
+          '4': -X-
+          '5': -X-
+          '6': -X-
+          '7': -X-
+          '8': -X-
+          '9': -X-
+      accreditation:
+        ordinal:
+          '1': -X-
+          '2': -X-
+          '3': -X-
+          '4': -X-
       button_text: Chwilio
 
     page_title: Dod o hyd i gynghorydd ymddeoliad

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -258,6 +258,7 @@ cy:
           '2': -X-
           '3': -X-
           '4': -X-
+      select_prompt: -X-
       button_text: Chwilio
 
     page_title: Dod o hyd i gynghorydd ymddeoliad

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -240,6 +240,9 @@ cy:
         - text: Fodd bynnag, yn fwyfwy y dyddiau hyn, mae yna gynghorwyr sy’n cynnig cyngor dros y ffôn neu ar-lein yn unig.  Yn aml mae gan y cynghorwyr hyn lai o gostau ac os ydych chi’n fodlon derbyn eich cyngor fel hyn, yna gallech arbed ychydig o arian.  Dewiswch yr opsiwn ‘dros y ffôn neu ar-lein yn unig’.
         - text: Neu gallwch gysylltu â chynghorwyr sy’n cynnig y ddau opsiwn i gymharu gwasanaeth a chostau.
         - text: Y peth pwysig i’w gofio yw bod pob un o’r cynghorwyr ar Gyfeirlyfr y Gwasanaeth Cynghori Ariannol – waeth sut y cynigiant gyngor – wedi eu rheoleiddio.  Mae gennych union yr un diogelwch pa un ai’ch bod yn cwrdd â rhywun wyneb yn wyneb neu’n delio ag ef neu hi’n unigol dros y ffôn neu ar-lein.
+      qualifications_and_accreditations:
+        heading: -X-
+        label: -X-
       button_text: Chwilio
 
     page_title: Dod o hyd i gynghorydd ymddeoliad

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,7 @@
           '2': Later Life Academy
           '3': ISO 22222
           '4': British Standard in Financial Planning BS8577
+      select_prompt: Please select
       button_text: Search
 
     page_title: Find a retirement adviser

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -243,6 +243,21 @@
       qualifications_and_accreditations:
         heading: Accreditations & qualifications
         label: Filter by adviser qualification or accreditation
+      qualification:
+        ordinal:
+          '3': Chartered Financial Planner
+          '4': Certified Financial Planner
+          '5': Pension transfers
+          '6': Equity release
+          '7': Long term care planning
+          '8': Holder of Trust and Estate Practitioner
+          '9': Fellow of the Chartered Insurance Institute
+      accreditation:
+        ordinal:
+          '1': SOLLA
+          '2': Later Life Academy
+          '3': ISO 22222
+          '4': British Standard in Financial Planning BS8577
       button_text: Search
 
     page_title: Find a retirement adviser

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -240,6 +240,9 @@
           - text: However, increasingly, there are advisers who offer advice by telephone or online only.  These advisers often have less overheads and if you are happy to receive advice this way, you may find it can save you money.  Choose the ‘phone or online only’ option.
           - text: Or you can contact advisers offering both options to compare service and costs.
           - text: The important thing to remember is that all the advisers on the Money Advice Service Directory – no matter how they offer advice – are fully regulated.  You have exactly the same protection whether you see someone face-to-face or deal with them exclusively by phone or online.
+      qualifications_and_accreditations:
+        heading: Accreditations & qualifications
+        label: Filter by adviser qualification or accreditation
       button_text: Search
 
     page_title: Find a retirement adviser

--- a/spec/features/results_filter_on_quals_and_accreds_spec.rb
+++ b/spec/features/results_filter_on_quals_and_accreds_spec.rb
@@ -1,0 +1,91 @@
+RSpec.feature 'Consumer filters results based on qualifications and accreditations',
+              vcr: vcr_options_for_feature(:qualifications_and_accreditations_filters_on_results_list) do
+  let(:landing_page) { LandingPage.new }
+  let(:results_page) { ResultsPage.new }
+  let(:postcode) { 'EH3 9DR' }
+
+  let(:qualifications) { FactoryGirl.create_list(:qualification, 3) }
+  let(:accreditations) { FactoryGirl.create_list(:accreditation, 3) }
+  let(:ord_to_qualification) { map_order_to_object(qualifications) }
+  let(:ord_to_accreditation) { map_order_to_object(accreditations) }
+
+  let(:firm_1) do
+    FactoryGirl.create(:firm_without_advisers) do |f|
+      create_adviser(f, postcode, qualifications: [1, 2], accreditations: [1, 2])
+    end
+  end
+  let(:firm_2) do
+    FactoryGirl.create(:firm_without_advisers) do |f|
+      create_adviser(f, postcode, qualifications: [1, 3], accreditations: [1, 3])
+    end
+  end
+  let(:firms) { [firm_1, firm_2] }
+
+  scenario 'Filtering results based on qualifications and accreditations' do
+    with_elastic_search! do
+      given_some_firms_were_indexed
+
+      when_i_am_on_the_search_results_page
+      then_i_see_all_results
+
+      when_i_filter_the_results_by(ord_to_qualification[2])
+      then_the_results_are([firm_1])
+      # then_previously_selected_filters_are_preserved_for(qualifications, accreditations)
+    end
+  end
+
+  def given_some_firms_were_indexed
+    with_fresh_index! { firms }
+  end
+
+  def when_i_am_on_the_search_results_page
+    landing_page.load
+
+    landing_page.in_person.tap do |section|
+      section.postcode.set postcode
+      section.search.click
+    end
+  end
+
+  def then_i_see_all_results
+    expect(results_page).to be_displayed
+    expect_no_errors_on(results_page)
+    expect(results_page.firms.count).to eq(firms.count)
+  end
+
+  def when_i_filter_the_results_by(qual_or_accred)
+    # XXX friendly_name or id? Or something else?
+    results_page.search_form.qualifications_and_accreditations.set(qual_or_accred.friendly_name)
+  end
+
+  def then_the_results_are(expected_results)
+    expect(results_page.firms.count).to eq(expected_results.count)
+    expected_names = expected_results.map(&:registered_name)
+    expect(results_page.firm_names).to match_array(expected_names)
+  end
+
+  # def then_previously_selected_filters_are_preserved_for(qualifications, accreditations)
+  # end
+
+  private
+
+  def expect_no_errors_on(the_page)
+    expect(the_page).not_to have_text %r{Error|[Ww]arn|[Ee]xception}
+    expect(the_page.status_code).not_to eq(500)
+  end
+
+  def map_order_to_object(collection)
+    collection.each_with_object({}) { |o, h| h[o.order] = o }
+  end
+
+  def create_adviser(firm, postcode, qualifications: [], accreditations: [])
+    create(:adviser,
+           firm: firm,
+           postcode: postcode,
+           latitude: 55.9469408,
+           longitude: -3.2017516,
+           accreditations: accreditations.map { |i| ord_to_accreditation[i] },
+           qualifications: qualifications.map { |i| ord_to_qualification[i] }
+          )
+  end
+end

--- a/spec/features/results_filter_on_quals_and_accreds_spec.rb
+++ b/spec/features/results_filter_on_quals_and_accreds_spec.rb
@@ -98,8 +98,10 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
   end
 
   def then_i_see_all_expected_filter_options
-    expect(results_page.search_form.qualifications_and_accreditations_option_names)
-      .to match_array(enabled_option_names)
+    results_page.search_form.qualifications_and_accreditations_option_names.tap do |opts|
+      expect(opts.first).to eq(I18n.t('search.filter.select_prompt'))
+      expect(opts[1..-1]).to match_array(enabled_option_names)
+    end
   end
 
   def when_i_filter_the_results_by(option)

--- a/spec/features/results_filter_on_quals_and_accreds_spec.rb
+++ b/spec/features/results_filter_on_quals_and_accreds_spec.rb
@@ -3,6 +3,7 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
   let(:postcode) { 'EH3 9DR' }
+  let(:select_prompt) { I18n.t('search.filter.select_prompt') }
 
   #
   # Create fixture records
@@ -37,9 +38,11 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
   let(:qual_a) { enabled_qualification_opts[0] }
   let(:qual_b) { enabled_qualification_opts[1] }
   let(:qual_c) { enabled_qualification_opts[2] }
+  let(:qual_d) { enabled_qualification_opts[3] }
   let(:accr_a) { enabled_accreditation_opts[0] }
   let(:accr_b) { enabled_accreditation_opts[1] }
   let(:accr_c) { enabled_accreditation_opts[2] }
+  let(:no_selection) { FilterOption.new(nil, select_prompt) }
 
   #
   # Construct the firm and adviser fixtures
@@ -66,12 +69,17 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
 
       when_i_filter_the_results_by(qual_b)
       then_the_results_are([firm_1])
-      # then_previously_selected_filters_are_preserved_for(qualifications, accreditations)
+
+      when_i_filter_the_results_by(accr_a)
+      then_the_results_are([firm_1, firm_2])
 
       when_i_filter_the_results_by(accr_c)
       then_the_results_are([firm_2])
 
-      when_i_filter_the_results_by(accr_a)
+      when_i_filter_the_results_by(qual_d)
+      then_the_results_are([])
+
+      when_i_filter_the_results_by(no_selection)
       then_the_results_are([firm_1, firm_2])
     end
   end
@@ -99,7 +107,7 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
 
   def then_i_see_all_expected_filter_options
     results_page.search_form.qualifications_and_accreditations_option_names.tap do |opts|
-      expect(opts.first).to eq(I18n.t('search.filter.select_prompt'))
+      expect(opts.first).to eq(select_prompt)
       expect(opts[1..-1]).to match_array(enabled_option_names)
     end
   end
@@ -119,9 +127,6 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
     expected_names = expected_results.map(&:registered_name)
     expect(results_page.firm_names).to match_array(expected_names)
   end
-
-  # def then_previously_selected_filters_are_preserved_for(qualifications, accreditations)
-  # end
 
   private
 

--- a/spec/features/results_filter_on_quals_and_accreds_spec.rb
+++ b/spec/features/results_filter_on_quals_and_accreds_spec.rb
@@ -4,19 +4,54 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
   let(:results_page) { ResultsPage.new }
   let(:postcode) { 'EH3 9DR' }
 
-  let(:qualifications) { FactoryGirl.create_list(:qualification, 3) }
-  let(:accreditations) { FactoryGirl.create_list(:accreditation, 3) }
+  #
+  # Create fixture records
+  #
+  # A record must exist for each option that will appear in the filter.
+  # The record name fields do not matter as the filter names are populated from
+  # the locale file.
+  # Mapping from record to enabled filter option is done via the 'order' field
+  # rather than by database id, which may vary
+  # Creating 10 of each type to ensure we definitely have more than the subset
+  # that will be enabled.
+  let(:qualifications) { FactoryGirl.create_list(:qualification, 10) }
+  let(:accreditations) { FactoryGirl.create_list(:accreditation, 10) }
+
+  #
+  # Provide a way to lookup record by a given order number
+  #
   let(:ord_to_qualification) { map_order_to_object(qualifications) }
   let(:ord_to_accreditation) { map_order_to_object(accreditations) }
 
+  #
+  # Load the real set of enabled filter options
+  #
+  let(:enabled_qualification_opts) { enabled_options_for(Qualification) }
+  let(:enabled_accreditation_opts) { enabled_options_for(Accreditation) }
+  let(:enabled_option_names) { enabled_qualification_opts.map(&:name) + enabled_accreditation_opts.map(&:name) }
+
+  #
+  # Bookmark specific filters to use in the test, so we don't have to rely on
+  # hardcoded numbers
+  #
+  let(:qual_a) { enabled_qualification_opts[0] }
+  let(:qual_b) { enabled_qualification_opts[1] }
+  let(:qual_c) { enabled_qualification_opts[2] }
+  let(:accr_a) { enabled_accreditation_opts[0] }
+  let(:accr_b) { enabled_accreditation_opts[1] }
+  let(:accr_c) { enabled_accreditation_opts[2] }
+
+  #
+  # Construct the firm and adviser fixtures
+  #
   let(:firm_1) do
     FactoryGirl.create(:firm_without_advisers) do |f|
-      create_adviser(f, postcode, qualifications: [1, 2], accreditations: [1, 2])
+      create_adviser(f, postcode, qualifications: [qual_a, qual_b], accreditations: [accr_a, accr_b])
     end
   end
   let(:firm_2) do
     FactoryGirl.create(:firm_without_advisers) do |f|
-      create_adviser(f, postcode, qualifications: [1, 3], accreditations: [1, 3])
+      create_adviser(f, postcode, qualifications: [qual_a, qual_c], accreditations: [accr_a, accr_c])
     end
   end
   let(:firms) { [firm_1, firm_2] }
@@ -27,10 +62,17 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
 
       when_i_am_on_the_search_results_page
       then_i_see_all_results
+      then_i_see_all_expected_filter_options
 
-      when_i_filter_the_results_by(ord_to_qualification[2])
+      when_i_filter_the_results_by(qual_b)
       then_the_results_are([firm_1])
       # then_previously_selected_filters_are_preserved_for(qualifications, accreditations)
+
+      when_i_filter_the_results_by(accr_c)
+      then_the_results_are([firm_2])
+
+      when_i_filter_the_results_by(accr_a)
+      then_the_results_are([firm_1, firm_2])
     end
   end
 
@@ -45,6 +87,8 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
       section.postcode.set postcode
       section.search.click
     end
+
+    results_page.wait_for_firms
   end
 
   def then_i_see_all_results
@@ -53,12 +97,22 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
     expect(results_page.firms.count).to eq(firms.count)
   end
 
-  def when_i_filter_the_results_by(qual_or_accred)
-    # XXX friendly_name or id? Or something else?
-    results_page.search_form.qualifications_and_accreditations.set(qual_or_accred.friendly_name)
+  def then_i_see_all_expected_filter_options
+    expect(results_page.search_form.qualifications_and_accreditations_option_names)
+      .to match_array(enabled_option_names)
+  end
+
+  def when_i_filter_the_results_by(option)
+    results_page.search_form.tap do |section|
+      section.qualifications_and_accreditations.select(option.name)
+      section.search.click
+    end
+
+    results_page.wait_for_firms
   end
 
   def then_the_results_are(expected_results)
+    expect_no_errors_on(results_page)
     expect(results_page.firms.count).to eq(expected_results.count)
     expected_names = expected_results.map(&:registered_name)
     expect(results_page.firm_names).to match_array(expected_names)
@@ -68,6 +122,13 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
   # end
 
   private
+
+  FilterOption = Struct.new(:order, :name)
+
+  def enabled_options_for(model)
+    to_obj = -> (k, v) { FilterOption.new(k.to_s.to_i, v) }
+    I18n.t("search.filter.#{model.model_name.i18n_key}.ordinal").map(&to_obj)
+  end
 
   def expect_no_errors_on(the_page)
     expect(the_page).not_to have_text %r{Error|[Ww]arn|[Ee]xception}
@@ -84,8 +145,8 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
            postcode: postcode,
            latitude: 55.9469408,
            longitude: -3.2017516,
-           accreditations: accreditations.map { |i| ord_to_accreditation[i] },
-           qualifications: qualifications.map { |i| ord_to_qualification[i] }
+           accreditations: accreditations.map { |opt| ord_to_accreditation[opt.order] },
+           qualifications: qualifications.map { |opt| ord_to_qualification[opt.order] }
           )
   end
 end

--- a/spec/fixtures/vcr_cassettes/qualifications_and_accreditations_filters_on_results_list.yml
+++ b/spec/fixtures/vcr_cassettes/qualifications_and_accreditations_filters_on_results_list.yml
@@ -21,9 +21,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 08 Oct 2015 15:42:15 GMT
+      - Wed, 14 Oct 2015 14:36:11 GMT
       Expires:
-      - Fri, 09 Oct 2015 15:42:15 GMT
+      - Thu, 15 Oct 2015 14:36:11 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
@@ -104,7 +104,7 @@ http_interactions:
            "status" : "OK"
         }
     http_version: 
-  recorded_at: Thu, 08 Oct 2015 15:42:15 GMT
+  recorded_at: Wed, 14 Oct 2015 14:36:11 GMT
 - request:
     method: get
     uri: http://maps.googleapis.com/maps/api/geocode/json?address=EH3%209DR,%20United%20Kingdom&language=en&sensor=false
@@ -126,9 +126,9 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 13 Oct 2015 14:48:58 GMT
+      - Wed, 14 Oct 2015 14:36:11 GMT
       Expires:
-      - Wed, 14 Oct 2015 14:48:58 GMT
+      - Thu, 15 Oct 2015 14:36:11 GMT
       Cache-Control:
       - public, max-age=86400
       Access-Control-Allow-Origin:
@@ -209,5 +209,425 @@ http_interactions:
            "status" : "OK"
         }
     http_version: 
-  recorded_at: Tue, 13 Oct 2015 14:48:58 GMT
+  recorded_at: Wed, 14 Oct 2015 14:36:11 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EH3%209DR,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 14 Oct 2015 14:36:11 GMT
+      Expires:
+      - Thu, 15 Oct 2015 14:36:11 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '483'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EH3 9DR",
+                       "short_name" : "EH3 9DR",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Edinburgh, Edinburgh, Edinburgh EH3 9DR, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 55.9473792,
+                          "lng" : -3.201227
+                       },
+                       "southwest" : {
+                          "lat" : 55.9466098,
+                          "lng" : -3.202296
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.9469408,
+                       "lng" : -3.2017516
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 55.9483434802915,
+                          "lng" : -3.200412519708498
+                       },
+                       "southwest" : {
+                          "lat" : 55.9456455197085,
+                          "lng" : -3.203110480291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJdUOMBpnHh0gRL_2RZSTUab4",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 14 Oct 2015 14:36:11 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EH3%209DR,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 14 Oct 2015 14:36:12 GMT
+      Expires:
+      - Thu, 15 Oct 2015 14:36:12 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '483'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EH3 9DR",
+                       "short_name" : "EH3 9DR",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Edinburgh, Edinburgh, Edinburgh EH3 9DR, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 55.9473792,
+                          "lng" : -3.201227
+                       },
+                       "southwest" : {
+                          "lat" : 55.9466098,
+                          "lng" : -3.202296
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.9469408,
+                       "lng" : -3.2017516
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 55.9483434802915,
+                          "lng" : -3.200412519708498
+                       },
+                       "southwest" : {
+                          "lat" : 55.9456455197085,
+                          "lng" : -3.203110480291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJdUOMBpnHh0gRL_2RZSTUab4",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 14 Oct 2015 14:36:12 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EH3%209DR,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 14 Oct 2015 14:36:12 GMT
+      Expires:
+      - Thu, 15 Oct 2015 14:36:12 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '483'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EH3 9DR",
+                       "short_name" : "EH3 9DR",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Edinburgh, Edinburgh, Edinburgh EH3 9DR, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 55.9473792,
+                          "lng" : -3.201227
+                       },
+                       "southwest" : {
+                          "lat" : 55.9466098,
+                          "lng" : -3.202296
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.9469408,
+                       "lng" : -3.2017516
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 55.9483434802915,
+                          "lng" : -3.200412519708498
+                       },
+                       "southwest" : {
+                          "lat" : 55.9456455197085,
+                          "lng" : -3.203110480291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJdUOMBpnHh0gRL_2RZSTUab4",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 14 Oct 2015 14:36:12 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EH3%209DR,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 14 Oct 2015 14:36:12 GMT
+      Expires:
+      - Thu, 15 Oct 2015 14:36:12 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '483'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EH3 9DR",
+                       "short_name" : "EH3 9DR",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Edinburgh, Edinburgh, Edinburgh EH3 9DR, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 55.9473792,
+                          "lng" : -3.201227
+                       },
+                       "southwest" : {
+                          "lat" : 55.9466098,
+                          "lng" : -3.202296
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.9469408,
+                       "lng" : -3.2017516
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 55.9483434802915,
+                          "lng" : -3.200412519708498
+                       },
+                       "southwest" : {
+                          "lat" : 55.9456455197085,
+                          "lng" : -3.203110480291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJdUOMBpnHh0gRL_2RZSTUab4",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 14 Oct 2015 14:36:12 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/qualifications_and_accreditations_filters_on_results_list.yml
+++ b/spec/fixtures/vcr_cassettes/qualifications_and_accreditations_filters_on_results_list.yml
@@ -1,0 +1,108 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EH3%209DR,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 08 Oct 2015 15:42:15 GMT
+      Expires:
+      - Fri, 09 Oct 2015 15:42:15 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '483'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EH3 9DR",
+                       "short_name" : "EH3 9DR",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Edinburgh, Edinburgh, Edinburgh EH3 9DR, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 55.9473792,
+                          "lng" : -3.201227
+                       },
+                       "southwest" : {
+                          "lat" : 55.9466098,
+                          "lng" : -3.202296
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.9469408,
+                       "lng" : -3.2017516
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 55.9483434802915,
+                          "lng" : -3.200412519708498
+                       },
+                       "southwest" : {
+                          "lat" : 55.9456455197085,
+                          "lng" : -3.203110480291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJdUOMBpnHh0gRL_2RZSTUab4",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 08 Oct 2015 15:42:15 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/qualifications_and_accreditations_filters_on_results_list.yml
+++ b/spec/fixtures/vcr_cassettes/qualifications_and_accreditations_filters_on_results_list.yml
@@ -105,4 +105,109 @@ http_interactions:
         }
     http_version: 
   recorded_at: Thu, 08 Oct 2015 15:42:15 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EH3%209DR,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 13 Oct 2015 14:48:58 GMT
+      Expires:
+      - Wed, 14 Oct 2015 14:48:58 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '483'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EH3 9DR",
+                       "short_name" : "EH3 9DR",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Edinburgh",
+                       "short_name" : "Edinburgh",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Edinburgh, Edinburgh, Edinburgh EH3 9DR, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 55.9473792,
+                          "lng" : -3.201227
+                       },
+                       "southwest" : {
+                          "lat" : 55.9466098,
+                          "lng" : -3.202296
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.9469408,
+                       "lng" : -3.2017516
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 55.9483434802915,
+                          "lng" : -3.200412519708498
+                       },
+                       "southwest" : {
+                          "lat" : 55.9456455197085,
+                          "lng" : -3.203110480291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJdUOMBpnHh0gRL_2RZSTUab4",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Tue, 13 Oct 2015 14:48:58 GMT
 recorded_with: VCR 2.9.3

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -182,6 +182,36 @@ RSpec.describe SearchForm do
     end
   end
 
+  describe '#qualifications_accreditations' do
+    let(:form) { described_class.new }
+
+    before :each do
+      Qualification.create(id: 1, order: 1, name: 'Should not be returned in the resulting options')
+      Qualification.create(id: 2, order: 3, name: 'Chartered Financial Planner')
+      Qualification.create(id: 3, order: 4, name: 'Certified Financial Planner')
+      Qualification.create(
+        id: 4, order: 5, name: 'Pension transfer qualifications - holder of G60, AF3, AwPETR®, or equivalent')
+
+      Accreditation.create(id: 4, order: 1, name: 'SOLLA')
+      Accreditation.create(id: 5, order: 2, name: 'Later Life Academy')
+      Accreditation.create(id: 6, order: 3, name: 'ISO 22222')
+    end
+
+    context 'for all qualifications and accreditations that have translation keys' do
+      it 'provides a list of alphabetically ordered options ' do
+        expected_list = [
+          ['Certified Financial Planner', 'q3'],
+          ['Chartered Financial Planner', 'q2'],
+          ['ISO 22222', 'a6'],
+          ['Later Life Academy', 'a5'],
+          ['Pension transfers', 'q4'],
+          %w(SOLLA a4) # Rubocop expects %w for this row
+        ]
+        expect(form.qualifications_accreditations).to eql(expected_list)
+      end
+    end
+  end
+
   describe '#any_pension_pot_size?' do
     subject(:any_pension_pot_size?) { form.any_pension_pot_size? }
 

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe SearchForm do
     end
   end
 
-  describe '#pension_pot_sizes' do
+  describe '#options_for_pension_pot_sizes' do
     let(:form) { described_class.new }
 
     let(:investment_sizes) { create_list(:investment_size, 3) }
@@ -172,11 +172,11 @@ RSpec.describe SearchForm do
     it 'returns the localized name and ID for each investment size' do
       tuples = investment_sizes.map { |i| [i.localized_name, i.id] }
 
-      expect(form.pension_pot_sizes).to include(*tuples)
+      expect(form.options_for_pension_pot_sizes).to include(*tuples)
     end
 
     it 'returns the any size option as the last element' do
-      expect(form.pension_pot_sizes.last).to eql([
+      expect(form.options_for_pension_pot_sizes.last).to eql([
         I18n.t('search_filter.pension_pot.any_size_option'), SearchForm::ANY_SIZE_VALUE
       ])
     end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe SearchForm do
 
     context 'when a qualification filter has been selected' do
       before do
-        allow(form).to receive(:qualifications_and_accreditations).and_return('q4')
+        allow(form).to receive(:qualification_or_accreditation).and_return('q4')
       end
 
       it { is_expected.to eql(4) }
@@ -226,7 +226,7 @@ RSpec.describe SearchForm do
 
     context 'when an accreditation filter has been selected' do
       before do
-        allow(form).to receive(:qualifications_and_accreditations).and_return('a4')
+        allow(form).to receive(:qualification_or_accreditation).and_return('a4')
       end
 
       it { is_expected.to be_nil }
@@ -234,7 +234,7 @@ RSpec.describe SearchForm do
 
     context 'when the blank filter has been selected' do
       before do
-        allow(form).to receive(:qualifications_and_accreditations).and_return('')
+        allow(form).to receive(:qualification_or_accreditation).and_return('')
       end
 
       it { is_expected.to be_nil }
@@ -242,7 +242,7 @@ RSpec.describe SearchForm do
 
     context 'when the filter is not set' do
       before do
-        allow(form).to receive(:qualifications_and_accreditations).and_return(nil)
+        allow(form).to receive(:qualification_or_accreditation).and_return(nil)
       end
 
       it { is_expected.to be_nil }
@@ -255,7 +255,7 @@ RSpec.describe SearchForm do
 
     context 'when an accreditation filter has been selected' do
       before do
-        allow(form).to receive(:qualifications_and_accreditations).and_return('a4')
+        allow(form).to receive(:qualification_or_accreditation).and_return('a4')
       end
 
       it { is_expected.to eql(4) }
@@ -263,7 +263,7 @@ RSpec.describe SearchForm do
 
     context 'when a qualification filter has been selected' do
       before do
-        allow(form).to receive(:qualifications_and_accreditations).and_return('q4')
+        allow(form).to receive(:qualification_or_accreditation).and_return('q4')
       end
 
       it { is_expected.to be_nil }
@@ -271,7 +271,7 @@ RSpec.describe SearchForm do
 
     context 'when the blank filter has been selected' do
       before do
-        allow(form).to receive(:qualifications_and_accreditations).and_return('')
+        allow(form).to receive(:qualification_or_accreditation).and_return('')
       end
 
       it { is_expected.to be_nil }
@@ -279,7 +279,7 @@ RSpec.describe SearchForm do
 
     context 'when the filter is not set' do
       before do
-        allow(form).to receive(:qualifications_and_accreditations).and_return(nil)
+        allow(form).to receive(:qualification_or_accreditation).and_return(nil)
       end
 
       it { is_expected.to be_nil }

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe SearchForm do
     end
   end
 
-  describe '#qualifications_accreditations' do
+  describe '#options_for_qualifications_and_accreditations' do
     let(:form) { described_class.new }
 
     before :each do
@@ -207,7 +207,7 @@ RSpec.describe SearchForm do
           ['Pension transfers', 'q4'],
           %w(SOLLA a4) # Rubocop expects %w for this row
         ]
-        expect(form.qualifications_accreditations).to eql(expected_list)
+        expect(form.options_for_qualifications_and_accreditations).to eql(expected_list)
       end
     end
   end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -232,7 +232,15 @@ RSpec.describe SearchForm do
       it { is_expected.to be_nil }
     end
 
-    context 'when no filter has been selected' do
+    context 'when the blank filter has been selected' do
+      before do
+        allow(form).to receive(:qualifications_and_accreditations).and_return('')
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the filter is not set' do
       before do
         allow(form).to receive(:qualifications_and_accreditations).and_return(nil)
       end
@@ -261,7 +269,15 @@ RSpec.describe SearchForm do
       it { is_expected.to be_nil }
     end
 
-    context 'when no filter has been selected' do
+    context 'when the blank filter has been selected' do
+      before do
+        allow(form).to receive(:qualifications_and_accreditations).and_return('')
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the filter is not set' do
       before do
         allow(form).to receive(:qualifications_and_accreditations).and_return(nil)
       end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -212,6 +212,64 @@ RSpec.describe SearchForm do
     end
   end
 
+  describe '#selected_qualification_id' do
+    let(:form) { described_class.new }
+    subject { form.selected_qualification_id }
+
+    context 'when a qualification filter has been selected' do
+      before do
+        allow(form).to receive(:qualifications_and_accreditations).and_return('q4')
+      end
+
+      it { is_expected.to eql(4) }
+    end
+
+    context 'when an accreditation filter has been selected' do
+      before do
+        allow(form).to receive(:qualifications_and_accreditations).and_return('a4')
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when no filter has been selected' do
+      before do
+        allow(form).to receive(:qualifications_and_accreditations).and_return(nil)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#selected_accreditation_id' do
+    let(:form) { described_class.new }
+    subject { form.selected_accreditation_id }
+
+    context 'when an accreditation filter has been selected' do
+      before do
+        allow(form).to receive(:qualifications_and_accreditations).and_return('a4')
+      end
+
+      it { is_expected.to eql(4) }
+    end
+
+    context 'when a qualification filter has been selected' do
+      before do
+        allow(form).to receive(:qualifications_and_accreditations).and_return('q4')
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when no filter has been selected' do
+      before do
+        allow(form).to receive(:qualifications_and_accreditations).and_return(nil)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe '#any_pension_pot_size?' do
     subject(:any_pension_pot_size?) { form.any_pension_pot_size? }
 

--- a/spec/support/search_form_section.rb
+++ b/spec/support/search_form_section.rb
@@ -15,4 +15,8 @@ class SearchFormSection < SitePrism::Section
   element :inheritance_tax_planning, '.t-inheritance_tax_planning'
   element :wills_and_probate, '.t-wills_and_probate'
   element :qualifications_and_accreditations, '.t-qualifications-and-accreditations'
+
+  def qualifications_and_accreditations_option_names
+    qualifications_and_accreditations.all('option').map(&:text)
+  end
 end

--- a/spec/support/search_form_section.rb
+++ b/spec/support/search_form_section.rb
@@ -14,4 +14,5 @@ class SearchFormSection < SitePrism::Section
   element :equity_release, '.t-equity_release'
   element :inheritance_tax_planning, '.t-inheritance_tax_planning'
   element :wills_and_probate, '.t-wills_and_probate'
+  element :qualifications_and_accreditations, '.t-qualifications-and-accreditations'
 end


### PR DESCRIPTION
## Summary

Adds in a results page filter to reduce results based on which qualifications a firm's advisers have.

It is expected that the primary users of this will be more specialist such as the Citizens Advice Bureau making a search for a member of the public. They will be more informed about what the qualifications mean.

## Notes

* Qualifications and accreditations are configured in two separate database tables. But here we need to merge and present the combined set in one select list.
* `Accreditation#order` and `Qualification#order` are pre-existing fields intended to be consistent/static ids that can be used to refer to specific records regardless of what Postgres id has been assigned.
* Several classes are near to or over the 100 line max class length limit imposed in Rubocop by default. Here I have raised it temporarily to 120. We have a plan to fix this, but it's out of scope for this PR and doesn't *need* to be addressed for this week's release.

## Screenies

![screen shot 2015-10-15 at 13 38 26](https://cloud.githubusercontent.com/assets/306583/10513858/525aa30e-7342-11e5-8588-22b16c242689.png)

---

![screen shot 2015-10-15 at 13 38 38](https://cloud.githubusercontent.com/assets/306583/10513860/567109ec-7342-11e5-91df-f863140edbfb.png)

## Welsh

Welsh has been requested and will be added independently.