### PR TITLE
[DEV APPROVED] Changing border and shadow to match results page

### DIFF
--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -19,6 +19,8 @@ $callout-text-color: $color-black;
 $color-link-blue: $color-blue-medium;
 $color-porcelain: #F0F4F4;
 
+$firm-border-radius: 5px;
+$firm-border-color: $background-color;
 $firm-header-color: $color-green-primary;
 $firm-pin-color: $color-green-secondary;
 
@@ -39,8 +41,6 @@ $list-numbers-list-style-color: $color-green-secondary;
 $pagination-icon-color: #010202;
 $pagination-text-color: $color-black;
 
-$result-radius: 5px;
-$result-border-color: $background-color;
 $result-shadow-color: $color-grey-light;
 $result-heading-color: $color-black;
 $result-text-color: $color-black;

--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -5,7 +5,7 @@
 
 .firm__header {
   background-color: $background-color;
-  border: 1px solid $color-grey-normal;
+  border: 1px solid $firm-border-color;
   border-top-right-radius: 5px;
   border-top-left-radius: 5px;
   padding: $baseline-unit*2;
@@ -28,11 +28,13 @@
 .firm__content {
   @include clearfix();
   padding: $baseline-unit*2;
-  border-right: 1px solid $color-grey-normal;
-  border-left: 1px solid $color-grey-normal;
-  border-bottom: 3px solid $color-grey-seven;
-  border-bottom-left-radius: 5px;
-  border-bottom-right-radius: 5px;
+  border-right: 1px solid $firm-border-color;
+  border-left: 1px solid $firm-border-color;
+  border-bottom: 1px solid $firm-border-color;
+  border-bottom-left-radius: $firm-border-radius;
+  border-bottom-right-radius: $firm-border-radius;
+
+  box-shadow: 0 1px 0 0 $result-shadow-color;
 
   @include respond-to($mq-m) {
     padding-bottom: $baseline-unit*6;

--- a/app/assets/stylesheets/components/_keyword.scss
+++ b/app/assets/stylesheets/components/_keyword.scss
@@ -2,7 +2,7 @@
   @include body(14, 14);
 
   padding-bottom: $baseline-unit*2;
-  border-bottom: 1px solid $result-border-color;
+  border-bottom: 1px solid $firm-border-color;
 
   &:last-of-type {
     padding-bottom: 0;

--- a/app/assets/stylesheets/components/_result.scss
+++ b/app/assets/stylesheets/components/_result.scss
@@ -4,8 +4,8 @@
   margin-bottom: $baseline-unit*6;
   padding: $baseline-unit;
 
-  border: 1px solid $result-border-color;
-  border-radius: $result-radius;
+  border: 1px solid $firm-border-color;
+  border-radius: $firm-border-radius;
   box-shadow: 0 1px 0 0 $result-shadow-color;
 
   color: $result-text-color;
@@ -59,7 +59,7 @@
   margin-bottom: 0;
   padding-top: 0;
 
-  border-top: 1px solid $result-border-color;
+  border-top: 1px solid $firm-border-color;
 
   @include body(16,30);
 }


### PR DESCRIPTION
The border and drop shadow on the profile page was darker than on the results page. This makes them consistent across pages.

### before

![screenshot 2015-11-02 14 32 58](https://cloud.githubusercontent.com/assets/52965/10884232/c48769b4-816e-11e5-8d35-d2ab448fcf94.png)

### after

![screenshot 2015-11-02 14 32 51](https://cloud.githubusercontent.com/assets/52965/10884239/c9fd6b78-816e-11e5-8cc0-9a206b95c900.png)
