### PR TITLE
fix header in ie8

### DIFF
--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -1,16 +1,12 @@
 .l-header {
   // override to force the header to be the correct height
   height: 73px;
+  display: block;
 }
 
-.l-header__logo {
-  @include column(8);
-  margin-top: 20px;
-
-
-  @include respond-to($mq-m) {
-    margin-top: 14px;
-  }
+.l-header .mas-logo {
+  width: 30%;
+  margin-top: $baseline-unit*2;
 }
 
 .l-header__locale {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -168,29 +168,7 @@
   <a class="skip-to-link" href="<%= t('skip_links.to_accessibility_link') %>"><%= t('skip_links.to_accessibility') %></a>
 
   <%= render 'shared/svg_icons' %>
-
-  <header class="l-header" role="banner">
-    <div class="l-constrained">
-
-      <div class="l-header__logo">
-        <a class="brand-logo" href="<%= t('mas_home_url') %>">
-          <span class="visually-hidden"><%= t('mas') %></span>
-          <svg title="<%= t('mas') %>" xmlns="http://www.w3.org/2000/svg" class="brand-logo__svg">
-            <use xlink:href="#brand-logo-<%= I18n.locale %>"></use>
-          </svg>
-          <div class="brand-logo__img brand-logo__img--<%= I18n.locale %>"></div>
-        </a>
-      </div>
-
-      <div class="l-header__locale locale">
-        <% if I18n.locale == I18n.default_locale %>
-          <%= link_to t('locales.cy'), params.merge(locale: 'cy', only_path: true), class: 'locale__link' %>
-        <% else %>
-          <%= link_to t('locales.en'), params.merge(locale: 'en', only_path: true), class: 'locale__link' %>
-        <% end %>
-      </div>
-    </div>
-  </header>
+  <%= render 'shared/header' %>
 
   <div class="l-context-bar">
     <div class="l-constrained">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,17 @@
+<header class="l-header" role="banner">
+  <div class="l-constrained">
+    <div class="mas-logo">
+      <a class="mas-logo__link" href="/">
+        <img alt="Money Advice Service" class="mas-logo__img" src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/logo-sprite-en-f13de50d8bcd8dbbabfbe56b441a8633.png">
+      </a>
+    </div>
+
+    <div class="l-header__locale locale">
+      <% if I18n.locale == I18n.default_locale %>
+        <%= link_to t('locales.cy'), params.merge(locale: 'cy', only_path: true), class: 'locale__link' %>
+      <% else %>
+        <%= link_to t('locales.en'), params.merge(locale: 'en', only_path: true), class: 'locale__link' %>
+      <% end %>
+    </div>
+  </div>
+</header>


### PR DESCRIPTION
Similiar to the PR raised for the self-service portion of RAD https://github.com/moneyadviceservice/rad/pull/375, the header was not appearing in IE8.

* Fixes the `<header>` element to properly display as a `block`.
* Refactors the header out into a shared partial so `rad` and `rad_consumer` share the same pattern for template abstraction.
* The main website and RAD use a PNG image for the main brand logo. RAD consumer was using an SVG, and subsequently not rendering correctly in IE8 after the header was correctly displaying as a block. Taking a look side by side, there was a difference between the two images. I've switched the image asset to be the PNG file the same as `frontend` for consistency.

*mismatch of png + svg between browsers*
![screen shot 2016-03-09 at 11 11 04](https://cloud.githubusercontent.com/assets/32398/13633588/e36c62e8-e5e7-11e5-863e-2d51c5b2966c.png)


*IE8 after fixes (self service left, directory right)*
![screen shot 2016-03-09 at 10 57 46](https://cloud.githubusercontent.com/assets/32398/13633410/b089f148-e5e6-11e5-8c54-0a31d82e5691.png)