### PR TITLE
[DEV APPROVED] [AWAITING WELSH TRANSLATIONS] Recently visited firms

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -37,6 +37,7 @@
 @import 'components/outline_button';
 @import 'components/pagination';
 @import 'components/plain_list';
+@import 'components/recently_viewed';
 @import 'components/result';
 @import 'components/search_filter';
 @import 'components/video';

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -50,6 +50,10 @@ $office-tick-fill-color: $color-green-secondary;
 $pagination-icon-color: #010202;
 $pagination-text-color: $color-black;
 
+$recently-viewed-firm-border-color: $color-grey-pale;
+$recently-viewed-firm-border-radius: 5px;
+$recently-viewed-firm-border-shadow-color: $color-grey-light;
+
 $result-shadow-color: $color-grey-light;
 $result-heading-color: $color-black;
 $result-text-color: $color-black;

--- a/app/assets/stylesheets/components/_recently_viewed.scss
+++ b/app/assets/stylesheets/components/_recently_viewed.scss
@@ -4,9 +4,9 @@
   margin-bottom: $baseline-unit*4;
   padding: $baseline-unit*2;
 
-  border: 1px solid $firm-border-color;
-  border-radius: $firm-border-radius;
-  box-shadow: 0 1px 0 0 $result-shadow-color;
+  border: 1px solid $recently-viewed-firm-border-color;
+  border-radius: $recently-viewed-firm-border-radius;
+  box-shadow: 0 1px 0 0 $recently-viewed-firm-border-shadow-color;
 
   color: $result-text-color;
 }

--- a/app/assets/stylesheets/components/_recently_viewed.scss
+++ b/app/assets/stylesheets/components/_recently_viewed.scss
@@ -1,0 +1,20 @@
+.recently-viewed__item {
+  @include clearfix();
+
+  margin-bottom: $baseline-unit*4;
+  padding: $baseline-unit*2;
+
+  border: 1px solid $firm-border-color;
+  border-radius: $firm-border-radius;
+  box-shadow: 0 1px 0 0 $result-shadow-color;
+
+  color: $result-text-color;
+}
+
+.recently-viewed__item__firm-name {
+  font-weight: bold;
+}
+
+.recently-viewed__item__adviser-distance {
+  font-weight: 300;
+}

--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -7,5 +7,14 @@ class FirmsController < ApplicationController
     @offices = Geosort.by_distance(@search_form.coordinates, @firm.offices)
 
     @latitude, @longitude = @search_form.coordinates
+
+    store_recently_visited_firm
+  end
+
+  private
+
+  def store_recently_visited_firm
+    visited_firms = RecentlyVisitedFirms.new(session)
+    visited_firms.store(@firm, request.original_url)
   end
 end

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -40,7 +40,9 @@ module FirmHelper
     end
   end
 
-  def recently_visited_firms
-    session[:recently_visited_firms]
+  def recently_visited_firms(current_firm)
+    session[:recently_visited_firms].reject do |f|
+      f['id'] == current_firm.id
+    end
   end
 end

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -17,8 +17,8 @@ module FirmHelper
                 class: style_classes
   end
 
-  def closest_adviser_text(firm_result)
-    I18n.t('search.result.miles_away', distance: format('%.1f', firm_result.closest_adviser.to_f))
+  def closest_adviser_text(distance)
+    I18n.t('search.result.miles_away', distance: format('%.1f', distance.to_f))
   end
 
   def minimum_pot_size_text(firm_result)
@@ -38,5 +38,9 @@ module FirmHelper
     else
       "http://#{link}"
     end
+  end
+
+  def recently_visited_firms
+    Firm.all
   end
 end

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -41,8 +41,8 @@ module FirmHelper
   end
 
   def recently_visited_firms(current_firm)
-    session[:recently_visited_firms].reject do |f|
-      f['id'] == current_firm.id
+    session[:recently_visited_firms].reject do |recently_visited_firm_hash|
+      recently_visited_firm_hash['id'] == current_firm.id
     end
   end
 end

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -41,6 +41,6 @@ module FirmHelper
   end
 
   def recently_visited_firms
-    Firm.all
+    session[:recently_visited_firms]
   end
 end

--- a/app/models/recently_visited_firms.rb
+++ b/app/models/recently_visited_firms.rb
@@ -8,19 +8,19 @@ class RecentlyVisitedFirms
     @store[:recently_visited_firms]
   end
 
-  def store(firm, url)
-    return if firm_already_present?(firm)
+  def store(firm_result, url)
+    return if firm_already_present?(firm_result)
     firms.pop if firms.length >= 3
