### PR TITLE
[DEV APPROVED] only display the buttons if it's a remote search

### DIFF
--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -19,7 +19,7 @@
 
 .firm__adviser-distance {
   margin-left: -2px;
-  margin-bottom: $baseline-unit*1;
+  margin-bottom: 0;
   font-weight: bold;
   color: $adviser-distance-text-color;
 }

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -2,34 +2,34 @@
   <%= heading_tag(@firm.name, level: 2, class: 'firm__name') %>
   <% if search_form.face_to_face? %>
     <%= render partial: 'search/partials/firm/adviser_distance', object: @firm, as: :firm, locals: { search_form: search_form }%>
+  <% else %>
+    <ul class="firm__links">
+      <% if @firm.telephone_number.present? %>
+        <li>
+          <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>
+            <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
+            %><%= @firm.telephone_number %>
+          <% end %>
+        </li>
+      <% end %>
+
+      <% if @firm.email_address.present? %>
+        <li>
+          <%= mail_to @firm.email_address, class: 'outline-button' do %>
+            <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
+            %><%= t('firms.show.email_firm') %>
+          <% end %>
+        </li>
+      <% end %>
+
+      <% if @firm.website_address.present? %>
+        <li>
+          <%= link_to @firm.website_address, class: 'outline-button', target: '_blank' do %>
+            <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
+            %><%= t('firms.show.website_address') %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
   <% end %>
-
-  <ul class="firm__links">
-    <% if @firm.telephone_number.present? %>
-      <li>
-        <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>
-          <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
-          %><%= @firm.telephone_number %>
-        <% end %>
-      </li>
-    <% end %>
-
-    <% if @firm.email_address.present? %>
-      <li>
-        <%= mail_to @firm.email_address, class: 'outline-button' do %>
-          <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
-          %><%= t('firms.show.email_firm') %>
-        <% end %>
-      </li>
-    <% end %>
-
-    <% if @firm.website_address.present? %>
-      <li>
-        <%= link_to @firm.website_address, class: 'outline-button', target: '_blank' do %>
-          <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
-          %><%= t('firms.show.website_address') %>
-        <% end %>
-      </li>
-    <% end %>
-  </ul>
 </div>


### PR DESCRIPTION
When viewing a profile page from an 'in-person' search, the buttons that appear for the phone, website, and email should not be displayed in the 'header' area. This information will be displayed directly next to each office in the offices tab.

For profiles from 'phone or online', they should be retained.

**'in-person' profile.**
![screenshot 2015-11-05 09 17 59](https://cloud.githubusercontent.com/assets/32398/10964342/8a1b4462-839e-11e5-8856-4d47dd83e7d4.png)

**'phone or online' profile.**
![screenshot 2015-11-05 09 18 12](https://cloud.githubusercontent.com/assets/32398/10964343/8a38ce1a-839e-11e5-869c-938e0ebdf1ca.png)