### PR TITLE
[DEV APPROVED] Profile 'Website' button should open link in a new window

### DIFF
--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -18,7 +18,7 @@
     <% end %>
 
     <% if @firm.website_address.present? %>
-      <%= link_to @firm.website_address, class: 'outline-button' do %>
+      <%= link_to @firm.website_address, class: 'outline-button', target: '_blank' do %>
         <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
         %><%= t('firms.show.website_address') %>
       <% end %>


### PR DESCRIPTION
Pressing this button ...

![screen shot 2015-10-29 at 15 26 37](https://cloud.githubusercontent.com/assets/306583/10823062/c5d58afa-7e51-11e5-9c1c-b43b6c0a905f.png)

... will now open the page in a new tab/window as indicated by the contained icon.