-    firms.unshift('id' => firm.id,
-                  'name' => firm.name,
-                  'closest_adviser' => firm.closest_adviser,
-                  'face_to_face?' => firm.in_person_advice_methods.present?,
+    firms.unshift('id' => firm_result.id,
+                  'name' => firm_result.name,
+                  'closest_adviser' => firm_result.closest_adviser,
+                  'face_to_face?' => firm_result.in_person_advice_methods.present?,
                   'url' => url)
   end
 
   private
 
-  def firm_already_present?(firm)
-    firms.any? { |f| firm.id == f['id'] }
+  def firm_already_present?(firm_result)
+    firms.any? { |firm_hash| firm_result.id == firm_hash['id'] }
   end
 end

--- a/app/models/recently_visited_firms.rb
+++ b/app/models/recently_visited_firms.rb
@@ -14,6 +14,7 @@ class RecentlyVisitedFirms
     firms.unshift('id' => firm.id,
                   'name' => firm.name,
                   'closest_adviser' => firm.closest_adviser,
+                  'face_to_face?' => firm.in_person_advice_methods.present?,
                   'url' => url)
   end
 

--- a/app/models/recently_visited_firms.rb
+++ b/app/models/recently_visited_firms.rb
@@ -1,0 +1,25 @@
+class RecentlyVisitedFirms
+  def initialize(store)
+    @store = store
+    @store[:recently_visited_firms] ||= []
+  end
+
+  def firms
+    @store[:recently_visited_firms]
+  end
+
+  def store(firm, url)
+    return if firm_already_present?(firm)
+    firms.pop if firms.length >= 3
+    firms.unshift('id' => firm.id,
+                  'name' => firm.name,
+                  'closest_adviser' => firm.closest_adviser,
+                  'url' => url)
+  end
+
+  private
+
+  def firm_already_present?(firm)
+    firms.any? { |f| firm.id == f['id'] }
+  end
+end

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="firm__header">
   <%= heading_tag(@firm.name, level: 2, class: 'firm__name') %>
   <% if search_form.face_to_face? %>
-    <%= render partial: 'search/partials/firm/adviser_distance', object: @firm, as: :firm, locals: { search_form: search_form }%>
+    <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: @firm.closest_adviser }%>
   <% end %>
   <% if search_form.face_to_face? && @offices.present? %>
     <%= render partial: 'firms/partials/firm_links',

--- a/app/views/firms/partials/_profile_help.html.erb
+++ b/app/views/firms/partials/_profile_help.html.erb
@@ -1,3 +1,5 @@
+<%= render 'firms/partials/recently_visited', search_form: search_form %>
+
 <% if search_form.face_to_face? %>
 
   <%= heading_tag(t('firms.show.face_to_face.header'),

--- a/app/views/firms/partials/_recently_visited.html.erb
+++ b/app/views/firms/partials/_recently_visited.html.erb
@@ -3,7 +3,7 @@
                 class: 'l-firm__heading l-firm__heading--collapse') %>
 
 <ol class="l-results__list recently-viewed">
-  <% recently_visited_firms.each do |recently_visited_firm_hash| %>
+  <% recently_visited_firms(@firm).each do |recently_visited_firm_hash| %>
     <li class="recently-viewed__item t-firm">
       <%= link_to recently_visited_firm_hash['name'], recently_visited_firm_hash['url'], class: "recently-viewed__item__firm-name" %>
 

--- a/app/views/firms/partials/_recently_visited.html.erb
+++ b/app/views/firms/partials/_recently_visited.html.erb
@@ -5,13 +5,11 @@
 <ol class="l-results__list recently-viewed">
   <% recently_visited_firms.each do |firm| %>
     <li class="recently-viewed__item t-firm">
-      <%= link_to firm.registered_name, firm, class: "recently-viewed__item__firm-name" %>
+      <%= link_to firm['name'], firm['url'], class: "recently-viewed__item__firm-name" %>
 
       <% if search_form.face_to_face? %>
-        <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: @firm.closest_adviser, distance_class: 'recently-viewed__item__adviser-distance' }%>
+        <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: firm['closest_adviser'], distance_class: 'recently-viewed__item__adviser-distance' }%>
       <% end %>
     </li>
   <% end %>
 </ol>
-
-<%= session[:recently_visited_firms] %>

