### PR TITLE
Firm CSS refactor

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -37,6 +37,7 @@
 @import 'components/office';
 @import 'components/outline_button';
 @import 'components/pagination';
+@import 'components/plain_list';
 @import 'components/result';
 @import 'components/search_filter';
 @import 'components/types_of_advice';

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -39,7 +39,6 @@
 @import 'components/plain_list';
 @import 'components/result';
 @import 'components/search_filter';
-@import 'components/types_of_advice';
 @import 'components/video';
 
 @import 'print';

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -30,7 +30,6 @@
 @import 'components/education';
 @import 'components/firm';
 @import 'components/further_info';
-@import 'components/investing';
 @import 'components/keyword';
 @import 'components/list_numbers';
 @import 'components/locale';

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -27,6 +27,7 @@ $firm-border-color: $color-grey-pale;
 $firm-divider-color: $color-grey-pale;
 $firm-header-color: $color-green-primary;
 $firm-pin-color: $color-green-secondary;
+$firm-text-color: $color-black;
 
 $further-info-border-color: #3c97bf;
 $further-info-background-color: $color-blue-medium;
@@ -35,8 +36,6 @@ $further-info-text-color: $color-white;
 $further-info-icon-width: 20px;
 $further-info-icon-height: 20px;
 $further-info-background-color: $color-blue-medium;
-
-$investing-text-color: $color-black;
 
 $keyword-dividing-color: $color-porcelain;
 
@@ -72,5 +71,3 @@ $search-results-heading-color: $color-black;
 $search-filter-icon-color: $color-white;
 $search-filter-padding: $baseline-unit*4;
 $search-filter-label-color: $color-black;
-
-$types-of-advice-text-color: $color-black;

--- a/app/assets/stylesheets/components/_advice_method.scss
+++ b/app/assets/stylesheets/components/_advice_method.scss
@@ -25,5 +25,4 @@
 
 .advice-method__list-item{
   margin-bottom: 0;
-  color: $advice-method-text-color;
 }

--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -21,6 +21,11 @@
   margin-bottom: 0;
 }
 
+.firm__types-of-advice-heading {
+  @include body(16, 16);
+  margin-top: 0;
+}
+
 .firm__back-link {
   display: block;
   margin-bottom: $baseline-unit*2;

--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -17,6 +17,10 @@
   padding: $baseline-unit*2 $baseline-unit*4;
 }
 
