### PR TITLE
[DEV APPROVED] reduce whitespace to match spacing further up

### DIFF
--- a/app/assets/stylesheets/components/_callout.scss
+++ b/app/assets/stylesheets/components/_callout.scss
@@ -1,3 +1,7 @@
+.callout--top-collapse{
+  margin-top: 0;
+}
+
 .callout .further-info__content {
   @include body(14, 18);
 }

--- a/app/assets/stylesheets/components/_types_of_advice.scss
+++ b/app/assets/stylesheets/components/_types_of_advice.scss
@@ -1,3 +1,8 @@
+.types-of-advice__heading {
+  @include body(16, 16);
+  margin-top: 0;
+}
+
 .types-of-advice__list {
   list-style: none;
   margin-top: 0;

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -19,7 +19,7 @@
 <%= heading_tag(t('firms.show.panels.firm.services.heading'), level: 3, class: 'l-firm__heading') %>
 <div class="l-2col l-firm__row">
   <div class="l-2col-even">
-    <%= heading_tag(t('firms.show.panels.firm.services.types_of_advice.heading'), level: 4) %>
+    <%= heading_tag(t('firms.show.panels.firm.services.types_of_advice.heading'), level: 4, class: 'types-of-advice__heading') %>
 
     <ul class="types-of-advice__list" >
       <%= type_of_advice_list_item firm, :retirement_income_products %>
@@ -61,7 +61,7 @@
   </div>
 
   <div class="l-2col-even l-firm__callout">
-    <div class="callout">
+    <div class="callout callout--top-collapse">
       <% if firm.minimum_fixed_fee.present? %>
         <div class="callout__item" data-further-info>
           <h4 class="callout__heading">


### PR DESCRIPTION
Reduces the whitespace between "Firm's services" and "Types of advice offered" to match the whitespace between the top heading and the map.

**before**
![screenshot 2015-11-02 11 41 09](https://cloud.githubusercontent.com/assets/32398/10880991/5d76ecb6-8157-11e5-80bd-d346ec4a2683.png)

**after**
![screenshot 2015-11-02 11 40 49](https://cloud.githubusercontent.com/assets/32398/10881020/81577f7e-8157-11e5-8bfe-c09e3305629a.png)