--- a/app/views/firms/partials/_recently_visited.html.erb
+++ b/app/views/firms/partials/_recently_visited.html.erb
@@ -1,0 +1,17 @@
+<%= heading_tag(t('firms.show.recently_visited.header'),
+                level: 3,
+                class: 'l-firm__heading l-firm__heading--collapse') %>
+
+<ol class="l-results__list recently-viewed">
+  <% recently_visited_firms.each do |firm| %>
+    <li class="recently-viewed__item t-firm">
+      <%= link_to firm.registered_name, firm, class: "recently-viewed__item__firm-name" %>
+
+      <% if search_form.face_to_face? %>
+        <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: @firm.closest_adviser, distance_class: 'recently-viewed__item__adviser-distance' }%>
+      <% end %>
+    </li>
+  <% end %>
+</ol>
+
+<%= session[:recently_visited_firms] %>

--- a/app/views/firms/partials/_recently_visited.html.erb
+++ b/app/views/firms/partials/_recently_visited.html.erb
@@ -1,15 +1,17 @@
-<%= heading_tag(t('firms.show.recently_visited.header'),
-                level: 3,
-                class: 'l-firm__heading l-firm__heading--collapse') %>
+<% if recently_visited_firms(@firm).present? %>
+  <%= heading_tag(t('firms.show.recently_visited.header'),
+                  level: 3,
+                  class: 'l-firm__heading l-firm__heading--collapse') %>
 
-<ol class="l-results__list recently-viewed">
-  <% recently_visited_firms(@firm).each do |recently_visited_firm_hash| %>
-    <li class="recently-viewed__item t-firm">
-      <%= link_to recently_visited_firm_hash['name'], recently_visited_firm_hash['url'], class: "recently-viewed__item__firm-name" %>
+  <ol class="l-results__list recently-viewed">
+    <% recently_visited_firms(@firm).each do |recently_visited_firm_hash| %>
+      <li class="recently-viewed__item t-firm">
+        <%= link_to recently_visited_firm_hash['name'], recently_visited_firm_hash['url'], class: "recently-viewed__item__firm-name" %>
 
-      <% if recently_visited_firm_hash['face_to_face?'] %>
-        <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: recently_visited_firm_hash['closest_adviser'], distance_class: 'recently-viewed__item__adviser-distance' }%>
-      <% end %>
-    </li>
-  <% end %>
-</ol>
+        <% if recently_visited_firm_hash['face_to_face?'] %>
+          <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: recently_visited_firm_hash['closest_adviser'], distance_class: 'recently-viewed__item__adviser-distance' }%>
+        <% end %>
+      </li>
+    <% end %>
+  </ol>
+<% end %>

--- a/app/views/firms/partials/_recently_visited.html.erb
+++ b/app/views/firms/partials/_recently_visited.html.erb
@@ -3,12 +3,12 @@
                 class: 'l-firm__heading l-firm__heading--collapse') %>
 
 <ol class="l-results__list recently-viewed">
-  <% recently_visited_firms.each do |firm| %>
+  <% recently_visited_firms.each do |recently_visited_firm_hash| %>
     <li class="recently-viewed__item t-firm">
-      <%= link_to firm['name'], firm['url'], class: "recently-viewed__item__firm-name" %>
+      <%= link_to recently_visited_firm_hash['name'], recently_visited_firm_hash['url'], class: "recently-viewed__item__firm-name" %>
 
-      <% if search_form.face_to_face? %>
-        <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: firm['closest_adviser'], distance_class: 'recently-viewed__item__adviser-distance' }%>
+      <% if recently_visited_firm_hash['face_to_face?'] %>
+        <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: recently_visited_firm_hash['closest_adviser'], distance_class: 'recently-viewed__item__adviser-distance' }%>
       <% end %>
     </li>
   <% end %>

--- a/app/views/search/partials/_firm.html.erb
+++ b/app/views/search/partials/_firm.html.erb
@@ -14,7 +14,7 @@
 
   <div class="result__information">
     <% if search_form.face_to_face? %>
-      <%= render partial: 'search/partials/firm/adviser_distance', object: firm, as: :firm %>
+      <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: firm.closest_adviser } %>
       <%= render partial: 'search/partials/firm/num_offices_advisers', object: firm, as: :firm %>
     <% end %>
     <div class="result__offerings-qualifications">

--- a/app/views/search/partials/firm/_adviser_distance.html.erb
+++ b/app/views/search/partials/firm/_adviser_distance.html.erb
@@ -1,5 +1,5 @@
-<div class="firm__adviser-distance t-distance_to_the_nearest_adviser">
+<div class="firm__adviser-distance <%= distance_class if local_assigns[:distance_class] %> t-distance_to_the_nearest_adviser">
   <%= svg_icon :map_pin, class: 'firm__adviser-distance-pin' %>
   <%= t('search.result.adviser') %>
