### PR TITLE
[Dev approved] Add sharia ethical investing

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -29,6 +29,7 @@
 @import 'components/education';
 @import 'components/firm';
 @import 'components/further_info';
+@import 'components/investing';
 @import 'components/keyword';
 @import 'components/list_numbers';
 @import 'components/locale';

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -23,7 +23,8 @@ $contact-link-text-color: $color-blue-medium;
 $contact-link-fill-color: $color-blue-medium;
 
 $firm-border-radius: 5px;
-$firm-border-color: $background-color;
+$firm-border-color: $color-grey-pale;
+$firm-divider-color: $color-grey-pale;
 $firm-header-color: $color-green-primary;
 $firm-pin-color: $color-green-secondary;
 
@@ -34,6 +35,8 @@ $further-info-text-color: $color-white;
 $further-info-icon-width: 20px;
 $further-info-icon-height: 20px;
 $further-info-background-color: $color-blue-medium;
+
+$investing-text-color: $color-black;
 
 $keyword-dividing-color: $color-porcelain;
 

--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -81,5 +81,5 @@
 }
 
 .firm__divider {
-  border-top: 1px solid $color-grey-normal;
+  border-top: 1px solid $firm-divider-color;
 }

--- a/app/assets/stylesheets/components/_investing.scss
+++ b/app/assets/stylesheets/components/_investing.scss
@@ -1,0 +1,16 @@
+.investing__heading {
+  margin-bottom: 0;
+}
+
+.investing__list {
+  list-style: none;
+  margin-top: 0;
+  margin-bottom: $baseline-unit;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.investing__list-item{
+  margin-bottom: 0;
+  color: $investing-text-color;
+}

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -1,4 +1,8 @@
 module FirmHelper
+  def firm_has_investing_types?(firm)
+    firm.ethical_investing_flag || firm.sharia_investing_flag
+  end
+
   def type_of_advice_list_item(firm, type)
     return unless firm.includes_advice_type? type
     content_tag :li,

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -81,6 +81,26 @@
   </div>
 </div>
 
+<% if firm_has_investing_types?(firm) %>
+  <div class="l-firm__row">
+    <div class="l-1col firm__divider">
+      <%= heading_tag(t('firms.show.panels.firm.services.investing.heading'), level: 4, class: 'investing__heading') %>
+      <ul class="investing__list">
+        <% if firm.ethical_investing_flag %>
+          <li class="investing__list-item">
+            <%= t('firms.show.panels.firm.services.investing.ethical') %>
+          </li>
+        <% end %>
+        <% if firm.sharia_investing_flag %>
+          <li class="investing__list-item">
+            <%= t('firms.show.panels.firm.services.investing.sharia') %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
 <% if firm_has_qualifications_or_accreditations?(firm) %>
   <div class="l-firm__row">
     <div class="l-1col firm__divider">

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -74,6 +74,10 @@ cy:
               equity_release: Rhyddhau Ecwiti
               inheritance_tax_planning: Cynllunio ar gyfer treth etifeddiant
               wills_and_probate: Ewyllysiau a phrofiant
+            investing:
+              heading: Gwasanaethau Eraill
+              ethical: Buddsoddiadau moesol
+              sharia: Buddsoddiadau sy’n cydymffurfio â Shariah
             qualifications:
               heading: Cymwysterau a feddir gan gynghorwyr y cwmni
         offices:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,10 @@ en:
               equity_release: Equity release
               inheritance_tax_planning: Inheritance tax planning
               wills_and_probate: Wills & probate
+            investing:
+              heading: Other services
+              ethical: Ethical investments
+              sharia: Shariah-compliant investments
             qualifications:
               heading: Qualifications held by firm advisers
         offices:

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -3,6 +3,54 @@ require 'spec_helper'
 RSpec.describe FirmHelper, type: :helper do
   let(:firm) { double }
 
+  describe 'firm_has_investing_types?' do
+    subject { helper.firm_has_investing_types?(firm) }
+
+    context 'it has neither sharia or ethical investing' do
+      before do
+        allow(firm).to receive(:ethical_investing_flag).and_return(false)
+        allow(firm).to receive(:sharia_investing_flag).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'it has sharia but not ethical investing' do
+      before do
+        allow(firm).to receive(:ethical_investing_flag).and_return(false)
+        allow(firm).to receive(:sharia_investing_flag).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'it has ethical but not sharia investing' do
+      before do
+        allow(firm).to receive(:ethical_investing_flag).and_return(true)
+        allow(firm).to receive(:sharia_investing_flag).and_return(false)
+      end
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'it has ethical and sharia investing' do
+      before do
+        allow(firm).to receive(:ethical_investing_flag).and_return(true)
+        allow(firm).to receive(:sharia_investing_flag).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+  end
+
   describe 'type_of_advice_list_item' do
     subject { helper.type_of_advice_list_item(firm, :equity_release) }
 


### PR DESCRIPTION
Adds the **Other services** section to the firm profile, which can include Sharia or ethical investments. 

Also corrected the colour used as a divider between sections as it was slightly darker than the designs we're working with. So it now matches the border colour.

![screen shot 2015-11-10 at 12 01 06](https://cloud.githubusercontent.com/assets/32398/11061960/c6358e5a-87a2-11e5-914b-3220ed12b0c0.png)
