### PR TITLE
update site assets to point to azure cdn

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,17 +16,17 @@
 
   <%= favicon_link_tag 'favicon.ico' %>
 
-  <link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/dough/assets/stylesheets/basic-d9d6ce6d2f790984f07aff8009901a29.css" media="screen" rel="stylesheet" />
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/basic-c6f0bc03dbe96c1cc8b39033ef43f72f.css" media="screen" rel="stylesheet" />
 
   <!--[if ( gte IE 7 ) & ( lte IE 8 ) & (!IEMobile) ]>
-  <link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/dough/assets/stylesheets/font_files-ff703b1d1494bc230ea71275731abdde.css" media="screen" rel="stylesheet" />
-  <link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/enhanced_fixed-ec3120ee9d7ff3a43394b5e68669525f.css" media="all" rel="stylesheet" />
-  <script src="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/html5shiv/dist/html5shiv-fee07e49a2d47f6e8f4f18d64a93ed5e.js"></script>
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/font_files-dcbb90df70309af8f6ceeaff0db9a5af.css" media="screen" rel="stylesheet" />
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_fixed-a29cec672e787c77b507eb06b8793384.css" media="all" rel="stylesheet" />
+  <script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/html5shiv/dist/html5shiv-ccc40f0f8bab80e89dfead2f99f6efdf.js"></script>
   <script>var responsiveStyle = false;</script>
   <![endif]-->
 
   <!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
-  <link href="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/enhanced_responsive-6ee3e18dd34ca469b3528cdcd0a411c4.css" media="only all" rel="stylesheet" />
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_responsive-8ca8df163c8e0afa00849c3bf43f19e8.css" media="only all" rel="stylesheet" />
   <script>var responsiveStyle = true;</script>
   <!--<![endif]-->
 
@@ -64,7 +64,7 @@
           };
 
           fonts = {
-            url: 'https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/dough/assets/stylesheets/font_base64-348ce9151db29f9a692d5d63f1b30b36.css',
+            url: 'https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/font_base64-28a0a91cf9910ceb5cc55a64841ae31a.css',
             cacheName: 'MAS.fonts',
             loadClass: 'wf-museosans-n4-active fontsLoaded',
             localstorage: undefined,
@@ -376,7 +376,7 @@
 
 <%= javascript_include_tag 'requirejs/require', data: { main: javascript_path('application') } %>
 
-<script src="https://6716c801720b2d014ddd-90dd74bb468e514261468bbc28ae4817.ssl.cf3.rackcdn.com/a/webchat-2c865ab48399b819f20cdd4525fc8b4f.js"></script>
+<script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/webchat-8a47f66c98f9abd3ce2afd710aff5891.js"></script>
 <script type='text/javascript'>
   sWODomain = 'www.moneyadviceservice.org.uk';
 


### PR DESCRIPTION
Replacing asset urls from Rackspace CDN, to the new Azure CDN. (Same as https://github.com/moneyadviceservice/rad/pull/380)

_NOTE:_ There are four PDF files that appear to have been manually uploaded to the CDN which are not being changed as part of this PR. @slaywell has updated a card in the MAS backlog to include changing these over as it involves some manual intervention to make it happen.
```
https://fedb5feb4c074be48b1a-7d2b925ab3869b76f1d9fad9b2ecd2bb.ssl.cf3.rackcdn.com/rad_expert_transcript.cy.pdf
https://fedb5feb4c074be48b1a-7d2b925ab3869b76f1d9fad9b2ecd2bb.ssl.cf3.rackcdn.com/rad_customer_transcript.cy.pdf`
https://fedb5feb4c074be48b1a-7d2b925ab3869b76f1d9fad9b2ecd2bb.ssl.cf3.rackcdn.com/rad_expert_transcript.en.pdf
https://fedb5feb4c074be48b1a-7d2b925ab3869b76f1d9fad9b2ecd2bb.ssl.cf3.rackcdn.com/rad_customer_transcript.en.pdf
```