-  <%= closest_adviser_text(firm) %>
+  <%= closest_adviser_text(distance) %>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -44,6 +44,8 @@ cy:
           part_one: "Rydych wedi dewis cwmni sy’n cynnig cyngor"
           part_two: dros y ffôn neu ar-lein yn unig
           part_three: "Mae hyn yn golygu llai o gostau i’r cwmni, a chostau llai i chi o ganlyniad. Y peth pwysig i’w gofio yw bod pob un o’r cynghorwyr sydd ar y cyfeirlyfr - waeth sut y cynigiant gyngor – wedi eu rheoleiddio ac yn cynnig yr un diogelwch."
+      recently_visited:
+        header: CwmnÏau eraill yr edrychoch arnynt
       website_address: Gwefan
       panels:
         firm:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,8 @@ en:
           part_one: You have chosen a firm that offers advice
           part_two: by telephone or online only
           part_three: This often means less overheads for them, and therefore lower costs for you. The important thing to remember is that all the advisers on the directory - no matter how they offer advice – are fully regulated and offer the same protection.
+      recently_visited:
+        header: Other firms you've viewed
       website_address: 'Website'
       panels:
         firm:

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe FirmsController, type: :controller do
     before do
       allow(FirmRepository).to receive(:new).and_return(firm_repository)
       allow(firm_repository).to receive(:search).and_return(double(firms: [firm_result_1, firm_result_2]))
+      allow_any_instance_of(RecentlyVisitedFirms).to receive(:store)
     end
 
     it 'successfully renders the show page' do
@@ -50,6 +51,13 @@ RSpec.describe FirmsController, type: :controller do
         get :show, id: firm.id, locale: :en, search_form: search_form_params
         expect(assigns(:latitude)).to eq(51.5180697)
         expect(assigns(:longitude)).to eq(-0.1085203)
+      end
+    end
+
+    it 'add requested firm in the recentyl_visited list' do
+      VCR.use_cassette(:geocode_search_form_postcode) do
+        expect_any_instance_of(RecentlyVisitedFirms).to receive(:store).with(firm_result_1, request.original_url)
+        get :show, id: firm.id, locale: :en, search_form: search_form_params
       end
     end
   end

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -76,29 +76,25 @@ RSpec.describe FirmHelper, type: :helper do
   end
 
   describe 'closest_adviser_text' do
-    before do
-      allow(firm).to receive(:closest_adviser).and_return(closest_adviser)
-    end
-
-    subject { helper.closest_adviser_text(firm) }
+    subject { helper.closest_adviser_text(distance) }
 
     context 'when the adviser is less than 1 mile away' do
-      let(:closest_adviser) { '0.1358' }
+      let(:distance) { '0.1358' }
       it { is_expected.to eq('0.1 miles away') }
     end
 
     context 'when the adviser is exactly 1 mile away' do
-      let(:closest_adviser) { '1.0' }
+      let(:distance) { '1.0' }
       it { is_expected.to eq('1.0 miles away') }
     end
 
     context 'when the adviser is greater than 1 mile away' do
-      let(:closest_adviser) { '1.12345678' }
+      let(:distance) { '1.12345678' }
       it { is_expected.to eq('1.1 miles away') }
     end
 
     context 'when the adviser is exactly 2 miles away' do
-      let(:closest_adviser) { '2.00000' }
+      let(:distance) { '2.00000' }
       it { is_expected.to eq('2.0 miles away') }
     end
   end

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -179,4 +179,37 @@ RSpec.describe FirmHelper, type: :helper do
       end
     end
   end
+
+  describe 'recently_visited_firms' do
+    it 'retrieves firms from the session' do
+      session[:recently_visited_firms] = [
+        { 'id' => 1 },
+        { 'id' => 2 },
+        { 'id' => 3 }
+      ]
+
+      current_firm = double('id' => 5)
+      expect(helper.recently_visited_firms(current_firm)).to eql([
+        { 'id' => 1 },
+        { 'id' => 2 },
+        { 'id' => 3 }
+      ])
+    end
+
+    context 'when viewing firm that is already in recently_visited_firms list' do
+      it 'removes the current_firm from the list being displayed' do
+        session[:recently_visited_firms] = [
+          { 'id' => 1 },
+          { 'id' => 2 },
+          { 'id' => 3 }
+        ]
+
+        current_firm = double('id' => 2)
+        expect(helper.recently_visited_firms(current_firm)).to eql([
+          { 'id' => 1 },
+          { 'id' => 3 }
+        ])
+      end
+    end
+  end
 end

