### PR TITLE
Don't render the dividing line when there are no logos

### DIFF
--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -97,16 +97,16 @@
   </div>
 </div>
 
-<div class="l-firm__row">
-  <div class="l-1col firm__divider">
-    <% if firm_has_qualifications_or_accreditations?(firm) %>
-      <%= heading_tag(t('firms.show.panels.firm.services.qualifications.heading'), level: 4) %>
-      <% firm.adviser_qualification_ids.each do |id| %>
-        <%= render_logo(id, :qualification) %>
-      <% end %>
-      <% firm.adviser_accreditation_ids.each do |id| %>
-        <%= render_logo(id, :accreditation) %>
-      <% end %>
-    <% end %>
+<% if firm_has_qualifications_or_accreditations?(firm) %>
+  <div class="l-firm__row">
+    <div class="l-1col firm__divider">
+        <%= heading_tag(t('firms.show.panels.firm.services.qualifications.heading'), level: 4) %>
+        <% firm.adviser_qualification_ids.each do |id| %>
+          <%= render_logo(id, :qualification) %>
+        <% end %>
+        <% firm.adviser_accreditation_ids.each do |id| %>
+          <%= render_logo(id, :accreditation) %>
+        <% end %>
+    </div>
   </div>
-</div>
+<% end %>


### PR DESCRIPTION
<img width="798" alt="screen shot 2015-10-23 at 11 34 17" src="https://cloud.githubusercontent.com/assets/306583/10690570/bba80d9a-797a-11e5-9665-8b200c29ddcf.png">
<img width="806" alt="screen shot 2015-10-23 at 11 35 03" src="https://cloud.githubusercontent.com/assets/306583/10690571/bba85bf6-797a-11e5-8bd5-5e633dfbad91.png">
<img width="810" alt="screen shot 2015-10-23 at 11 34 49" src="https://cloud.githubusercontent.com/assets/306583/10690572/bba874ba-797a-11e5-9b50-e2c5a51a403e.png">