### PR TITLE
[DEV APPROVED] Drop the 'h' from the end of 'sharia' and the hyphen from the sentence

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -77,7 +77,7 @@ cy:
             investing:
               heading: Gwasanaethau Eraill
               ethical: Buddsoddiadau moesol
-              sharia: Buddsoddiadau sy’n cydymffurfio â Shariah
+              sharia: Buddsoddiadau sy’n cydymffurfio â Sharia
             languages: Ieithoedd ychwanegol a siaradir gan gynghorwyr
             qualifications:
               heading: Cymwysterau a feddir gan gynghorwyr y cwmni

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,7 +78,7 @@ en:
             investing:
               heading: Other services
               ethical: Ethical investments
-              sharia: Sharia-compliant investments
+              sharia: Sharia compliant investments
             languages: Additional languages spoken by advisers
             qualifications:
               heading: Qualifications held by firm advisers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,7 +78,7 @@ en:
             investing:
               heading: Other services
               ethical: Ethical investments
-              sharia: Shariah-compliant investments
+              sharia: Sharia-compliant investments
             languages: Additional languages spoken by advisers
             qualifications:
               heading: Qualifications held by firm advisers


### PR DESCRIPTION
MAS comms style dictates we use the version of the word _'sharia'_ without an _'h'_ at the end.

(Related PR to make RAD consistent too is here: https://github.com/moneyadviceservice/rad/pull/336)