### PR TITLE
add rsvp to requirejs config

### DIFF
--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -7,6 +7,7 @@
 
 //= depend_on_asset jqueryThrottleDebounce/jquery.ba-throttle-debounce
 //= depend_on_asset eventsWithPromises/src/eventsWithPromises
+//= depend_on_asset rsvp/rsvp
 //= depend_on_asset dough/assets/js/lib/featureDetect
 //= depend_on_asset dough/assets/js/lib/utilities
 //= depend_on_asset dough/assets/js/lib/mediaQueries
@@ -38,7 +39,8 @@
       DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),
       TabSelector: requirejs_path('dough/assets/js/components/TabSelector'),
       FirmMap: requirejs_path('modules/FirmMap'),
-      async: requirejs_path('requirejs-plugins/src/async')
+      async: requirejs_path('requirejs-plugins/src/async'),
+      rsvp: requirejs_path('rsvp/rsvp')
     }
   }
 %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,6 +15,7 @@ Rails.application.configure do
 
   # Application JavaScript
   config.assets.precompile += %w(
+    rsvp/rsvp.js
     modules/FurtherInfo.js
     modules/SearchFilter.js
     modules/NestedOptions.js
@@ -32,6 +33,7 @@ Rails.application.configure do
     jquery-ujs/src/rails.js
     jqueryThrottleDebounce/jquery.ba-throttle-debounce.js
     eventsWithPromises/src/eventsWithPromises.js
+    rsvp/rsvp.amd.js
     requirejs/require.js
     requirejs-plugins/src/async.js
   )


### PR DESCRIPTION
In development this isn't a visible issue, but deploying to staging. RSVP isn't available, which in turn causes a JavaScript error as DoughBaseComponent has a dependency on it. This change ensures that it is available in non development ENVs