### PR TITLE
[DEV APPROVED] Add offices to map

### DIFF
--- a/app/assets/javascripts/modules/FirmMap.js
+++ b/app/assets/javascripts/modules/FirmMap.js
@@ -101,11 +101,11 @@ define(['jquery', 'DoughBaseComponent'],
    * @param {GoogleMap} gMap Instance of the map to position markers onto
    */
   FirmMapProto._positionMarkers = function(gMap) {
-    var $advisers = this.$find('[data-dough-map-point]');
+    var $elements = this.$find('[data-dough-map-point]');
 
-    $advisers.each($.proxy(function(_, adviser) {
-      var $adviser = $(adviser),
-          markerConfig = this._generateMarkerConfig($adviser);
+    $elements.each($.proxy(function(_, element) {
+      var $element = $(element),
+          markerConfig = this._generateMarkerConfig($element);
 
       markerConfig.map = gMap;
       new google.maps.Marker(markerConfig);
@@ -130,12 +130,15 @@ define(['jquery', 'DoughBaseComponent'],
    * @returns {Object} Config for creating a google maps marker with
    */
   FirmMapProto._generateMarkerConfig = function($element) {
+    var pinUrlString = $element.data('dough-map-point-type') + 'PinUrl';
+    var iconUrl = this.config[pinUrlString];
+
     return {
       position: {
         lat: $element.data('dough-map-point-lat'),
         lng: $element.data('dough-map-point-lng')
       },
-      icon: { url: this.config.adviserPinUrl }
+      icon: { url: iconUrl }
     };
   };
 

--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -3,6 +3,10 @@
   margin-bottom: $baseline-unit*6;
 }
 
+.firm__details-heading {
+  margin-top: 0;
+}
+
 .firm__header {
   background-color: $background-color;
   border: 1px solid $firm-border-color;
@@ -75,9 +79,18 @@
 }
 
 .firm__map {
-  height: 400px;
-  width: 100%;
-  margin-bottom: $baseline-unit*4;
+  display: none;
+
+  .js & {
+    display: block;
+    height: 400px;
+    width: 100%;
+    margin-bottom: $baseline-unit*4;
+  }
+}
+
+.firm__map-pin-items {
+  display: none;
 }
 
 .firm__divider {

--- a/app/assets/stylesheets/states/_is_hidden.scss
+++ b/app/assets/stylesheets/states/_is_hidden.scss
@@ -28,3 +28,10 @@
     }
   }
 }
+
+.is-hidden-no-js {
+  display: none;
+  .js & {
+    display: block;
+  }
+}

--- a/app/views/firms/partials/_content.html.erb
+++ b/app/views/firms/partials/_content.html.erb
@@ -1,7 +1,7 @@
 <div class="firm__content">
   <% if @search_form.face_to_face? %>
     <div class="tab-selector" data-dough-component="TabSelector">
-      <div data-dough-tab-selector-triggers-outer class="tab-selector__triggers-outer">
+      <div data-dough-tab-selector-triggers-outer class="tab-selector__triggers-outer is-hidden-no-js">
         <div data-dough-tab-selector-triggers-inner class="tab-selector__triggers-inner">
           <div class="tab-selector__trigger-container is-active" data-dough-tab-selector-trigger-container>
             <a class="tab-selector__trigger" href="#panel-1" data-dough-tab-selector-trigger="1">
@@ -18,11 +18,11 @@
       </div>
 
       <div class="tab-selector__target is-active" id="panel-1" data-dough-tab-selector-target="1">
-        <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.firm.heading') %></h2>
+        <h2 class="tab-selector__target-heading firm__details-heading"><%= t('firms.show.panels.firm.heading') %></h2>
         <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude, search_form: @search_form } %>
       </div>
       <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
-        <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.office.heading') %></h2>
+        <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.offices.heading') %></h2>
         <%= render partial: 'firms/partials/offices', locals: { firm: @firm } %>
       </div>
     </div>

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -1,20 +1,17 @@
 <% if search_form.face_to_face? %>
-  <%= heading_tag(t('firms.show.panels.firm.locations'), level: 3, class: 'l-firm__heading') %>
+  <%= heading_tag(t('firms.show.panels.firm.locations'), level: 3, class: 'l-firm__heading is-hidden-no-js') %>
 
   <%= firm_map_component(center: {lat: latitude, lng: longitude},
         adviserPinUrl: image_path('pins/adviser.png'),
         officePinUrl: image_path('pins/office.png')) do %>
     <div class="firm__map" data-dough-map></div>
 
-    <ul class="is-hidden">
+    <ul class="firm__map-pin-items is-hidden">
       <% firm.advisers.each do |adviser| %>
         <li data-dough-map-point data-dough-map-point-type="adviser" data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
           <%= adviser.name %>
         </li>
       <% end %>
-    </ul>
-
-    <ul class="is-hidden">
       <% firm.offices.each do |office| %>
         <li data-dough-map-point data-dough-map-point-type="office" data-dough-map-point-lat="<%= office.location.latitude %>" data-dough-map-point-lng="<%= office.location.longitude %>"></li>
       <% end %>

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -8,9 +8,15 @@
 
     <ul class="is-hidden">
       <% firm.advisers.each do |adviser| %>
-        <li data-dough-map-point data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
+        <li data-dough-map-point data-dough-map-point-type="adviser" data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
           <%= adviser.name %>
         </li>
+      <% end %>
+    </ul>
+
+    <ul class="is-hidden">
+      <% firm.offices.each do |office| %>
+        <li data-dough-map-point data-dough-map-point-type="office" data-dough-map-point-lat="<%= office.location.latitude %>" data-dough-map-point-lng="<%= office.location.longitude %>"></li>
       <% end %>
     </ul>
   <% end %>


### PR DESCRIPTION
complimentary work to https://github.com/moneyadviceservice/mas-rad_core/pull/126. Adds the office markers to the map (note: using dummy data in pic below)
![screen shot 2015-11-10 at 16 53 24](https://cloud.githubusercontent.com/assets/32398/11069029/25366842-87cc-11e5-9a6a-6b9a33218ea7.png)

Additionally, we've added some additional styling to improve the appearance of the profile page when javascript is disabled. Previously the map would not render, but the space for it, the heading, and a list of advisers would appear making the page difficult to understand.
![screen shot 2015-11-11 at 10 02 07](https://cloud.githubusercontent.com/assets/32398/11088603/88f7bd92-885b-11e5-933d-f8be8e1328c4.png)

