### PR TITLE
Remove assertion on result order

### DIFF
--- a/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
+++ b/spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb
@@ -13,7 +13,6 @@ RSpec.feature 'Results page, consumer requires various types of advice over the 
       and_i_indicate_i_need_advice_on_various_topics
       when_i_submit_the_search
       then_i_am_shown_firms_that_provide_the_selected_types_of_advice
-      and_they_are_ordered_by_name
     end
   end
 
@@ -87,11 +86,5 @@ RSpec.feature 'Results page, consumer requires various types of advice over the 
   def then_i_am_shown_firms_that_provide_the_selected_types_of_advice
     expect(results_page).to be_displayed
     expect(results_page).to have_firms(count: 2)
-  end
-
-  def and_they_are_ordered_by_name
-    ordered_results = [@first, @second].map(&:registered_name).sort
-
-    expect(results_page.firm_names).to eql(ordered_results)
   end
 end


### PR DESCRIPTION
Due to the introduction of randomised search results, there's now an error that sometimes appears in spec/features/results_phone_or_online_filter_for_other_advice_types_spec.rb.

Essentially we no longer need to worry about which order they are returned in, so test adjusted accordingly.