### PR TITLE
Types of advice

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'dough-ruby',
     ref: 'cf08913'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.0.84'
+gem 'mas-rad_core', '0.0.85'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.84)
+    mas-rad_core (0.0.85)
       active_model_serializers
       geocoder
       httpclient
@@ -251,7 +251,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
-  mas-rad_core (= 0.0.84)
+  mas-rad_core (= 0.0.85)
   pg
   pry-rails
   rails (~> 4.2)

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -34,6 +34,7 @@
 @import 'components/pagination';
 @import 'components/result';
 @import 'components/search_filter';
+@import 'components/types_of_advice';
 @import 'components/video';
 
 @import 'print';

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -51,4 +51,6 @@ $search-filter-icon-color: $color-white;
 $search-filter-padding: $baseline-unit*4;
 $search-filter-label-color: $color-black;
 
+$types-of-advice-text-color: $color-black;
+
 $color-link-blue: $color-blue-medium;

--- a/app/assets/stylesheets/components/_types_of_advice.scss
+++ b/app/assets/stylesheets/components/_types_of_advice.scss
@@ -1,0 +1,12 @@
+.types-of-advice__list {
+  list-style: none;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.types-of-advice__list-item{
+  margin-bottom: 0;
+  color: $types-of-advice-text-color;
+}

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -1,0 +1,8 @@
+module FirmHelper
+  def type_of_advice_list_item(firm, type)
+    return unless firm.includes_advice_type? type
+    content_tag :li,
+                I18n.t("firms.show.panels.firm.services.types_of_advice.#{type}"),
+                class: 'types-of-advice__list-item'
+  end
+end

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -16,6 +16,16 @@
 
 <%= heading_tag(t('firms.show.panels.firm.services.heading'), level: 3, class: 'l-firm__heading') %>
 
+<%= heading_tag(t('firms.show.panels.firm.services.types_of_advice.heading'), level: 4) %>
+
+<ul class="types-of-advice__list">
+  <%= type_of_advice_list_item firm, :retirement_income_products %>
+  <%= type_of_advice_list_item firm, :options_when_paying_for_care %>
+  <%= type_of_advice_list_item firm, :equity_release %>
+  <%= type_of_advice_list_item firm, :inheritance_tax_planning %>
+  <%= type_of_advice_list_item firm, :wills_and_probate %>
+</ul>
+
 <%= heading_tag(t('firms.show.panels.firm.services.advice_methods.heading'), level: 4) %>
 
 <% if firm.in_person_advice_methods.present? %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -43,6 +43,13 @@ cy:
               in_person: Yn bersonol
               phone: Dros y ffôn
               online: Trwy gynhadledd fideo
+            types_of_advice:
+              heading: Mathau o gyngor a gynigir
+              retirement_income_products: Cynilion a buddsoddiadau cronfeydd pensiwn
+              options_when_paying_for_care: Dewisiadau wrth dalu am ofal
+              equity_release: Rhyddhau Ecwiti
+              inheritance_tax_planning: Cynllunio ar gyfer treth etifeddiant
+              wills_and_probate: Ewyllysiau a phrofiant
         offices:
           heading: Swyddfeydd
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,13 @@
               in_person: In person
               phone: By telephone
               online: By video conferencing
+            types_of_advice:
+              heading: Types of advice offered
+              retirement_income_products: Pension pot savings & investments
+              options_when_paying_for_care: Options when paying for care
+              equity_release: Equity release
+              inheritance_tax_planning: Inheritance tax planning
+              wills_and_probate: Wills & probate
         offices:
           heading: 'Offices'
 

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe FirmHelper, type: :helper do
+  let(:firm) { double }
+
+  subject { helper.type_of_advice_list_item(firm, :equity_release) }
+
+  describe 'type_of_advice_list_item' do
+    context 'it does not have the advice type' do
+      before do
+        allow(firm).to receive(:includes_advice_type?).and_return(false)
+      end
+
+      it 'returns nil' do
+        expect(subject).to eq(nil)
+      end
+    end
+
+    context 'has the advice type' do
+      before do
+        allow(firm).to receive(:includes_advice_type?).and_return(true)
+      end
+
+      it 'returns a list item element containing the corresponding translation' do
+        expect(subject).to eq('<li class="types-of-advice__list-item">Equity release</li>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the 'Types of advice offered' section to the firm profile.

![screen shot 2015-10-19 at 10 27 20](https://cloud.githubusercontent.com/assets/32398/10574182/54ccc448-764c-11e5-9496-ee42c3568d18.png)
