### PR TITLE
Order offices by distance

### DIFF
--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -4,6 +4,8 @@ class FirmsController < ApplicationController
     result = FirmRepository.new.search(@search_form.to_query)
 
     @firm  = result.firms.first
+    @offices = Geosort.by_distance(@search_form.coordinates, @firm.offices)
+
     @latitude, @longitude = @search_form.coordinates
   end
 end

--- a/app/views/firms/partials/_content.html.erb
+++ b/app/views/firms/partials/_content.html.erb
@@ -23,7 +23,7 @@
       </div>
       <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
         <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.offices.heading') %></h2>
-        <%= render partial: 'firms/partials/offices', locals: { firm: @firm } %>
+        <%= render partial: 'firms/partials/offices', locals: { firm: @firm, offices: @offices } %>
       </div>
     </div>
   <% else %>

--- a/app/views/firms/partials/_firm_links.html.erb
+++ b/app/views/firms/partials/_firm_links.html.erb
@@ -1,7 +1,7 @@
 <ul class="firm__links">
   <% if telephone_number.present? %>
     <li>
-      <%= link_to "tel:#{telephone_number}", class: 'outline-button' do %>
+      <%= link_to "tel:#{telephone_number}", class: 'outline-button t-telephone' do %>
         <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
         %><%= telephone_number %>
       <% end %>
@@ -10,7 +10,7 @@
 
   <% if email_address.present? %>
     <li>
-      <%= mail_to email_address, class: 'outline-button' do %>
+      <%= mail_to email_address, class: 'outline-button t-email' do %>
         <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
         %><%= t('firms.show.email_firm') %>
       <% end %>

--- a/app/views/firms/partials/_firm_links.html.erb
+++ b/app/views/firms/partials/_firm_links.html.erb
@@ -1,0 +1,28 @@
+<ul class="firm__links">
+  <% if telephone_number.present? %>
+    <li>
+      <%= link_to "tel:#{telephone_number}", class: 'outline-button' do %>
+        <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
+        %><%= telephone_number %>
+      <% end %>
+    </li>
+  <% end %>
+
+  <% if email_address.present? %>
+    <li>
+      <%= mail_to email_address, class: 'outline-button' do %>
+        <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
+        %><%= t('firms.show.email_firm') %>
+      <% end %>
+    </li>
+  <% end %>
+
+  <% if website_address.present? %>
+    <li>
+      <%= link_to website_address, class: 'outline-button', target: '_blank' do %>
+        <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
+        %><%= t('firms.show.website_address') %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -2,6 +2,8 @@
   <%= heading_tag(@firm.name, level: 2, class: 'firm__name') %>
   <% if search_form.face_to_face? %>
     <%= render partial: 'search/partials/firm/adviser_distance', object: @firm, as: :firm, locals: { search_form: search_form }%>
+  <% end %>
+  <% if search_form.face_to_face? && @offices.present? %>
     <%= render partial: 'firms/partials/firm_links',
              locals: { telephone_number: @offices.first.telephone_number, email_address: @offices.first.email_address, website_address: @firm.website_address } %>
   <% else %>

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -2,8 +2,10 @@
   <%= heading_tag(@firm.name, level: 2, class: 'firm__name') %>
   <% if search_form.face_to_face? %>
     <%= render partial: 'search/partials/firm/adviser_distance', object: @firm, as: :firm, locals: { search_form: search_form }%>
+    <%= render partial: 'firms/partials/firm_links',
+             locals: { telephone_number: @offices.first.telephone_number, email_address: @offices.first.email_address, website_address: @firm.website_address } %>
+  <% else %>
+    <%= render partial: 'firms/partials/firm_links',
+               locals: { telephone_number: @firm.telephone_number, email_address: @firm.email_address, website_address: @firm.website_address } %>
   <% end %>
-
-  <%= render partial: 'firms/partials/firm_links',
-             locals: { telephone_number: @firm.telephone_number, email_address: @firm.email_address, website_address: @firm.website_address } %>
 </div>

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -3,32 +3,7 @@
   <% if search_form.face_to_face? %>
     <%= render partial: 'search/partials/firm/adviser_distance', object: @firm, as: :firm, locals: { search_form: search_form }%>
   <% end %>
