### PR TITLE
don't display a title for the map markers

### DIFF
--- a/app/assets/javascripts/modules/FirmMap.js
+++ b/app/assets/javascripts/modules/FirmMap.js
@@ -135,8 +135,7 @@ define(['jquery', 'DoughBaseComponent'],
         lat: $element.data('dough-map-point-lat'),
         lng: $element.data('dough-map-point-lng')
       },
-      icon: { url: this.config.adviserPinUrl },
-      title: $element.text()
+      icon: { url: this.config.adviserPinUrl }
     };
   };
 


### PR DESCRIPTION
Small PR to remove the title from appearing when hovering over an adviser pin (see image for example of old behaviour)

![screen shot 2015-10-28 at 10 11 01](https://cloud.githubusercontent.com/assets/32398/10785463/39d8b662-7d5c-11e5-8a42-04bc95d6a35e.png)
