### PR TITLE
State sort order on remote-advice search results page

### DIFF
--- a/app/assets/stylesheets/layouts/_results.scss
+++ b/app/assets/stylesheets/layouts/_results.scss
@@ -107,10 +107,29 @@
   }
 }
 
+.l-results__summary-row {
+  // This is necessary to collapse the far-left and far-right gutters
+  @include row(12);
+}
+
 .l-results__summary-text {
   @include body(16, 18);
   font-weight: 300;
-  margin: 0;
+
+  @include column(12);
+
+  @include respond-to($mq-m) {
+    @include column(6);
+  }
+}
+
+.l-results__summary-text--right {
+  margin-top: $baseline-unit;
+
+  @include respond-to($mq-m) {
+    text-align: right;
+    margin-top: 0;
+  }
 }
 
 .l-results__feedback {

--- a/app/views/search/partials/_results.html.erb
+++ b/app/views/search/partials/_results.html.erb
@@ -1,12 +1,19 @@
 <% if search_form.valid? %>
   <% if @result.firms.any? %>
     <div class="l-results__summary">
-      <p class="l-results__summary-text t-results-summary-text">
-        <%= t('search.summary_of_results.showing',
-              first_record: @result.first_record,
-              last_record: @result.last_record,
-              total_records: @result.total_records) %>
-      </p>
+      <div class="l-results__summary-row">
+        <div class="l-results__summary-text t-results-summary-text">
+          <%= t('search.summary_of_results.showing',
+                first_record: @result.first_record,
+                last_record: @result.last_record,
+                total_records: @result.total_records) %>
+        </div>
+        <% unless search_form.face_to_face? %>
+          <div class="l-results__summary-text l-results__summary-text--right">
+            <%= t('search.summary_of_results.order') %>
+          </div>
+        <% end %>
+      </div>
     </div>
   <% else %>
     <p><%= t('search.no_results_message') %></p>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -319,6 +319,7 @@ cy:
     no_results_message: Nid oes canlyniadau sy’n cyfateb â meini prawf eich chwiliad. Newidiwch eich meini prawf a rhoi cynnig arall arni.
     summary_of_results:
       showing: "Yn dangos %{first_record}-%{last_record} o %{total_records} cwmnïau"
+      order: Cwmnïau a gyflwynir heb fod mewn unrhyw drefn benodol
 
     result:
       adviser: mae gan gynghorydd

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -319,6 +319,7 @@ en:
     no_results_message: There are no results matching your search criteria. Please amend your criteria and try again.
     summary_of_results:
       showing: "Showing %{first_record}-%{last_record} of %{total_records} firms"
+      order: Firms presented in no particular order
 
     result:
       adviser: has an adviser


### PR DESCRIPTION
# What?

Add the line "Firms presented in no particular order" on the 'online or remote' search results page.

# Why?

Because the results are now returned in a random order to get rid of alphabetical sort bias.

# Screenshots

![screen shot 2016-02-12 at 15 30 27](https://cloud.githubusercontent.com/assets/306583/13011425/a4db146e-d19e-11e5-8ce6-99af88c6afcd.png)

![screen shot 2016-02-12 at 15 31 00](https://cloud.githubusercontent.com/assets/306583/13011424/a4daa038-d19e-11e5-9215-b09621ed3699.png)

![screen shot 2016-02-12 at 15 31 27](https://cloud.githubusercontent.com/assets/306583/13011426/a4dbeb1e-d19e-11e5-9f83-aa6abef087b6.png)
