### PR TITLE
Randomise firm search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,8 @@
 class SearchController < ApplicationController
+  MAX_RANDOM_SEED_VALUE = 1024
+
   def index
-    @form = SearchForm.new(params[:search_form])
+    @form = SearchForm.new(search_form_params)
 
     if @form.valid?
       @result = FirmRepository.new.search(@form.to_query, page: page)
@@ -23,5 +25,13 @@ class SearchController < ApplicationController
 
   def from_results?
     params.key?(:origin)
+  end
+
+  def random_search_seed
+    session[:random_search_seed] ||= rand(MAX_RANDOM_SEED_VALUE)
+  end
+
+  def search_form_params
+    params.require(:search_form).merge(random_search_seed: random_search_seed)
   end
 end

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -23,6 +23,7 @@ class SearchForm
                 :pension_pot_size,
                 :firm_id,
                 :qualification_or_accreditation,
+                :random_search_seed,
                 *TYPES_OF_ADVICE
 
   before_validation :upcase_postcode, if: :face_to_face?

--- a/app/serializers/search_form_serializer.rb
+++ b/app/serializers/search_form_serializer.rb
@@ -8,7 +8,7 @@ class SearchFormSerializer < ActiveModel::Serializer
       if object.face_to_face?
         options << {
           _geo_distance: {
-            'advisers.location': object.coordinates.reverse,
+            'advisers.location' => object.coordinates.reverse,
             order: 'asc',
             unit: 'miles'
           }

--- a/spec/features/consumer_searches_remote_advice_spec.rb
+++ b/spec/features/consumer_searches_remote_advice_spec.rb
@@ -14,7 +14,22 @@ RSpec.feature 'Consumer searches for phone or online advice',
       and_firms_providing_remote_services_were_previously_indexed
       when_i_submit_a_search_selecting_online_and_telephone_advice
       then_i_am_shown_firms_that_provide_advice_online_and_by_telephone
-      and_they_are_ordered_alphabetically
+    end
+  end
+
+  scenario 'Searching twice should produce the same order of results' do
+    with_elastic_search! do
+      given_i_am_on_the_rad_landing_page
+      and_firms_providing_remote_services_were_previously_indexed
+
+      when_i_submit_a_search_selecting_online_and_telephone_advice
+      then_i_am_shown_firms_that_provide_advice_online_and_by_telephone
+      and_they_are_ordered_randomly
+
+      given_i_am_on_the_rad_landing_page
+      when_i_submit_a_search_selecting_online_and_telephone_advice
+      then_i_am_shown_firms_that_provide_advice_online_and_by_telephone
+      and_they_are_ordered_the_same_as_last_time
     end
   end
 
@@ -37,10 +52,12 @@ RSpec.feature 'Consumer searches for phone or online advice',
     landing_page.load
   end
 
-  def and_they_are_ordered_alphabetically
-    names = remote_results_page.firm_names
+  def and_they_are_ordered_randomly
+    @random_order = remote_results_page.firm_names
+  end
 
-    expect(remote_results_page.firm_names).to eql(names.sort)
+  def and_they_are_ordered_the_same_as_last_time
+    expect(remote_results_page.firm_names).to eq(@random_order)
   end
 
   def when_i_submit_a_search_selecting_online_and_telephone_advice

--- a/spec/serializers/search_form_serializer_spec.rb
+++ b/spec/serializers/search_form_serializer_spec.rb
@@ -84,6 +84,19 @@ RSpec.describe SearchFormSerializer do
         expect(query_hash).to eq(bool: { must: [{ match: { investment_sizes: '3' } }] })
       end
     end
+
+    context 'when phone or online' do
+      before do
+        params.merge!(
+          advice_method: SearchForm::ADVICE_METHOD_PHONE_OR_ONLINE,
+          random_search_seed: 1234
+        )
+      end
+
+      it 'performs a randomly seeded search' do
+        expect(subject.query[:function_score]).to include(random_score: { seed: 1234 })
+      end
+    end
   end
 
   describe '#sort' do
@@ -113,6 +126,18 @@ RSpec.describe SearchFormSerializer do
         VCR.use_cassette(:geocode_search_form_postcode) do
           expect(subject.sort.last).to eq('registered_name')
         end
+      end
+    end
+
+    context 'when phone or online' do
+      before do
+        params.merge!(
+          advice_method: SearchForm::ADVICE_METHOD_PHONE_OR_ONLINE
+        )
+      end
+
+      it 'sorts by `_score` first' do
+        expect(subject.sort.first).to eq('_score')
       end
     end
   end

--- a/spec/serializers/search_form_serializer_spec.rb
+++ b/spec/serializers/search_form_serializer_spec.rb
@@ -85,4 +85,37 @@ RSpec.describe SearchFormSerializer do
       end
     end
   end
+
+  describe '#sort' do
+    it 'is `registered_name` by default' do
+      expect(subject.sort).to eq(['registered_name'])
+    end
+
+    context 'when face to face' do
+      before do
+        params.merge!(
+          advice_method: SearchForm::ADVICE_METHOD_FACE_TO_FACE,
+          postcode: 'EC1N 2TD'
+        )
+      end
+
+      it 'sorts by geo distance first' do
+        VCR.use_cassette(:geocode_search_form_postcode) do
+          expect(subject.sort.first).to eq({
+            _geo_distance: {
+              'advisers.location' => [-0.1085203, 51.5180697],
+              order: 'asc',
+              unit: 'miles'
+            }
+          })
+        end
+      end
+
+      it 'sorts by `registered_name` second' do
+        VCR.use_cassette(:geocode_search_form_postcode) do
+          expect(subject.sort.last).to eq('registered_name')
+        end
+      end
+    end
+  end
 end

--- a/spec/serializers/search_form_serializer_spec.rb
+++ b/spec/serializers/search_form_serializer_spec.rb
@@ -101,13 +101,11 @@ RSpec.describe SearchFormSerializer do
 
       it 'sorts by geo distance first' do
         VCR.use_cassette(:geocode_search_form_postcode) do
-          expect(subject.sort.first).to eq({
-            _geo_distance: {
-              'advisers.location' => [-0.1085203, 51.5180697],
-              order: 'asc',
-              unit: 'miles'
-            }
-          })
+          expect(subject.sort.first).to eq(_geo_distance: {
+                                             'advisers.location' => [-0.1085203, 51.5180697],
+                                             order: 'asc',
+                                             unit: 'miles'
+                                           })
         end
       end
 


### PR DESCRIPTION
> Currently, remote firms are shown alphabetically in the search results.  As most users do not click beyond the first results page, randomization of results would provide a fairer display to firms appearing at the end of the alphabet. 

Randomises the search results for phone/online only firm searches. Uses a randomly generated seed value for the search, which is persisted between requests for an individual user. This ensures that the user doesn't see the search results change between each request (if they go back/forward between the search results page).