### PR TITLE
Always show the contact details of the firm in the profile header

### DIFF
--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -2,34 +2,33 @@
   <%= heading_tag(@firm.name, level: 2, class: 'firm__name') %>
   <% if search_form.face_to_face? %>
     <%= render partial: 'search/partials/firm/adviser_distance', object: @firm, as: :firm, locals: { search_form: search_form }%>
-  <% else %>
-    <ul class="firm__links">
-      <% if @firm.telephone_number.present? %>
-        <li>
-          <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>
-            <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
-            %><%= @firm.telephone_number %>
-          <% end %>
-        </li>
-      <% end %>
-
-      <% if @firm.email_address.present? %>
-        <li>
-          <%= mail_to @firm.email_address, class: 'outline-button' do %>
-            <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
-            %><%= t('firms.show.email_firm') %>
-          <% end %>
-        </li>
-      <% end %>
-
-      <% if @firm.website_address.present? %>
-        <li>
-          <%= link_to @firm.website_address, class: 'outline-button', target: '_blank' do %>
-            <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
-            %><%= t('firms.show.website_address') %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
   <% end %>
+  <ul class="firm__links">
+    <% if @firm.telephone_number.present? %>
+      <li>
+        <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>
+          <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
+          %><%= @firm.telephone_number %>
+        <% end %>
+      </li>
+    <% end %>
+
+    <% if @firm.email_address.present? %>
+      <li>
+        <%= mail_to @firm.email_address, class: 'outline-button' do %>
+          <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
+          %><%= t('firms.show.email_firm') %>
+        <% end %>
+      </li>
+    <% end %>
+
+    <% if @firm.website_address.present? %>
+      <li>
+        <%= link_to @firm.website_address, class: 'outline-button', target: '_blank' do %>
+          <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
+          %><%= t('firms.show.website_address') %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
 </div>


### PR DESCRIPTION
For firms that offer face-to-face advice and therefore have an offices tab in their profile (with contact details shown in it) we experimented with hiding the contact details in the profile header. But decided that it was better to show them.

So goes from:

![screen shot 2015-11-13 at 11 51 26](https://cloud.githubusercontent.com/assets/306583/11145532/4771f820-89fe-11e5-8bc4-b0f8abe6791d.png)


to ...

![screen shot 2015-11-13 at 11 52 53](https://cloud.githubusercontent.com/assets/306583/11145534/4c5e84e8-89fe-11e5-91bd-dd7472d5da10.png)

Now for all firms (both face-to-face advice and remote advice firms)