### PR TITLE
[DEV APPROVED] don't display tabs when searching for online and telephone advice (remote). fix whitespace.

### DIFF
--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -77,6 +77,7 @@
 .firm__map {
   height: 400px;
   width: 100%;
+  margin-bottom: $baseline-unit*4;
 }
 
 .firm__divider {

--- a/app/assets/stylesheets/layouts/_firm.scss
+++ b/app/assets/stylesheets/layouts/_firm.scss
@@ -21,6 +21,10 @@
   margin-bottom: 0;
 }
 
+.l-firm__heading {
+  margin-top: $baseline-unit;
+}
+
 .l-firm__heading--collapse {
   margin-top: -($baseline-unit);
 }

--- a/app/views/firms/partials/_content.html.erb
+++ b/app/views/firms/partials/_content.html.erb
@@ -1,27 +1,31 @@
 <div class="firm__content">
-  <div class="tab-selector" data-dough-component="TabSelector">
-    <div data-dough-tab-selector-triggers-outer class="tab-selector__triggers-outer">
-      <div data-dough-tab-selector-triggers-inner class="tab-selector__triggers-inner">
-        <div class="tab-selector__trigger-container is-active" data-dough-tab-selector-trigger-container>
-          <a class="tab-selector__trigger" href="#panel-1" data-dough-tab-selector-trigger="1">
-            <%= t('firms.show.panels.firm.heading') %>
-          </a>
-        </div>
-        <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
-          <a class="tab-selector__trigger" href="#panel-2" data-dough-tab-selector-trigger="2">
-            <%= t('firms.show.panels.offices.heading') %>
-          </a>
+  <% if @search_form.face_to_face? %>
+    <div class="tab-selector" data-dough-component="TabSelector">
+      <div data-dough-tab-selector-triggers-outer class="tab-selector__triggers-outer">
+        <div data-dough-tab-selector-triggers-inner class="tab-selector__triggers-inner">
+          <div class="tab-selector__trigger-container is-active" data-dough-tab-selector-trigger-container>
+            <a class="tab-selector__trigger" href="#panel-1" data-dough-tab-selector-trigger="1">
+              <%= t('firms.show.panels.firm.heading') %>
+            </a>
+          </div>
+          <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
+            <a class="tab-selector__trigger" href="#panel-2" data-dough-tab-selector-trigger="2">
+              <%= t('firms.show.panels.offices.heading') %>
+            </a>
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="tab-selector__target is-active" id="panel-1" data-dough-tab-selector-target="1">
-      <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.firm.heading') %></h2>
-      <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude, search_form: @search_form } %>
+      <div class="tab-selector__target is-active" id="panel-1" data-dough-tab-selector-target="1">
+        <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.firm.heading') %></h2>
+        <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude, search_form: @search_form } %>
+      </div>
+      <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
+        <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.office.heading') %></h2>
+        <%= render partial: 'firms/partials/offices' %>
+      </div>
     </div>
-    <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
-      <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.office.heading') %></h2>
-      <%= render partial: 'firms/partials/offices' %>
-    </div>
-  </div>
+  <% else %>
+    <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude, search_form: @search_form } %>
+  <% end %>
 </div>

--- a/app/views/firms/partials/_profile_help.html.erb
+++ b/app/views/firms/partials/_profile_help.html.erb
@@ -2,7 +2,7 @@
 
   <%= heading_tag(t('firms.show.face_to_face.header'),
                   level: 3,
-                  class: 'l-firm__heading--collapse') %>
+                  class: 'l-firm__heading l-firm__heading--collapse') %>
   <p>
     <%= t('firms.show.face_to_face.text') %>
 
@@ -13,7 +13,7 @@
 
   <%= heading_tag(t('firms.show.remote.header'),
                   level: 3,
-                  class: 'l-firm__heading--collapse') %>
+                  class: 'l-firm__heading l-firm__heading--collapse') %>
   <p>
     <%= t('firms.show.remote.text.part_one') %>
     <strong><%= t('firms.show.remote.text.part_two') %></strong>.


### PR DESCRIPTION
There are two types of search within rad consumer: 'in-person', and 'phone or online only'. In the case of it being phone or online only, the office information isn't to be displayed and subsequently, the dough tabs at the top of the page shouldn't appear either.

**profile when from a 'in-person' search result**
![screenshot 2015-11-05 09 08 30](https://cloud.githubusercontent.com/assets/32398/10964129/dd00dd92-839c-11e5-81b6-0d1d46fa17d8.png)

**profile when from a 'phone or online only' search result**
![screenshot 2015-11-05 09 08 42](https://cloud.githubusercontent.com/assets/32398/10964130/dd19971a-839c-11e5-9f53-da0a01ad499b.png)