+.firm__service-heading {
+  margin-bottom: 0;
+}
+
 .firm__back-link {
   display: block;
   margin-bottom: $baseline-unit*2;

--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -1,6 +1,8 @@
 .firm {
   @include clearfix();
   margin-bottom: $baseline-unit*6;
+
+  color: $firm-text-color;
 }
 
 .firm__details-heading {
@@ -13,7 +15,6 @@
   border-top-right-radius: 5px;
   border-top-left-radius: 5px;
   padding: $baseline-unit*2 $baseline-unit*4;
-  color: $color-black;
 }
 
 .firm__back-link {

--- a/app/assets/stylesheets/components/_investing.scss
+++ b/app/assets/stylesheets/components/_investing.scss
@@ -1,16 +1,3 @@
 .investing__heading {
   margin-bottom: 0;
 }
-
-.investing__list {
-  list-style: none;
-  margin-top: 0;
-  margin-bottom: $baseline-unit;
-  margin-left: 0;
-  padding-left: 0;
-}
-
-.investing__list-item{
-  margin-bottom: 0;
-  color: $investing-text-color;
-}

--- a/app/assets/stylesheets/components/_investing.scss
+++ b/app/assets/stylesheets/components/_investing.scss
@@ -1,3 +1,0 @@
-.investing__heading {
-  margin-bottom: 0;
-}

--- a/app/assets/stylesheets/components/_plain_list.scss
+++ b/app/assets/stylesheets/components/_plain_list.scss
@@ -1,0 +1,11 @@
+.plain_list {
+  list-style: none;
+  margin-top: 0;
+  margin-bottom: $baseline-unit;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.plain_list__item {
+  margin-bottom: 0;
+}

--- a/app/assets/stylesheets/components/_types_of_advice.scss
+++ b/app/assets/stylesheets/components/_types_of_advice.scss
@@ -2,15 +2,3 @@
   @include body(16, 16);
   margin-top: 0;
 }
-
-.types-of-advice__list {
-  list-style: none;
-  margin-top: 0;
-  margin-bottom: 0;
-  margin-left: 0;
-  padding-left: 0;
-}
-
-.types-of-advice__list-item{
-  margin-bottom: 0;
-}

--- a/app/assets/stylesheets/components/_types_of_advice.scss
+++ b/app/assets/stylesheets/components/_types_of_advice.scss
@@ -13,5 +13,4 @@
 
 .types-of-advice__list-item{
   margin-bottom: 0;
-  color: $types-of-advice-text-color;
 }

--- a/app/assets/stylesheets/components/_types_of_advice.scss
+++ b/app/assets/stylesheets/components/_types_of_advice.scss
@@ -1,4 +1,0 @@
-.types-of-advice__heading {
-  @include body(16, 16);
-  margin-top: 0;
-}

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -10,11 +10,11 @@ module FirmHelper
       .sort
   end
 
-  def type_of_advice_list_item(firm, type)
+  def type_of_advice_list_item(firm, type, style_classes)
     return unless firm.includes_advice_type? type
     content_tag :li,
                 I18n.t("firms.show.panels.firm.services.types_of_advice.#{type}"),
-                class: 'types-of-advice__list-item'
+                class: style_classes
   end
 
   def closest_adviser_text(firm_result)

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -24,7 +24,7 @@
 <%= heading_tag(t('firms.show.panels.firm.services.heading'), level: 3, class: 'l-firm__heading') %>
 <div class="l-2col l-firm__row">
   <div class="l-2col-even">
-    <%= heading_tag(t('firms.show.panels.firm.services.types_of_advice.heading'), level: 4, class: 'types-of-advice__heading') %>
+    <%= heading_tag(t('firms.show.panels.firm.services.types_of_advice.heading'), level: 4, class: 'firm__types-of-advice-heading') %>
 
     <ul class="plain_list">
       <%= type_of_advice_list_item firm, :retirement_income_products, 'plain_list__item' %>

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -26,13 +26,13 @@
   <div class="l-2col-even">
     <%= heading_tag(t('firms.show.panels.firm.services.types_of_advice.heading'), level: 4, class: 'types-of-advice__heading') %>
 
-    <ul class="types-of-advice__list" >
-      <%= type_of_advice_list_item firm, :retirement_income_products %>
-      <%= type_of_advice_list_item firm, :pension_transfer %>
-      <%= type_of_advice_list_item firm, :options_when_paying_for_care %>
-      <%= type_of_advice_list_item firm, :equity_release %>
-      <%= type_of_advice_list_item firm, :inheritance_tax_planning %>
-      <%= type_of_advice_list_item firm, :wills_and_probate %>
+    <ul class="plain_list">
+      <%= type_of_advice_list_item firm, :retirement_income_products, 'plain_list__item' %>
+      <%= type_of_advice_list_item firm, :pension_transfer, 'plain_list__item' %>
+      <%= type_of_advice_list_item firm, :options_when_paying_for_care, 'plain_list__item' %>
+      <%= type_of_advice_list_item firm, :equity_release, 'plain_list__item' %>
+      <%= type_of_advice_list_item firm, :inheritance_tax_planning, 'plain_list__item' %>
+      <%= type_of_advice_list_item firm, :wills_and_probate, 'plain_list__item' %>
     </ul>
 
     <%= heading_tag(t('firms.show.panels.firm.services.advice_methods.heading'), level: 4) %>

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -90,7 +90,7 @@
   <div class="l-1col firm__divider">
 
     <% if firm_has_investing_types?(firm) %>
-      <%= heading_tag(t('firms.show.panels.firm.services.investing.heading'), level: 4, class: 'investing__heading') %>
+      <%= heading_tag(t('firms.show.panels.firm.services.investing.heading'), level: 4, class: 'firm__service-heading') %>
       <ul class="plain_list">
         <% if firm.ethical_investing_flag %>
           <li class="plain_list__item">
@@ -105,7 +105,7 @@
       </ul>
     <% end %>
 
-    <%= heading_tag(t('firms.show.panels.firm.services.languages'), level: 4, class: 'investing__heading') %>
+    <%= heading_tag(t('firms.show.panels.firm.services.languages'), level: 4, class: 'firm__service-heading') %>
     <ul class="plain_list">
       <% firm_language_list(firm.languages).sort.each do |language| %>
         <li class="plain_list__item">

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -91,14 +91,14 @@
 
     <% if firm_has_investing_types?(firm) %>
       <%= heading_tag(t('firms.show.panels.firm.services.investing.heading'), level: 4, class: 'investing__heading') %>
-      <ul class="investing__list">
+      <ul class="plain_list">
         <% if firm.ethical_investing_flag %>
-          <li class="investing__list-item">
+          <li class="plain_list__item">
             <%= t('firms.show.panels.firm.services.investing.ethical') %>
           </li>
         <% end %>
         <% if firm.sharia_investing_flag %>
-          <li class="investing__list-item">
+          <li class="plain_list__item">
             <%= t('firms.show.panels.firm.services.investing.sharia') %>
           </li>
         <% end %>
@@ -106,9 +106,9 @@
     <% end %>
 
     <%= heading_tag(t('firms.show.panels.firm.services.languages'), level: 4, class: 'investing__heading') %>
-    <ul class="investing__list">
+    <ul class="plain_list">
       <% firm_language_list(firm.languages).sort.each do |language| %>
-        <li class="investing__list-item">
+        <li class="plain_list__item">
           <%= language %>
         </li>
       <% end %>

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe FirmHelper, type: :helper do
   end
 
   describe 'type_of_advice_list_item' do
-    subject { helper.type_of_advice_list_item(firm, :equity_release) }
+    subject { helper.type_of_advice_list_item(firm, :equity_release, 'list-item-style') }
 
     context 'it does not have the advice type' do
       before do
@@ -70,7 +70,7 @@ RSpec.describe FirmHelper, type: :helper do
       end
 
       it 'returns a list item element containing the corresponding translation' do
-        expect(subject).to eq('<li class="types-of-advice__list-item">Equity release</li>')
+        expect(subject).to eq('<li class="list-item-style">Equity release</li>')
       end
     end
   end


### PR DESCRIPTION
# Goals

* Set a default text colour for the firm details tab and reduce the number of places it gets redefined.
* Replace the `investing__*` styles with something more generic that makes sense to use on the language list too, `firm__service-heading`
* Create a general plain vertical list style that can be shared between the three places that use it.

# Screenshots

![screen shot 2016-02-12 at 16 22 25](https://cloud.githubusercontent.com/assets/306583/13013218/77538a64-d1a6-11e5-9980-248c8d1a8215.png)
