### PR TITLE
add style to set "white-space" to be normal for button in footer

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -24,6 +24,7 @@
 @import 'components/back_to_top';
 @import 'components/banner_list';
 @import 'components/brand_logo';
+@import 'components/button';
 @import 'components/callout';
 @import 'components/contact_link';
 @import 'components/education';

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,0 +1,3 @@
+.button--normal-white-space {
+  white-space: normal;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -322,7 +322,7 @@
             </ul>
 
             <fieldset class="newsletter-signup__form js-newsletter-form" id="newsletter_signup">
-                <a href="https://www.moneyadviceservice.org.uk/en/static/contact-us#newsletter_signup" class="t-newsletter-button button newsletter-signup__button newsletter-signup__button--third-party"><%= t('footer_primary.newsletter.sign_up') %></a>
+                <a href="https://www.moneyadviceservice.org.uk/en/static/contact-us#newsletter_signup" class="t-newsletter-button button newsletter-signup__button newsletter-signup__button--third-party button--normal-white-space"><%= t('footer_primary.newsletter.sign_up') %></a>
             </fieldset>
           </form>
         </div>


### PR DESCRIPTION
There is a button for a newsletter that appears at the bottom of all pages. This PR changes the button to use the normal white-space property so text wraps within the element, rather than the element spilling over other text/links.

**before**
![screen shot 2015-11-20 at 10 36 31](https://cloud.githubusercontent.com/assets/32398/11297780/9dca9a78-8f72-11e5-812f-8e6180c189d7.png)

**after**
![screen shot 2015-11-20 at 10 34 58](https://cloud.githubusercontent.com/assets/32398/11297770/8c13a338-8f72-11e5-8d5c-6a20010c225a.png)
