### PR TITLE
[DEV APPROVED] display office addresses when their pins are clicked

### DIFF
--- a/app/assets/javascripts/modules/FirmMap.js
+++ b/app/assets/javascripts/modules/FirmMap.js
@@ -101,15 +101,33 @@ define(['jquery', 'DoughBaseComponent'],
    * @param {GoogleMap} gMap Instance of the map to position markers onto
    */
   FirmMapProto._positionMarkers = function(gMap) {
-    var $elements = this.$find('[data-dough-map-point]');
+    var $elements = this.$find('[data-dough-map-point]'),
+        infoWindow = new google.maps.InfoWindow();
 
     $elements.each($.proxy(function(_, element) {
       var $element = $(element),
-          markerConfig = this._generateMarkerConfig($element);
+          markerConfig = this._generateMarkerConfig($element),
+          marker;
 
       markerConfig.map = gMap;
-      new google.maps.Marker(markerConfig);
+      marker = new google.maps.Marker(markerConfig);
+      FirmMapProto._addMarkerClickEvent(gMap, marker, infoWindow, $element.text());
     }, this));
+  };
+
+  /**
+   * _addMarkerClickEvent
+   *
+   * Sets up the click event to display the content for a given marker
+   *
+   * @private
+   *
+   */
+  FirmMapProto._addMarkerClickEvent = function(map, marker, infoWindow, content){
+    google.maps.event.addListener(marker, 'click', function() {
+      infoWindow.setContent(content);
+      infoWindow.open(map, this);
+    });
   };
 
   /**
@@ -139,7 +157,7 @@ define(['jquery', 'DoughBaseComponent'],
         lng: $element.data('dough-map-point-lng')
       },
       icon: { url: iconUrl },
-      clickable: false
+      clickable: ($element.data('dough-map-point-type') === 'office')
     };
   };
 

--- a/app/helpers/office_helper.rb
+++ b/app/helpers/office_helper.rb
@@ -1,0 +1,11 @@
+module OfficeHelper
+  def office_address(office)
+    [
+      office.address_line_one,
+      office.address_line_two,
+      office.address_town,
+      office.address_county,
+      office.address_postcode
+    ].join(', ')
+  end
+end

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -13,7 +13,9 @@
         </li>
       <% end %>
       <% firm.offices.each do |office| %>
-        <li data-dough-map-point data-dough-map-point-type="office" data-dough-map-point-lat="<%= office.location.latitude %>" data-dough-map-point-lng="<%= office.location.longitude %>"></li>
+        <li data-dough-map-point data-dough-map-point-type="office" data-dough-map-point-lat="<%= office.location.latitude %>" data-dough-map-point-lng="<%= office.location.longitude %>">
+          <%= office_address(office) %>
+        </li>
       <% end %>
     </ul>
   <% end %>

--- a/spec/helpers/office_helper_spec.rb
+++ b/spec/helpers/office_helper_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe OfficeHelper, type: :helper do
+  let(:data) do
+    {
+      '_id'              => 123,
+      'address_line_one' => 'c/o Postman Pat',
+      'address_line_two' => 'Forge Cottage',
+      'address_town'     => 'Greendale',
+      'address_county'   => 'Cumbria',
+      'address_postcode' => 'LA8 9BE',
+      'email_address'    => 'postie@example.com',
+      'telephone_number' => '5555 555 5555',
+      'disabled_access'  => true,
+      'location' => { 'lat' => 51.5180697, 'lon' => -0.1085203 }
+    }
+  end
+  let(:office_result) { OfficeResult.new(data) }
+
+  describe '#office_address' do
+    it 'outputs a ", " concatenated string of the address' do
+      expected = 'c/o Postman Pat, Forge Cottage, Greendale, Cumbria, LA8 9BE'
+      expect(office_address(office_result)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
Enables only office pins to display address details on the map using a google map 'InfoWindow'

![screen shot 2015-11-12 at 15 08 27](https://cloud.githubusercontent.com/assets/32398/11121731/646e2796-894f-11e5-9121-a2b19cafa935.png)
