### PR TITLE
stop markers changing the cursor from "grab" to "pointer"

### DIFF
--- a/app/assets/javascripts/modules/FirmMap.js
+++ b/app/assets/javascripts/modules/FirmMap.js
@@ -138,7 +138,8 @@ define(['jquery', 'DoughBaseComponent'],
         lat: $element.data('dough-map-point-lat'),
         lng: $element.data('dough-map-point-lng')
       },
-      icon: { url: iconUrl }
+      icon: { url: iconUrl },
+      clickable: false
     };
   };
 


### PR DESCRIPTION
We don't bind to the click event on a google maps marker, so setting `clickable: false` will stop the cursor changing from 'grab' to 'pointer', which we don't want.