### PR TITLE
[DEV APPROVED] adjust whitespace/padding around profile heading

### DIFF
--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -12,6 +12,11 @@
   color: $color-black;
 }
 
+.firm__back-link {
+  display: block;
+  margin-bottom: $baseline-unit*2;
+}
+
 .firm__adviser-distance {
   margin-left: -2px;
   margin-bottom: $baseline-unit*1;

--- a/app/assets/stylesheets/layouts/_firm.scss
+++ b/app/assets/stylesheets/layouts/_firm.scss
@@ -16,6 +16,11 @@
   }
 }
 
+.l-firm__profile-heading {
+  margin-top: $baseline-unit*4;
+  margin-bottom: 0;
+}
+
 .l-firm__heading--collapse {
   margin-top: -($baseline-unit);
 }

--- a/app/views/firms/show.html.erb
+++ b/app/views/firms/show.html.erb
@@ -1,13 +1,13 @@
 <div class="l-constrained">
   <div class="l-firm">
     <div class="l-1col">
-      <%= heading_tag(t('page_title'), level: 1, class: 'l-firm__heading') %>
-      <p>
+      <%= heading_tag(t('page_title'), level: 1, class: 'l-firm__profile-heading') %>
+      <span class="firm__back-link">
         <%= link_to search_path(search_form: params[:search_form]) do %>
           <%= svg_icon 'pagination-prev', class: 'firm__back-icon'
           %><%= t('firms.show.go_back') %>
         <% end %>
-      </p>
+      </span>
     </div>
 
     <div class="l-firm__main">


### PR DESCRIPTION
Reduces the amount of whitespace on the top heading to be inline with the heading size on the results page.

Balance the whitespace between the header, back link, and the page content

**before**
![screenshot 2015-11-02 13 47 30](https://cloud.githubusercontent.com/assets/32398/10883201/4a53436c-8168-11e5-9566-c69974ef352c.png)

**after**
![screenshot 2015-11-02 13 47 17](https://cloud.githubusercontent.com/assets/32398/10883202/4a6386b4-8168-11e5-8deb-fedb707e0426.png)