### PR TITLE
Updating english tooltip text on firm profile page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,7 +46,7 @@
               tooltip: Not all financial advisers provide advice for all levels of pension pots, savings or investments.  This tells you the minimum level of pension pot/savings/investments  you must have in order to deal with this firm.
             free_initial_meeting:
               heading: Free initial meeting
-              tooltip: This firm will offer an initial meeting at their own expense and will use this meeting to establish your needs and see if they can help you.
+              tooltip: This firm will offer an initial meeting at their own expense. The firm will use this meeting to establish your needs and see if they can help you.
           services:
             heading: Firm's services
             advice_methods:


### PR DESCRIPTION
This PR is in place to allow us to preview the new tooltip to the business on a demo server.
Once they are happy with the text in-situ on the page we'll request and add the welsh translations.