### PR TITLE
On the profile page when the firm has a minimum pot size of 'Under £50k' display the text 'No minimum pot size'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'dough-ruby',
     ref: 'cf08913'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.0.87'
+gem 'mas-rad_core', '0.0.88'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.87)
+    mas-rad_core (0.0.88)
       active_model_serializers
       geocoder
       httpclient
@@ -251,7 +251,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
-  mas-rad_core (= 0.0.87)
+  mas-rad_core (= 0.0.88)
   pg
   pry-rails
   rails (~> 4.2)

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -9,4 +9,11 @@ module FirmHelper
   def closest_adviser_text(firm_result)
     I18n.t('search.result.miles_away', distance: format('%.1f', firm_result.closest_adviser.to_f))
   end
+
+  def minimum_pot_size_text(firm_result)
+    record = InvestmentSize.find(firm_result.investment_sizes.first)
+
+    return I18n.t('investment_size.no_minimum') if record.lowest?
+    record.friendly_name
+  end
 end

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -83,7 +83,7 @@
           <p class="is-hidden further-info__content" data-further-info-target>
             <%= t('firms.show.panels.firm.callout.minimum_pot_size.tooltip') %>
           </p>
-          <%= InvestmentSize.find(firm.investment_sizes.first).friendly_name %>
+          <%= minimum_pot_size_text(firm) %>
         </div>
       <% end %>
       <% if firm.free_initial_meeting? %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -356,6 +356,7 @@ cy:
       "2": Ar-lein
 
   investment_size:
+    no_minimum: Dim isafswm ym maint y gronfa
     ordinal:
       '1': 'O dan £50,000'
       '2': '£50,000'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -356,6 +356,7 @@
       "2": Online
 
   investment_size:
+    no_minimum: xxx
     ordinal:
       '1': 'Under £50,000'
       '2': '£50,000'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -356,7 +356,7 @@
       "2": Online
 
   investment_size:
-    no_minimum: xxx
+    no_minimum: No minimum pot size
     ordinal:
       '1': 'Under £50,000'
       '2': '£50,000'

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -54,4 +54,31 @@ RSpec.describe FirmHelper, type: :helper do
       it { is_expected.to eq('2.0 miles away') }
     end
   end
+
+  describe 'minimum_pot_size_text' do
+    let(:available_ordinals) { I18n.t('investment_size.ordinal').keys.map(&:to_s).map(&:to_i) }
+    let(:lowest_size) { InvestmentSize.lowest }
+    let(:other_size) { InvestmentSize.last }
+    let(:expected_friendly_name) { I18n.t("investment_size.ordinal.#{other_size.order}") }
+    subject { helper.minimum_pot_size_text(firm) }
+
+    before do
+      available_ordinals.each do |ordinal|
+        FactoryGirl.create(:investment_size, order: ordinal)
+      end
+      allow(firm).to receive(:investment_sizes).and_return(firm_investment_sizes.map(&:id))
+    end
+
+    context 'when the minimum size is not `Under £50k`' do
+      let(:firm_investment_sizes) { [other_size] }
+
+      it { is_expected.to eq(expected_friendly_name) }
+    end
+
+    context 'when the minimum size is `Under £50k`' do
+      let(:firm_investment_sizes) { [lowest_size, other_size] }
+
+      it { is_expected.to eq(I18n.t('investment_size.no_minimum')) }
+    end
+  end
 end

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe FirmHelper, type: :helper do
   describe 'minimum_pot_size_text' do
     let(:available_ordinals) { I18n.t('investment_size.ordinal').keys.map(&:to_s).map(&:to_i) }
     let(:lowest_size) { InvestmentSize.lowest }
-    let(:other_size) { InvestmentSize.last }
+    let(:other_size) { InvestmentSize.where.not(order: lowest_size.order).first }
     let(:expected_friendly_name) { I18n.t("investment_size.ordinal.#{other_size.order}") }
     subject { helper.minimum_pot_size_text(firm) }
 


### PR DESCRIPTION
When the smallest pot size considered by a firm is 'Under £50k' it now shows:

![screen shot 2015-10-30 at 12 22 23](https://cloud.githubusercontent.com/assets/306583/10845618/28ee75b6-7f01-11e5-8283-ec1c02b1dae2.png)

otherwise it shows the value
![screen shot 2015-10-30 at 12 22 38](https://cloud.githubusercontent.com/assets/306583/10845625/36422bd6-7f01-11e5-9f10-7a60c3619b66.png)