-  <ul class="firm__links">
-    <% if @firm.telephone_number.present? %>
-      <li>
-        <%= link_to "tel:#{@firm.telephone_number}", class: 'outline-button' do %>
-          <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
-          %><%= @firm.telephone_number %>
-        <% end %>
-      </li>
-    <% end %>
 
-    <% if @firm.email_address.present? %>
-      <li>
-        <%= mail_to @firm.email_address, class: 'outline-button' do %>
-          <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
-          %><%= t('firms.show.email_firm') %>
-        <% end %>
-      </li>
-    <% end %>
-
-    <% if @firm.website_address.present? %>
-      <li>
-        <%= link_to @firm.website_address, class: 'outline-button', target: '_blank' do %>
-          <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
-          %><%= t('firms.show.website_address') %>
-        <% end %>
-      </li>
-    <% end %>
-  </ul>
+  <%= render partial: 'firms/partials/firm_links',
+             locals: { telephone_number: @firm.telephone_number, email_address: @firm.email_address, website_address: @firm.website_address } %>
 </div>

--- a/app/views/firms/partials/_offices.html.erb
+++ b/app/views/firms/partials/_offices.html.erb
@@ -1,5 +1,5 @@
 <div data-dough-component="ShowMore">
-  <% firm.offices.each do |office| %>
+  <% offices.each do |office| %>
     <div class="office t-office" data-dough-show-more-item>
       <div class="l-2col">
         <div class="l-2col-even l-office-col">
@@ -12,7 +12,7 @@
             <% if office.address_county.present? %>
               <div class="address__line"><%= office.address_county %>,</div>
             <% end %>
-            <div class="address__line"><%= office.address_postcode %></div>
+            <div class="address__line t-postcode"><%= office.address_postcode %></div>
           </div>
         </div>
         <div class="l-2col-even l-office-col">

--- a/lib/geosort.rb
+++ b/lib/geosort.rb
@@ -1,0 +1,15 @@
+module Geosort
+  def self.by_distance(initial_location, objects_with_location)
+    obj_distance_pairs = {}
+
+    objects_with_location.each do |obj|
+      distance = Geocoder::Calculations.distance_between(initial_location.to_a, obj.location.to_a)
+      obj_distance_pairs[obj] = distance
+    end
+
+    obj_distance_pairs
+      .sort_by {|_key, value| value}
+      .flatten
+      .reject {|x| x.is_a? Float }
+  end
+end

--- a/lib/geosort.rb
+++ b/lib/geosort.rb
@@ -8,8 +8,8 @@ module Geosort
     end
 
     obj_distance_pairs
-      .sort_by {|_key, value| value}
+      .sort_by { |_key, value| value }
       .flatten
-      .reject {|x| x.is_a? Float }
+      .reject { |x| x.is_a? Float }
   end
 end

--- a/lib/geosort.rb
+++ b/lib/geosort.rb
@@ -9,7 +9,6 @@ module Geosort
 
     obj_distance_pairs
       .sort_by { |_key, value| value }
-      .flatten
-      .reject { |x| x.is_a? Float }
+      .map { |pair| pair[0] }
   end
 end

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe FirmsController, type: :controller do
   let!(:firm) { FactoryGirl.create(:firm) }
   let(:search_form_params) { { 'advice_method' => SearchForm::ADVICE_METHOD_FACE_TO_FACE, 'postcode' => 'EC1N 2TD' } }
-  let(:firm_result_1) { double }
-  let(:firm_result_2) { double }
+  let(:firm_result_1) { double(offices: []) }
+  let(:firm_result_2) { double(offices: []) }
   let(:firm_repository) { double }
 
   describe 'GET #show' do

--- a/spec/features/firm_profile_for_in_person_search_spec.rb
+++ b/spec/features/firm_profile_for_in_person_search_spec.rb
@@ -29,9 +29,9 @@ RSpec.feature 'Firm profile page from an "in-person" search',
     with_fresh_index! do
       @firm = create(:firm)
       create(:adviser, firm: @firm, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616, travel_distance: 100)
