### PR TITLE
[DEV APPROVED] insert baseline margin-top

### DIFF
--- a/app/assets/stylesheets/components/_result.scss
+++ b/app/assets/stylesheets/components/_result.scss
@@ -66,6 +66,7 @@
 
 .result__office-adviser-count {
   @include body(16, 16);
+  margin-top: $baseline-unit;
 }
 
 .result__qualifications {


### PR DESCRIPTION
Re-introduces $baseline-unit margin between two elements which appears to have been removed at some point.

**before**
![screen shot 2015-11-19 at 19 05 00](https://cloud.githubusercontent.com/assets/32398/11281031/a57d67dc-8ef0-11e5-8587-8df252c216c7.png)

**after (original design)**
![screen shot 2015-11-19 at 19 05 15](https://cloud.githubusercontent.com/assets/32398/11281030/a576f35c-8ef0-11e5-8faf-bc7ac965d062.png)
