### PR TITLE
[DEV APPROVED] Do not display county of address if it is nil

### DIFF
--- a/app/views/firms/partials/_offices.html.erb
+++ b/app/views/firms/partials/_offices.html.erb
@@ -9,7 +9,9 @@
               <div class="address__line"><%= office.address_line_two %>,</div>
             <% end %>
             <div class="address__line"><%= office.address_town %>,</div>
-            <div class="address__line"><%= office.address_county %>,</div>
+            <% if office.address_county.present? %>
+              <div class="address__line"><%= office.address_county %>,</div>
+            <% end %>
             <div class="address__line"><%= office.address_postcode %></div>
           </div>
         </div>


### PR DESCRIPTION
:county is optional in the model. Currently when this is blank/nil we display a trailing ','
The PR removes that scenario from the UI.

Previously with a nil county
![screen shot 2015-11-12 at 13 52 53](https://cloud.githubusercontent.com/assets/67151/11120298/a0018d9c-8946-11e5-8c48-d31d7007738e.png)

With fix in place:
![screen shot 2015-11-12 at 14 06 58](https://cloud.githubusercontent.com/assets/67151/11120310/b03a318c-8946-11e5-9b98-d2b45be5f880.png)