-      @firm.main_office.update_attributes!(email_address: 'main.office@example.com', address_line_one: '120 Holborn', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 2TD', latitude: 51.518148, longitude:-0.108013)
-      create(:office, firm: @firm, email_address: 'local.1@example.com', address_line_one: 'Phoenix House', address_line_two: '18 King William St', address_town: 'London', address_county: nil, address_postcode: 'EC4N 7BP', latitude: 51.511224, longitude:-0.087422)
-      create(:office, firm: @firm, email_address: 'local.2@example.com',address_line_one: '12 Leather Ln', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 7SS', latitude: 51.519144, longitude:-0.108927)
+      @firm.main_office.update_attributes!(email_address: 'main.office@example.com', address_line_one: '120 Holborn', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 2TD', latitude: 51.518148, longitude: -0.108013)
+      create(:office, firm: @firm, email_address: 'local.1@example.com', address_line_one: 'Phoenix House', address_line_two: '18 King William St', address_town: 'London', address_county: nil, address_postcode: 'EC4N 7BP', latitude: 51.511224, longitude: -0.087422)
+      create(:office, firm: @firm, email_address: 'local.2@example.com', address_line_one: '12 Leather Ln', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 7SS', latitude: 51.519144, longitude: -0.108927)
 
       @remote_firm = create(:firm, :with_remote_advice)
       @remote_firm.main_office.update_attributes!(email_address: 'remote@example.com')

--- a/spec/features/firm_profile_for_in_person_search_spec.rb
+++ b/spec/features/firm_profile_for_in_person_search_spec.rb
@@ -4,33 +4,54 @@ RSpec.feature 'Firm profile page from an "in-person" search',
   let(:results_page) { ResultsPage.new }
   let(:profile_page) { ProfilePage.new }
 
-  scenario 'viewing office information' do
+  scenario 'viewing office information for an "in-person" search' do
     with_elastic_search! do
-      given_firm_with_two_offices_has_been_indexed
+      given_firm_with_multiple_offices_has_been_indexed
       and_i_perform_an_in_person_search
       when_i_view_the_firm_profile
       and_i_select_the_offices_tab
       then_i_should_see_a_number_of_offices_listed
       and_they_should_be_ordered_by_closest_to_search_postcode
+      and_the_email_address_for_the_nearest_office_is_prominent
     end
   end
 
-  def given_firm_with_two_offices_has_been_indexed
+  scenario 'viewing office information for an "phone or online" search' do
+    with_elastic_search! do
+      given_firm_with_multiple_offices_has_been_indexed
+      and_i_perform_a_phone_or_online_search
+      when_i_view_the_firm_profile
+      then_the_email_address_for_the_main_office_is_prominent
+    end
+  end
+
+  def given_firm_with_multiple_offices_has_been_indexed
     with_fresh_index! do
       @firm = create(:firm)
       create(:adviser, firm: @firm, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616, travel_distance: 100)
-      @firm.main_office.update_attributes!(address_line_one: '120 Holborn', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 2TD', latitude: 51.518148, longitude:-0.108013)
-      create(:office, firm: @firm, address_line_one: 'Phoenix House', address_line_two: '18 King William St', address_town: 'London', address_county: nil, address_postcode: 'EC4N 7BP', latitude: 51.511224, longitude:-0.087422)
-      create(:office, firm: @firm, address_line_one: '12 Leather Ln', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 7SS', latitude: 51.519144, longitude:-0.108927)
+      @firm.main_office.update_attributes!(email_address: 'main.office@example.com', address_line_one: '120 Holborn', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 2TD', latitude: 51.518148, longitude:-0.108013)
+      create(:office, firm: @firm, email_address: 'local.1@example.com', address_line_one: 'Phoenix House', address_line_two: '18 King William St', address_town: 'London', address_county: nil, address_postcode: 'EC4N 7BP', latitude: 51.511224, longitude:-0.087422)
+      create(:office, firm: @firm, email_address: 'local.2@example.com',address_line_one: '12 Leather Ln', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 7SS', latitude: 51.519144, longitude:-0.108927)
+
+      @remote_firm = create(:firm, :with_remote_advice)
+      @remote_firm.main_office.update_attributes!(email_address: 'remote@example.com')
     end
   end
 
   def and_i_perform_an_in_person_search
     landing_page.load
     landing_page.in_person.tap do |f|
-      f.postcode.set 'EC1N 2TD'
+      f.postcode.set 'EC1N 7SS'
       f.search.click
     end
+
+    expect(results_page).to be_displayed
+  end
+
+  def and_i_perform_a_phone_or_online_search
+    landing_page.load
+    landing_page.search_filter.phone_or_online.set true
+    landing_page.search_filter.search.click
 
     expect(results_page).to be_displayed
   end
@@ -49,7 +70,15 @@ RSpec.feature 'Firm profile page from an "in-person" search',
   end
 
   def and_they_should_be_ordered_by_closest_to_search_postcode
-    expect(profile_page.offices.first.postcode.text).to eq('EC1N 2TD')
+    expect(profile_page.offices.first.postcode.text).to eq('EC1N 7SS')
     expect(profile_page.offices.last.postcode.text).to eq('EC4N 7BP')
+  end
+
+  def and_the_email_address_for_the_nearest_office_is_prominent
+    expect(profile_page.email[:href]).to eq('mailto:local.2@example.com')
+  end
+
+  def then_the_email_address_for_the_main_office_is_prominent
+    expect(profile_page.email[:href]).to eq('mailto:remote@example.com')
   end
 end

--- a/spec/features/firm_profile_for_in_person_search_spec.rb
+++ b/spec/features/firm_profile_for_in_person_search_spec.rb
@@ -10,7 +10,8 @@ RSpec.feature 'Firm profile page from an "in-person" search',
       and_i_perform_an_in_person_search
       when_i_view_the_firm_profile
       and_i_select_the_offices_tab
-      then_i_should_see_both_offices_listed
+      then_i_should_see_a_number_of_offices_listed
+      and_they_should_be_ordered_by_closest_to_search_postcode
     end
   end
 
@@ -18,14 +19,16 @@ RSpec.feature 'Firm profile page from an "in-person" search',
     with_fresh_index! do
       @firm = create(:firm)
       create(:adviser, firm: @firm, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616, travel_distance: 100)
-      create(:office, firm: @firm)
+      @firm.main_office.update_attributes!(address_line_one: '120 Holborn', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 2TD', latitude: 51.518148, longitude:-0.108013)
+      create(:office, firm: @firm, address_line_one: 'Phoenix House', address_line_two: '18 King William St', address_town: 'London', address_county: nil, address_postcode: 'EC4N 7BP', latitude: 51.511224, longitude:-0.087422)
+      create(:office, firm: @firm, address_line_one: '12 Leather Ln', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 7SS', latitude: 51.519144, longitude:-0.108927)
     end
   end
 
   def and_i_perform_an_in_person_search
     landing_page.load
     landing_page.in_person.tap do |f|
-      f.postcode.set 'RG2 9FL'
+      f.postcode.set 'EC1N 2TD'
       f.search.click
     end
 
@@ -41,7 +44,12 @@ RSpec.feature 'Firm profile page from an "in-person" search',
     profile_page.office_tab.click
   end
 
-  def then_i_should_see_both_offices_listed
-    expect(profile_page.offices.length).to eq(2)
+  def then_i_should_see_a_number_of_offices_listed
+    expect(profile_page.offices.length).to eq(3)
+  end
+
+  def and_they_should_be_ordered_by_closest_to_search_postcode
+    expect(profile_page.offices.first.postcode.text).to eq('EC1N 2TD')
+    expect(profile_page.offices.last.postcode.text).to eq('EC4N 7BP')
   end
 end

--- a/spec/fixtures/vcr_cassettes/firm_profile_for_in_person_search.yml
+++ b/spec/fixtures/vcr_cassettes/firm_profile_for_in_person_search.yml
@@ -420,4 +420,509 @@ http_interactions:
         }
     http_version: 
   recorded_at: Thu, 19 Nov 2015 14:11:47 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC4N%207BP,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 19 Nov 2015 14:54:54 GMT
+      Expires:
+      - Fri, 20 Nov 2015 14:54:54 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '499'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EC4N 7BP",
+                       "short_name" : "EC4N 7BP",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Gt Lon",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "London EC4N 7BP, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.511525,
+                          "lng" : -0.0870997
+                       },
+                       "southwest" : {
+                          "lat" : 51.5111663,
+                          "lng" : -0.0877317
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.5112531,
+                       "lng" : -0.08743039999999999
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.5126946302915,
+                          "lng" : -0.08606671970849797
+                       },
+                       "southwest" : {
+                          "lat" : 51.5099966697085,
+                          "lng" : -0.08876468029150203
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJhXqgjVMDdkgRcrRqD3UmAqE",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 19 Nov 2015 14:54:54 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC4N%207BP,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 19 Nov 2015 14:54:54 GMT
+      Expires:
+      - Fri, 20 Nov 2015 14:54:54 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '499'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EC4N 7BP",
+                       "short_name" : "EC4N 7BP",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Gt Lon",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "London EC4N 7BP, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.511525,
+                          "lng" : -0.0870997
+                       },
+                       "southwest" : {
+                          "lat" : 51.5111663,
+                          "lng" : -0.0877317
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.5112531,
+                       "lng" : -0.08743039999999999
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.5126946302915,
+                          "lng" : -0.08606671970849797
+                       },
+                       "southwest" : {
+                          "lat" : 51.5099966697085,
+                          "lng" : -0.08876468029150203
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJhXqgjVMDdkgRcrRqD3UmAqE",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 19 Nov 2015 14:54:54 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%207SS,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 19 Nov 2015 14:55:55 GMT
+      Expires:
+      - Fri, 20 Nov 2015 14:55:55 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '499'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EC1N 7SS",
+                       "short_name" : "EC1N 7SS",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Gt Lon",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "London EC1N 7SS, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.5191588,
+                          "lng" : -0.1083228
+                       },
+                       "southwest" : {
+                          "lat" : 51.51883609999999,
+                          "lng" : -0.1101883
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.518938,
+                       "lng" : -0.1088302
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.5203464302915,
+                          "lng" : -0.107906569708498
+                       },
+                       "southwest" : {
+                          "lat" : 51.5176484697085,
+                          "lng" : -0.110604530291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJCxiBSkwbdkgR1X4vcWyDCDs",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 19 Nov 2015 14:55:55 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%207SS,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 19 Nov 2015 14:55:55 GMT
+      Expires:
+      - Fri, 20 Nov 2015 14:55:55 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '499'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EC1N 7SS",
+                       "short_name" : "EC1N 7SS",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Gt Lon",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "London EC1N 7SS, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.5191588,
+                          "lng" : -0.1083228
+                       },
+                       "southwest" : {
+                          "lat" : 51.51883609999999,
+                          "lng" : -0.1101883
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.518938,
+                       "lng" : -0.1088302
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.5203464302915,
+                          "lng" : -0.107906569708498
+                       },
+                       "southwest" : {
+                          "lat" : 51.5176484697085,
+                          "lng" : -0.110604530291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJCxiBSkwbdkgR1X4vcWyDCDs",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 19 Nov 2015 14:55:55 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 19 Nov 2015 15:05:56 GMT
+      Expires:
+      - Fri, 20 Nov 2015 15:05:56 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '406'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "United Kingdom",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 60.8608653,
+                          "lng" : 33.9165549
+                       },
+                       "southwest" : {
+                          "lat" : 34.5626609,
+                          "lng" : -8.649357199999999
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.378051,
+                       "lng" : -3.435973
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 60.856553,
+                          "lng" : 1.7627096
+                       },
+                       "southwest" : {
+                          "lat" : 49.8699654,
+                          "lng" : -8.649357199999999
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJqZHHQhE7WgIReiWIMkOg-MQ",
+                 "types" : [ "country", "political" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 19 Nov 2015 15:05:56 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/firm_profile_for_in_person_search.yml
+++ b/spec/fixtures/vcr_cassettes/firm_profile_for_in_person_search.yml
@@ -210,4 +210,214 @@ http_interactions:
         }
     http_version: 
   recorded_at: Thu, 05 Nov 2015 14:43:42 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 19 Nov 2015 14:11:46 GMT
+      Expires:
+      - Fri, 20 Nov 2015 14:11:46 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '495'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EC1N 2TD",
+                       "short_name" : "EC1N 2TD",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Gt Lon",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "London EC1N 2TD, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.5182639,
+                          "lng" : -0.1078729
+                       },
+                       "southwest" : {
+                          "lat" : 51.5173261,
+                          "lng" : -0.1094075
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.5180697,
+                       "lng" : -0.1085203
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.5191439802915,
+                          "lng" : -0.107291219708498
+                       },
+                       "southwest" : {
+                          "lat" : 51.5164460197085,
+                          "lng" : -0.109989180291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ5_7trE0bdkgRKFWaw55y3rM",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 19 Nov 2015 14:11:46 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%202TD,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 19 Nov 2015 14:11:47 GMT
+      Expires:
+      - Fri, 20 Nov 2015 14:11:47 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '495'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EC1N 2TD",
+                       "short_name" : "EC1N 2TD",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Gt Lon",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "London EC1N 2TD, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.5182639,
+                          "lng" : -0.1078729
+                       },
+                       "southwest" : {
+                          "lat" : 51.5173261,
+                          "lng" : -0.1094075
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.5180697,
+                       "lng" : -0.1085203
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.5191439802915,
+                          "lng" : -0.107291219708498
+                       },
+                       "southwest" : {
+                          "lat" : 51.5164460197085,
+                          "lng" : -0.109989180291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ5_7trE0bdkgRKFWaw55y3rM",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 19 Nov 2015 14:11:47 GMT
 recorded_with: VCR 2.9.3

--- a/spec/lib/geosort_spec.rb
+++ b/spec/lib/geosort_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Geocode do
 
     it 'returns the objects ordered by location' do
       sorted_names = Geosort.by_distance(initial_location, results).map(&:name)
-      expect(sorted_names).to eq(['A', 'C', 'D', 'B'])
+      expect(sorted_names).to eq(%w(A C D B))
     end
   end
 end

--- a/spec/lib/geosort_spec.rb
+++ b/spec/lib/geosort_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Geocode do
+  class ExampleResult
+    attr_reader :name, :location
+
+    def initialize(name, lat, lon)
+      @name = name
+      @location = Location.new(lat, lon)
+    end
+  end
+
+  describe 'by_location' do
+    let(:latitude) { 50.123456 }
+    let(:initial_location) { [latitude, -0.000001] }
+
+    let(:results) do
+      [
+        ExampleResult.new('A', latitude, -0.100001),
+        ExampleResult.new('B', latitude, -0.500001),
+        ExampleResult.new('C', latitude, -0.300001),
+        ExampleResult.new('D', latitude, -0.40001)
+      ]
+    end
+
+    it 'returns the objects ordered by location' do
+      sorted_names = Geosort.by_distance(initial_location, results).map(&:name)
+      expect(sorted_names).to eq(['A', 'C', 'D', 'B'])
+    end
+  end
+end

--- a/spec/support/office_section.rb
+++ b/spec/support/office_section.rb
@@ -1,3 +1,4 @@
 class OfficeSection < SitePrism::Section
   element :address, '.t-address'
+  element :postcode, '.t-postcode'
 end

--- a/spec/support/profile_page.rb
+++ b/spec/support/profile_page.rb
@@ -5,4 +5,6 @@ class ProfilePage < SitePrism::Page
 
   # the dough component re-writes the DOM so we can't attach a test class
   element :office_tab, '[data-dough-tab-selector-trigger="2"]'
+  element :telephone, '.t-telephone'
+  element :email, '.t-email'
 end


### PR DESCRIPTION
Bit of a heavy PR for what is a relatively minor thing in the UI...

In summary:
* When viewing the offices tab for a given firm, all of the offices are sorted by location relative to the initial postcode the user searched with.
* If it is a postcode search, the main links at the top of the profile should be for the telephone, email, and website of the nearest office, rather than the main office.

