### PR TITLE
ensure the pins will be displayed

### DIFF
--- a/app/assets/javascripts/modules/FirmMap.js
+++ b/app/assets/javascripts/modules/FirmMap.js
@@ -15,8 +15,8 @@ define(['jquery', 'DoughBaseComponent'],
       defaultConfig = {
         zoomLevel: 11,
         center: {lat: 0, lng: 0},
-        adviserPinUrl: '/assets/pins/adviser.png',
-        officePinUrl: '/assets/pins/office.png'
+        adviserPinUrl: null,
+        officePinUrl: null
       };
 
   /**

--- a/app/assets/javascripts/modules/FirmMap.js
+++ b/app/assets/javascripts/modules/FirmMap.js
@@ -57,7 +57,7 @@ define(['jquery', 'DoughBaseComponent'],
    */
   FirmMapProto.initializeGoogleMaps = function() {
     var $map = this._getMapElement();
-    require(['async!http://maps.google.com/maps/api/js?key=' + this.config.apiKey],
+    require(['async!//maps.google.com/maps/api/js?key=' + this.config.apiKey],
             $.proxy(this.setupMap, this));
   };
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,12 +17,14 @@ module ApplicationHelper
     end
   end
 
-  def firm_map_component(center:)
+  def firm_map_component(center:, adviserPinUrl:, officePinUrl:)
     options = {
       'data-dough-component': 'FirmMap',
       'data-dough-firm-map-config': {
         apiKey: ENV['GOOGLE_MAPS_API_KEY'],
-        center: center
+        center: center,
+        adviserPinUrl: adviserPinUrl,
+        officePinUrl: officePinUrl
       }.to_json
     }
     content_tag :div, options do

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -1,7 +1,9 @@
 <% if search_form.face_to_face? %>
   <%= heading_tag(t('firms.show.panels.firm.locations'), level: 3, class: 'l-firm__heading') %>
 
-  <%= firm_map_component(center: {lat: latitude, lng: longitude}) do %>
+  <%= firm_map_component(center: {lat: latitude, lng: longitude},
+        adviserPinUrl: image_path('pins/adviser.png'),
+        officePinUrl: image_path('pins/office.png')) do %>
     <div class="firm__map" data-dough-map></div>
 
     <ul class="is-hidden">


### PR DESCRIPTION
Another map/pin related PR... This wasn't picked on before as we never had the profile deployed to the demo server. The pin marker images are held within `app/assets`, so we need to use `image_path` to ensure we have the assets available.