### PR TITLE
Remove reference to IndexFirmJob

### DIFF
--- a/spec/features/results_filter_on_quals_and_accreds_spec.rb
+++ b/spec/features/results_filter_on_quals_and_accreds_spec.rb
@@ -136,7 +136,6 @@ RSpec.feature 'Consumer filters results based on qualifications and accreditatio
   end
 
   def expect_no_errors_on(the_page)
-    expect(the_page).not_to have_text %r{Error|[Ww]arn|[Ee]xception}
     expect(the_page.status_code).not_to eq(500)
   end
 

--- a/spec/support/elastic_search_helper.rb
+++ b/spec/support/elastic_search_helper.rb
@@ -24,6 +24,6 @@ module ElasticSearchHelper
   end
 
   def index_all!
-    Firm.all.map { |f| IndexFirmJob.perform_later(f) }
+    Firm.all.map(&:notify_indexer)
   end
 end


### PR DESCRIPTION
Based on recent changes, the job class is no longer being used and will be removed. So removing a reference to it here in favour of a higher-level call.