### PR TITLE
Mixed bag of UI changes post-demo

### DIFF
--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -45,7 +45,18 @@
 }
 
 .firm__links {
+  @extend .unstyled-list;
   margin: $baseline-unit 0;
+
+  li:last-child {
+    margin-bottom: 0;
+  }
+
+  @include respond-to($mq-s) {
+    li {
+      display: inline;
+    }
+  }
 }
 
 .firm__back-icon {

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -1,6 +1,8 @@
 <div class="firm__header">
   <%= heading_tag(@firm.name, level: 2, class: 'firm__name') %>
-  <%= render partial: 'search/partials/firm/adviser_distance', object: @firm, as: :firm, locals: { search_form: search_form }%>
+  <% if search_form.face_to_face? %>
+    <%= render partial: 'search/partials/firm/adviser_distance', object: @firm, as: :firm, locals: { search_form: search_form }%>
+  <% end %>
 
   <div class="firm__links">
     <% if @firm.telephone_number.present? %>

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -4,26 +4,32 @@
     <%= render partial: 'search/partials/firm/adviser_distance', object: @firm, as: :firm, locals: { search_form: search_form }%>
   <% end %>
 
-  <div class="firm__links">
+  <ul class="firm__links">
     <% if @firm.telephone_number.present? %>
-      <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>
-        <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
-        %><%= @firm.telephone_number %>
-      <% end %>
+      <li>
+        <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>
+          <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
+          %><%= @firm.telephone_number %>
+        <% end %>
+      </li>
     <% end %>
 
     <% if @firm.email_address.present? %>
-      <%= mail_to @firm.email_address, class: 'outline-button' do %>
-        <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
-        %><%= t('firms.show.email_firm') %>
-      <% end %>
+      <li>
+        <%= mail_to @firm.email_address, class: 'outline-button' do %>
+          <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
+          %><%= t('firms.show.email_firm') %>
+        <% end %>
+      </li>
     <% end %>
 
     <% if @firm.website_address.present? %>
-      <%= link_to @firm.website_address, class: 'outline-button', target: '_blank' do %>
-        <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
-        %><%= t('firms.show.website_address') %>
-      <% end %>
+      <li>
+        <%= link_to @firm.website_address, class: 'outline-button', target: '_blank' do %>
+          <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
+          %><%= t('firms.show.website_address') %>
+        <% end %>
+      </li>
     <% end %>
-  </div>
+  </ul>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -309,7 +309,7 @@ cy:
     back_to_top: "Ewch i'r brig"
     no_results_message: Nid oes canlyniadau sy’n cyfateb â meini prawf eich chwiliad. Newidiwch eich meini prawf a rhoi cynnig arall arni.
     summary_of_results:
-      showing: "Yn dangos %{first_record}-%{last_record} o %{total_records} gynghorwyr mwyaf lleol"
+      showing: "Yn dangos %{first_record}-%{last_record} o %{total_records} gynghorwyr"
 
     result:
       adviser: mae gan gynghorydd

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -309,7 +309,7 @@ cy:
     back_to_top: "Ewch i'r brig"
     no_results_message: Nid oes canlyniadau sy’n cyfateb â meini prawf eich chwiliad. Newidiwch eich meini prawf a rhoi cynnig arall arni.
     summary_of_results:
-      showing: "Yn dangos %{first_record}-%{last_record} o %{total_records} gynghorwyr"
+      showing: "Yn dangos %{first_record}-%{last_record} o %{total_records} cwmnïau"
 
     result:
       adviser: mae gan gynghorydd

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,7 +309,7 @@ en:
     back_to_top: Go to top
     no_results_message: There are no results matching your search criteria. Please amend your criteria and try again.
     summary_of_results:
-      showing: "Showing %{first_record}-%{last_record} of %{total_records} advisers"
+      showing: "Showing %{first_record}-%{last_record} of %{total_records} firms"
 
     result:
       adviser: has an adviser

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,7 +309,7 @@ en:
     back_to_top: Go to top
     no_results_message: There are no results matching your search criteria. Please amend your criteria and try again.
     summary_of_results:
-      showing: "Showing %{first_record}-%{last_record} of %{total_records} nearest advisers"
+      showing: "Showing %{first_record}-%{last_record} of %{total_records} advisers"
 
     result:
       adviser: has an adviser

--- a/spec/support/results_page.rb
+++ b/spec/support/results_page.rb
@@ -20,7 +20,7 @@ class ResultsPage < SitePrism::Page
   end
 
   def showing_firms?(first, to:, of:)
-    summary.text == "Showing #{first}-#{to} of #{of} nearest advisers"
+    summary.text == "Showing #{first}-#{to} of #{of} advisers"
   end
 
   def firm_names

--- a/spec/support/results_page.rb
+++ b/spec/support/results_page.rb
@@ -20,7 +20,7 @@ class ResultsPage < SitePrism::Page
   end
 
   def showing_firms?(first, to:, of:)
-    summary.text == "Showing #{first}-#{to} of #{of} advisers"
+    summary.text == "Showing #{first}-#{to} of #{of} firms"
   end
 
   def firm_names


### PR DESCRIPTION
Hi. Sorry this is a mixed set of things that we needed to change after our Friday demo that we need done for our release today. Have tried to make it easier with screen shots.

## Remove "nearest" from results header text
![screen shot 2015-11-02 at 10 30 17](https://cloud.githubusercontent.com/assets/306583/10879623/f80f3086-814c-11e5-90bf-2e5256a84f6a.png)
![screen shot 2015-11-02 at 10 30 39](https://cloud.githubusercontent.com/assets/306583/10879630/003ebaba-814d-11e5-9487-ff1264f1746f.png)

## Should say firms and not advisers

![screen shot 2015-11-02 at 10 33 19](https://cloud.githubusercontent.com/assets/306583/10879677/5153f988-814d-11e5-9be8-92fe040add1c.png)
![screen shot 2015-11-02 at 10 33 31](https://cloud.githubusercontent.com/assets/306583/10879676/5151cdd4-814d-11e5-8c0b-baf1de895f10.png)

## Don't show adviser distance on profile page for remote firms

![screen shot 2015-11-02 at 10 35 41](https://cloud.githubusercontent.com/assets/306583/10879730/bbbe20aa-814d-11e5-93ad-279c099b82c5.png)
![screen shot 2015-11-02 at 10 36 13](https://cloud.githubusercontent.com/assets/306583/10879729/bbbb062c-814d-11e5-8df6-becf6ee8ac4f.png)

## Ensure the profile header buttons wrap nicely on mobile

![screen shot 2015-11-02 at 10 38 44](https://cloud.githubusercontent.com/assets/306583/10879821/56a5926a-814e-11e5-9f91-55e00c242289.png)
![screen shot 2015-11-02 at 10 39 06](https://cloud.githubusercontent.com/assets/306583/10879822/56a87660-814e-11e5-8d18-e6ce88a3131f.png)
