### PR TITLE
[DEV APPROVED] Firm website URL format: ensure external links have protocol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'dough-ruby',
     ref: 'cf08913'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.0.95'
+gem 'mas-rad_core', '0.0.97'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,7 @@ GEM
     globalid (0.3.5)
       activesupport (>= 4.1.0)
     hike (1.2.3)
-    httpclient (2.7.0.1)
+    httpclient (2.7.1)
     i18n (0.7.0)
     jquery-rails (4.0.3)
       rails-dom-testing (~> 1.0)
@@ -109,7 +109,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.95)
+    mas-rad_core (0.0.97)
       active_model_serializers
       geocoder
       httpclient
@@ -214,7 +214,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    statsd-ruby (1.2.1)
+    statsd-ruby (1.3.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -251,7 +251,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
-  mas-rad_core (= 0.0.95)
+  mas-rad_core (= 0.0.97)
   pg
   pry-rails
   rails (~> 4.2)
@@ -267,4 +267,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -24,4 +24,12 @@ module FirmHelper
   def minimum_fixed_fee(firm_result)
     number_to_currency firm_result.minimum_fixed_fee, unit: '£', precision: 0
   end
+
+  def link_with_protocol(link)
+    if link.starts_with?('http') || link.starts_with?('https')
+      link
+    else
+      "http://#{link}"
+    end
+  end
 end

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -25,7 +25,7 @@ module FirmHelper
     number_to_currency firm_result.minimum_fixed_fee, unit: '£', precision: 0
   end
 
-  def link_with_protocol(link)
+  def ensure_external_link_has_protocol(link)
     if link =~ /^https?/
       link
     else

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -26,7 +26,7 @@ module FirmHelper
   end
 
   def link_with_protocol(link)
-    if link.starts_with?('http') || link.starts_with?('https')
+    if link =~ /^https?/
       link
     else
       "http://#{link}"

--- a/app/views/firms/partials/_firm_links.html.erb
+++ b/app/views/firms/partials/_firm_links.html.erb
@@ -19,7 +19,7 @@
 
   <% if website_address.present? %>
     <li>
-      <%= link_to website_address, class: 'outline-button', target: '_blank' do %>
+      <%= link_to link_with_protocol(website_address), class: 'outline-button', target: '_blank' do %>
         <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
         %><%= t('firms.show.website_address') %>
       <% end %>

--- a/app/views/firms/partials/_firm_links.html.erb
+++ b/app/views/firms/partials/_firm_links.html.erb
@@ -19,7 +19,7 @@
 
   <% if website_address.present? %>
     <li>
-      <%= link_to link_with_protocol(website_address), class: 'outline-button', target: '_blank' do %>
+      <%= link_to ensure_external_link_has_protocol(website_address), class: 'outline-button', target: '_blank' do %>
         <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
         %><%= t('firms.show.website_address') %>
       <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151103161642) do
+ActiveRecord::Schema.define(version: 20160205150033) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "accreditations", force: :cascade do |t|
     t.string   "name",                   null: false
@@ -31,15 +32,16 @@ ActiveRecord::Schema.define(version: 20151103161642) do
   add_index "accreditations_advisers", ["adviser_id", "accreditation_id"], name: "advisers_accreditations_index", unique: true, using: :btree
 
   create_table "advisers", force: :cascade do |t|
-    t.string   "reference_number",              null: false
-    t.string   "name",                          null: false
-    t.integer  "firm_id",                       null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.string   "postcode",         default: "", null: false
-    t.integer  "travel_distance",  default: 0,  null: false
+    t.string   "reference_number",                              null: false
+    t.string   "name",                                          null: false
+    t.integer  "firm_id",                                       null: false
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
+    t.string   "postcode",                      default: "",    null: false
+    t.integer  "travel_distance",               default: 0,     null: false
     t.float    "latitude"
     t.float    "longitude"
+    t.boolean  "bypass_reference_number_check", default: false
   end
 
   create_table "advisers_professional_bodies", id: false, force: :cascade do |t|
@@ -86,8 +88,6 @@ ActiveRecord::Schema.define(version: 20151103161642) do
     t.integer  "initial_meeting_duration_id"
     t.integer  "minimum_fixed_fee",                        default: 0
     t.integer  "parent_id"
-    t.float    "latitude"
-    t.float    "longitude"
     t.boolean  "retirement_income_products_flag",          default: false, null: false
     t.boolean  "pension_transfer_flag",                    default: false, null: false
     t.boolean  "long_term_care_flag",                      default: false, null: false

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -143,4 +143,24 @@ RSpec.describe FirmHelper, type: :helper do
       it { expect(helper.minimum_fixed_fee(firm)).to eq('£21') }
     end
   end
+
+  describe 'link_with_protocol' do
+    context 'when the link protocol is http or https' do
+      let(:http_link) { 'http://example.org' }
+      let(:https_link) { 'https://example.org' }
+
+      it 'remains unchanged' do
+        expect(helper.link_with_protocol(http_link)).to eq(http_link)
+        expect(helper.link_with_protocol(https_link)).to eq(https_link)
+      end
+    end
+
+    context 'when the link does not have a protocol' do
+      let(:link) { 'example.org' }
+
+      it 'adds the http protocol' do
+        expect(helper.link_with_protocol(link)).to eq('http://example.org')
+      end
+    end
+  end
 end

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -144,14 +144,14 @@ RSpec.describe FirmHelper, type: :helper do
     end
   end
 
-  describe 'link_with_protocol' do
+  describe 'ensure_external_link_has_protocol' do
     context 'when the link protocol is http or https' do
       let(:http_link) { 'http://example.org' }
       let(:https_link) { 'https://example.org' }
 
       it 'remains unchanged' do
-        expect(helper.link_with_protocol(http_link)).to eq(http_link)
-        expect(helper.link_with_protocol(https_link)).to eq(https_link)
+        expect(helper.ensure_external_link_has_protocol(http_link)).to eq(http_link)
+        expect(helper.ensure_external_link_has_protocol(https_link)).to eq(https_link)
       end
     end
 
@@ -159,7 +159,7 @@ RSpec.describe FirmHelper, type: :helper do
       let(:link) { 'example.org' }
 
       it 'adds the http protocol' do
-        expect(helper.link_with_protocol(link)).to eq('http://example.org')
+        expect(helper.ensure_external_link_has_protocol(link)).to eq('http://example.org')
       end
     end
   end


### PR DESCRIPTION
> if a firm enter their website address in the following format: www.mywebsite.com an error message displays stating the firm should enter the address using this format: http://www.mywebsite.com
>
> The sign-up process can be simplified by allowing firms to enter their website with this format:
> www.mywebsite.com

Related PRs https://github.com/moneyadviceservice/rad/pull/333 and https://github.com/moneyadviceservice/mas-rad_core/pull/139

For this repository this meant updating to the latest version of rad-core, and if the protocol is not in the website address, adding it to the link (this is so that links actually go to the external site).

## Before

Link would go to `/example.com`

## After

Link goes to `http://example.com`