### PR TITLE
Show firm languages on the RAD directory

### DIFF
--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -3,6 +3,13 @@ module FirmHelper
     firm.ethical_investing_flag || firm.sharia_investing_flag
   end
 
+  def firm_language_list(language_codes)
+    (['eng'] + language_codes)
+      .map(&LanguageList::LanguageInfo.method(:find))
+      .map(&:common_name)
+      .sort
+  end
+
   def type_of_advice_list_item(firm, type)
     return unless firm.includes_advice_type? type
     content_tag :li,

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -86,9 +86,10 @@
   </div>
 </div>
 
-<% if firm_has_investing_types?(firm) %>
-  <div class="l-firm__row">
-    <div class="l-1col firm__divider">
+<div class="l-firm__row">
+  <div class="l-1col firm__divider">
+
+    <% if firm_has_investing_types?(firm) %>
       <%= heading_tag(t('firms.show.panels.firm.services.investing.heading'), level: 4, class: 'investing__heading') %>
       <ul class="investing__list">
         <% if firm.ethical_investing_flag %>
@@ -102,9 +103,22 @@
           </li>
         <% end %>
       </ul>
-    </div>
+    <% end %>
+
+    <%= heading_tag(t('XXX Languages spoken by adivsers'), level: 4, class: 'investing__heading') %>
+    <ul class="investing__list">
+      <li class="investing__list-item">
+        English
+      </li>
+      <% firm.languages.each do |language_code| %>
+        <li class="investing__list-item">
+          <%= LanguageList::LanguageInfo.find(language_code).common_name %>
+        </li>
+      <% end %>
+    </ul>
+
   </div>
-<% end %>
+</div>
 
 <% if firm_has_qualifications_or_accreditations?(firm) %>
   <div class="l-firm__row">

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -105,7 +105,7 @@
       </ul>
     <% end %>
 
-    <%= heading_tag(t('XXX Languages spoken by adivsers'), level: 4, class: 'investing__heading') %>
+    <%= heading_tag(t('firms.show.panels.firm.services.languages'), level: 4, class: 'investing__heading') %>
     <ul class="investing__list">
       <% firm_language_list(firm.languages).sort.each do |language| %>
         <li class="investing__list-item">

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -107,12 +107,9 @@
 
     <%= heading_tag(t('XXX Languages spoken by adivsers'), level: 4, class: 'investing__heading') %>
     <ul class="investing__list">
-      <li class="investing__list-item">
-        English
-      </li>
-      <% firm.languages.each do |language_code| %>
+      <% firm_language_list(firm.languages).sort.each do |language| %>
         <li class="investing__list-item">
-          <%= LanguageList::LanguageInfo.find(language_code).common_name %>
+          <%= language %>
         </li>
       <% end %>
     </ul>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -78,6 +78,7 @@ cy:
               heading: Gwasanaethau Eraill
               ethical: Buddsoddiadau moesol
               sharia: Buddsoddiadau sy’n cydymffurfio â Shariah
+            languages: Ieithoedd a siaradir gan gynghorwyr
             qualifications:
               heading: Cymwysterau a feddir gan gynghorwyr y cwmni
         offices:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
               heading: Other services
               ethical: Ethical investments
               sharia: Shariah-compliant investments
+            languages: Languages spoken by advisers
             qualifications:
               heading: Qualifications held by firm advisers
         offices:

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -163,4 +163,24 @@ RSpec.describe FirmHelper, type: :helper do
       end
     end
   end
+
+  describe 'firm_language_list' do
+    context 'when passed an empty list' do
+      it 'returns only English' do
+        expect(firm_language_list([])).to eq(['English'])
+      end
+    end
+
+    context 'when passed list of 3 letter language codes' do
+      it 'returns English and the given codes translated to their common names' do
+        expect(firm_language_list(%w(spa por aae)))
+          .to match_array(['English', 'Spanish', 'Portuguese', 'Arbëreshë Albanian'])
+      end
+
+      it 'returns the list alphabetically sorted' do
+        expect(firm_language_list(%w(spa por aae)))
+          .to eq(['Arbëreshë Albanian', 'English', 'Portuguese', 'Spanish'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Desktop orientation with some languages selected

![screen shot 2016-02-11 at 14 48 34](https://cloud.githubusercontent.com/assets/306583/12980610/1934a5ca-d0d5-11e5-8cb4-e8e84d6d3cea.png)

# When no languages selected

![screen shot 2016-02-11 at 14 49 01](https://cloud.githubusercontent.com/assets/306583/12980611/193532d8-d0d5-11e5-9cbd-52a72bad93fb.png)

# Mobile

![screen shot 2016-02-11 at 14 49 30](https://cloud.githubusercontent.com/assets/306583/12980609/19321e90-d0d5-11e5-8d32-5beb89a98591.png)