--- a/spec/models/recently_visited_firms_spec.rb
+++ b/spec/models/recently_visited_firms_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe RecentlyVisitedFirms do
+  def firm_result(id, name: 'foobar', closest_adviser: 10)
+    FirmResult.new('_source' => { '_id' => id,
+                                  'registered_name' => name,
+                                  'advisers' => [],
+                                  'offices' => [] },
+                   'sort' => [closest_adviser])
+  end
+
+  describe 'recently visited firms' do
+    it 'stores the attributes' do
+      visited_firms = RecentlyVisitedFirms.new({})
+      visited_firms.store(firm_result(1, name: 'foobar', closest_adviser: 10), 'url')
+
+      expect(visited_firms.firms.first['id']).to eq(1)
+      expect(visited_firms.firms.first['name']).to eq('foobar')
+      expect(visited_firms.firms.first['closest_adviser']).to eq(10)
+      expect(visited_firms.firms.first['url']).to eq('url')
+    end
+
+    it 'stores firms ordered by most recent first' do
+      visited_firms = RecentlyVisitedFirms.new({})
+      visited_firms.store(firm_result(1), 'url')
+      visited_firms.store(firm_result(2), 'url')
+
+      expect(visited_firms.firms[0]['id']).to eq(2)
+      expect(visited_firms.firms[1]['id']).to eq(1)
+    end
+
+    it 'stores no duplicate firms' do
+      visited_firms = RecentlyVisitedFirms.new({})
+      visited_firms.store(firm_result(1), 'url')
+      visited_firms.store(firm_result(1), 'url')
+
+      expect(visited_firms.firms.length).to eq(1)
+    end
+
+    it 'stores no more than three firms' do
+      visited_firms = RecentlyVisitedFirms.new({})
+      visited_firms.store(firm_result(1), 'url')
+      visited_firms.store(firm_result(2), 'url')
+      visited_firms.store(firm_result(3), 'url')
+      visited_firms.store(firm_result(4), 'url')
+
+      expect(visited_firms.firms.map { |f| f['id'] }).to eq([4, 3, 2])
+    end
+  end
+end

--- a/spec/models/recently_visited_firms_spec.rb
+++ b/spec/models/recently_visited_firms_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe RecentlyVisitedFirms do
-  def firm_result(id, name: 'foobar', closest_adviser: 10, in_person_advice_methods: [1,2])
+  def firm_result(id, name: 'foobar', closest_adviser: 10, in_person_advice_methods: [1, 2])
     FirmResult.new('_source' => { '_id' => id,
                                   'registered_name' => name,
                                   'advisers' => [],

--- a/spec/models/recently_visited_firms_spec.rb
+++ b/spec/models/recently_visited_firms_spec.rb
@@ -1,9 +1,10 @@
 RSpec.describe RecentlyVisitedFirms do
-  def firm_result(id, name: 'foobar', closest_adviser: 10)
+  def firm_result(id, name: 'foobar', closest_adviser: 10, in_person_advice_methods: [1,2])
     FirmResult.new('_source' => { '_id' => id,
                                   'registered_name' => name,
                                   'advisers' => [],
-                                  'offices' => [] },
+                                  'offices' => [],
+                                  'in_person_advice_methods' => in_person_advice_methods },
                    'sort' => [closest_adviser])
   end
 
@@ -15,7 +16,17 @@ RSpec.describe RecentlyVisitedFirms do
       expect(visited_firms.firms.first['id']).to eq(1)
       expect(visited_firms.firms.first['name']).to eq('foobar')
       expect(visited_firms.firms.first['closest_adviser']).to eq(10)
+      expect(visited_firms.firms.first['face_to_face?']).to eq(true)
       expect(visited_firms.firms.first['url']).to eq('url')
+    end
+
+    context 'remote search' do
+      it 'stores the attributes' do
+        visited_firms = RecentlyVisitedFirms.new({})
+        visited_firms.store(firm_result(1, in_person_advice_methods: []), 'url')
+
+        expect(visited_firms.firms.first['face_to_face?']).to eq(false)
+      end
     end
 
     it 'stores firms ordered by most recent first' do


### PR DESCRIPTION
The PR is to add a list of Recently Visited Firms to the firm profile page.

![screen shot 2016-03-09 at 14 54 49](https://cloud.githubusercontent.com/assets/271354/13637300/e7e7c0e6-e606-11e5-9ac7-e8f879eff78f.png)

We were asked to display up to 3 previous firms.

If the firm was remote, not to display any distance info.

If currently viewing a firm that is in the list, then don't display it in the recently used firms list. Looking at the screenshot you can see we are viewing Test 01 Firm, however this is excluded from the Recently Viewed Firms.