### PR TITLE
Advisers tab on the firm profile page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'dough-ruby',
     ref: 'cf08913'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.0.105'
+gem 'mas-rad_core', '0.0.106'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.105)
+    mas-rad_core (0.0.106)
       active_model_serializers
       geocoder
       httpclient
@@ -253,7 +253,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
-  mas-rad_core (= 0.0.105)
+  mas-rad_core (= 0.0.106)
   pg
   pry-rails
   rails (~> 4.2.5.2)

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -20,6 +20,7 @@
 @import 'components/accreditation';
 @import 'components/advice_method';
 @import 'components/advice_reasons';
+@import 'components/adviser';
 @import 'components/advert';
 @import 'components/back_to_top';
 @import 'components/banner_list';

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -14,6 +14,7 @@
 @import 'layouts/glossary';
 @import 'layouts/firm';
 @import 'layouts/office';
+@import 'layouts/adviser';
 
 @import 'states/is_hidden';
 

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -5,6 +5,10 @@ $advice-method-heading-color: $color-green-secondary;
 $advice-method-svg-color: $color-green-secondary;
 $advice-method-text-color: $color-black;
 
+$adviser-border-color: $color-grey-pale;
+$adviser-text-color: $color-black;
+$adviser-tick-fill-color: $color-green-secondary;
+
 $advert-background-color: $color-grey-pale;
 $advert-padding: $baseline-unit*3;
 $advert-image-width: 200px;

--- a/app/assets/stylesheets/components/_adviser.scss
+++ b/app/assets/stylesheets/components/_adviser.scss
@@ -1,0 +1,36 @@
+.office {
+  @include clearfix();
+  border-top: 1px solid $office-border-color;
+  color: $office-text-color;
+  padding: $baseline-unit*4 0;
+}
+
+.office:first-of-type {
+  border: none;
+  padding-top: $baseline-unit*2;
+}
+
+.office__disabled-access {
+  margin-top: 0;
+
+  @include respond-to($mq-m) {
+    margin-top: $baseline-unit;
+  }
+}
+
+.office__tick-icon {
+  @include inline-block();
+  position: relative;
+  top: 5px;
+  margin-right: $baseline-unit;
+  width: 20px;
+  height: 20px;
+  fill: $office-tick-fill-color;
+}
+
+.office__show-more-trigger {
+  display: block;
+  border-top: 1px solid $office-border-color;
+  text-align: center;
+  padding-top: $baseline-unit*2;
+}

--- a/app/assets/stylesheets/components/_adviser.scss
+++ b/app/assets/stylesheets/components/_adviser.scss
@@ -1,36 +1,18 @@
-.office {
+.adviser {
   @include clearfix();
-  border-top: 1px solid $office-border-color;
-  color: $office-text-color;
+  border-top: 1px solid $adviser-border-color;
+  color: $adviser-text-color;
   padding: $baseline-unit*4 0;
 }
 
-.office:first-of-type {
+.adviser:first-of-type {
   border: none;
   padding-top: $baseline-unit*2;
 }
 
-.office__disabled-access {
-  margin-top: 0;
-
-  @include respond-to($mq-m) {
-    margin-top: $baseline-unit;
-  }
-}
-
-.office__tick-icon {
-  @include inline-block();
-  position: relative;
-  top: 5px;
-  margin-right: $baseline-unit;
-  width: 20px;
-  height: 20px;
-  fill: $office-tick-fill-color;
-}
-
-.office__show-more-trigger {
+.adviser__show-more-trigger {
   display: block;
-  border-top: 1px solid $office-border-color;
+  border-top: 1px solid $adviser-border-color;
   text-align: center;
   padding-top: $baseline-unit*2;
 }

--- a/app/assets/stylesheets/components/_firm.scss
+++ b/app/assets/stylesheets/components/_firm.scss
@@ -60,10 +60,6 @@
   }
 }
 
-.firm__content--remote {
-  padding: $baseline-unit*2 $baseline-unit*4;
-}
-
 .firm__name {
   margin: 0;
   color: $firm-header-color;

--- a/app/assets/stylesheets/layouts/_adviser.scss
+++ b/app/assets/stylesheets/layouts/_adviser.scss
@@ -1,0 +1,3 @@
+.l-adviser-col {
+  margin: 0;
+}

--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -5,6 +5,7 @@ class FirmsController < ApplicationController
 
     @firm  = result.firms.first
     @offices = Geosort.by_distance(@search_form.coordinates, @firm.offices)
+    @advisers = Geosort.by_distance(@search_form.coordinates, @firm.advisers)
 
     @latitude, @longitude = @search_form.coordinates
 

--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -5,7 +5,7 @@ class FirmsController < ApplicationController
 
     @firm  = result.firms.first
     @offices = Geosort.by_distance(@search_form.coordinates, @firm.offices)
-    @advisers = Geosort.by_distance(@search_form.coordinates, @firm.advisers)
+    @advisers = sort_advisers(@search_form, @firm.advisers)
 
     @latitude, @longitude = @search_form.coordinates
 
@@ -17,5 +17,15 @@ class FirmsController < ApplicationController
   def store_recently_visited_firm
     visited_firms = RecentlyVisitedFirms.new(session)
     visited_firms.store(@firm, request.original_url)
+  end
+
+  private
+
+  def sort_advisers(search_form, advisers)
+    if search_form.face_to_face?
+      Geosort.by_distance(search_form.coordinates, advisers)
+    else
+      advisers.sort { |a1, a2| a1.name <=> a2.name }
+    end
   end
 end

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -45,4 +45,8 @@ module FirmHelper
       recently_visited_firm_hash['id'] == current_firm.id
     end
   end
+
+  def trim_postcode(postcode)
+    postcode.split(' ').first
+  end
 end

--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -47,6 +47,6 @@ module FirmHelper
   end
 
   def trim_postcode(postcode)
-    postcode.split(' ').first
+    postcode.split.first
   end
 end

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -21,7 +21,7 @@
             </div>
           </div>
 
-          <% if adviser.qualification_ids.present? or adviser.accreditation_ids.present? %>
+          <% if adviser.qualification_ids.present? || adviser.accreditation_ids.present? %>
             <div>
               <% adviser.qualification_ids.each do |id| %>
                 <%= render_logo(id, :qualification) %>

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -1,0 +1,22 @@
+<div data-dough-component="ShowMore">
+  <% advisers.each do |adviser| %>
+    <div class="office t-office" data-dough-show-more-item>
+      <div class="l-2col">
+        <div class="l-2col-even l-office-col">
+          <div class="address t-address">
+            <%= adviser.name %>
+          </div>
+        </div>
+        <div class="l-2col-even l-office-col">
+          <div class="office__telephone">
+            <%= 'G63' %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <a data-dough-show-more-trigger class="office__show-more-trigger is-hidden" href="#">
+    <%= t('firms.show.panels.offices.show_more') %>
+  </a>
+</div>

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -1,7 +1,6 @@
 <div data-dough-component="ShowMore">
-  <% 6.times do %>
   <% advisers.each do |adviser| %>
-    <div class="adviser t-office" data-dough-show-more-item>
+    <div class="adviser t-adviser" data-dough-show-more-item>
       <div class="l-2col">
         <div class="l-2col-even l-adviser-col">
           <div class="address t-address">
@@ -10,12 +9,13 @@
         </div>
         <div class="l-2col-even l-adviser-col">
           <div>
+            <%= I18n.t('search.result.miles_away', distance: format('%.1f', adviser.distance)) %><br>
             <%= trim_postcode(adviser.postcode) %>
+            <%= render partial: 'search/partials/firm/qualifications', object: @firm, as: :firm %>
           </div>
         </div>
       </div>
     </div>
-  <% end %>
   <% end %>
 
   <a data-dough-show-more-trigger class="adviser__show-more-trigger is-hidden" href="#">

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -8,7 +8,7 @@
       <div class="adviser t-adviser" data-dough-show-more-item>
         <div class="l-2col">
           <div class="l-2col-even l-adviser-col">
-            <div class="address t-address">
+            <div class="address t-name">
               <%= adviser.name %>
             </div>
           </div>

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -9,7 +9,7 @@
         </div>
         <div class="l-2col-even l-office-col">
           <div class="office__telephone">
-            <%= 'G63' %>
+            <%= trim_postcode(adviser.postcode) %>
           </div>
         </div>
       </div>

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -10,7 +10,7 @@
         <div class="l-2col-even l-adviser-col">
           <div>
             <%= I18n.t('search.result.miles_away', distance: format('%.1f', adviser.distance)) %><br>
-            <%= trim_postcode(adviser.postcode) %>
+            <span class="t-postcode"><%= trim_postcode(adviser.postcode) %></span>
             <%= render partial: 'search/partials/firm/qualifications', object: @firm, as: :firm %>
           </div>
         </div>

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -1,22 +1,24 @@
 <div data-dough-component="ShowMore">
+  <% 6.times do %>
   <% advisers.each do |adviser| %>
-    <div class="office t-office" data-dough-show-more-item>
+    <div class="adviser t-office" data-dough-show-more-item>
       <div class="l-2col">
-        <div class="l-2col-even l-office-col">
+        <div class="l-2col-even l-adviser-col">
           <div class="address t-address">
             <%= adviser.name %>
           </div>
         </div>
-        <div class="l-2col-even l-office-col">
-          <div class="office__telephone">
+        <div class="l-2col-even l-adviser-col">
+          <div>
             <%= trim_postcode(adviser.postcode) %>
           </div>
         </div>
       </div>
     </div>
   <% end %>
+  <% end %>
 
-  <a data-dough-show-more-trigger class="office__show-more-trigger is-hidden" href="#">
+  <a data-dough-show-more-trigger class="adviser__show-more-trigger is-hidden" href="#">
     <%= t('firms.show.panels.offices.show_more') %>
   </a>
 </div>

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -11,9 +11,19 @@
           <div>
             <%= I18n.t('search.result.miles_away', distance: format('%.1f', adviser.distance)) %><br>
             <span class="t-postcode"><%= trim_postcode(adviser.postcode) %></span>
-            <%= render partial: 'search/partials/firm/qualifications', object: @firm, as: :firm %>
           </div>
         </div>
+
+        <% if adviser.qualification_ids.present? or adviser.accreditation_ids.present? %>
+          <div>
+            <% adviser.qualification_ids.each do |id| %>
+              <%= render_logo(id, :qualification) %>
+            <% end %>
+            <% adviser.accreditation_ids.each do |id| %>
+              <%= render_logo(id, :accreditation) %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -29,6 +29,6 @@
   <% end %>
 
   <a data-dough-show-more-trigger class="adviser__show-more-trigger is-hidden" href="#">
-    <%= t('firms.show.panels.offices.show_more') %>
+    <%= t('firms.show.panels.advisers.show_more') %>
   </a>
 </div>

--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -1,31 +1,39 @@
 <div data-dough-component="ShowMore">
-  <% advisers.each do |adviser| %>
+  <% if advisers.empty? %>
     <div class="adviser t-adviser" data-dough-show-more-item>
-      <div class="l-2col">
-        <div class="l-2col-even l-adviser-col">
-          <div class="address t-address">
-            <%= adviser.name %>
-          </div>
-        </div>
-        <div class="l-2col-even l-adviser-col">
-          <div>
-            <%= I18n.t('search.result.miles_away', distance: format('%.1f', adviser.distance)) %><br>
-            <span class="t-postcode"><%= trim_postcode(adviser.postcode) %></span>
-          </div>
-        </div>
-
-        <% if adviser.qualification_ids.present? or adviser.accreditation_ids.present? %>
-          <div>
-            <% adviser.qualification_ids.each do |id| %>
-              <%= render_logo(id, :qualification) %>
-            <% end %>
-            <% adviser.accreditation_ids.each do |id| %>
-              <%= render_logo(id, :accreditation) %>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
+      <%= t('firms.show.panels.advisers.none') %>
     </div>
+  <% else %>
+    <% advisers.each do |adviser| %>
+      <div class="adviser t-adviser" data-dough-show-more-item>
+        <div class="l-2col">
+          <div class="l-2col-even l-adviser-col">
+            <div class="address t-address">
+              <%= adviser.name %>
+            </div>
+          </div>
+          <div class="l-2col-even l-adviser-col">
+            <div>
+              <% if search_form.face_to_face? %>
+                <%= I18n.t('search.result.miles_away', distance: format('%.1f', adviser.distance)) %><br>
+                <span class="t-postcode"><%= trim_postcode(adviser.postcode) %></span>
+              <% end %>
+            </div>
+          </div>
+
+          <% if adviser.qualification_ids.present? or adviser.accreditation_ids.present? %>
+            <div>
+              <% adviser.qualification_ids.each do |id| %>
+                <%= render_logo(id, :qualification) %>
+              <% end %>
+              <% adviser.accreditation_ids.each do |id| %>
+                <%= render_logo(id, :accreditation) %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 
   <a data-dough-show-more-trigger class="adviser__show-more-trigger is-hidden" href="#">

--- a/app/views/firms/partials/_content.html.erb
+++ b/app/views/firms/partials/_content.html.erb
@@ -14,6 +14,12 @@
               (<%= @firm.total_offices %>)
             </a>
           </div>
+          <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
+            <a class="tab-selector__trigger" href="#panel-3" data-dough-tab-selector-trigger="3">
+              <%= t('firms.show.panels.advisers.heading') %>
+              (<%= @firm.total_offices %>)
+            </a>
+          </div>
         </div>
       </div>
 
@@ -24,6 +30,9 @@
       <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
         <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.offices.heading') %></h2>
         <%= render partial: 'firms/partials/offices', locals: { firm: @firm, offices: @offices } %>
+      </div>
+      <div class="tab-selector__target is-inactive" id="panel-3" data-dough-tab-selector-target="3">
+        <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.offices.heading') %></h2>
       </div>
     </div>
   <% else %>

--- a/app/views/firms/partials/_content.html.erb
+++ b/app/views/firms/partials/_content.html.erb
@@ -1,42 +1,46 @@
-<div class="firm__content <%= 'firm__content--remote' if @search_form.phone_or_online? %>">
-  <% if @search_form.face_to_face? %>
-    <div class="tab-selector" data-dough-component="TabSelector">
-      <div data-dough-tab-selector-triggers-outer class="l-firm__tab-triggers tab-selector__triggers-outer is-hidden-no-js">
-        <div data-dough-tab-selector-triggers-inner class="tab-selector__triggers-inner">
-          <div class="tab-selector__trigger-container is-active" data-dough-tab-selector-trigger-container>
-            <a class="tab-selector__trigger" href="#panel-1" data-dough-tab-selector-trigger="1">
-              <%= t('firms.show.panels.firm.heading') %>
-            </a>
-          </div>
+<div class="firm__content">
+  <div class="tab-selector" data-dough-component="TabSelector">
+    <div data-dough-tab-selector-triggers-outer class="l-firm__tab-triggers tab-selector__triggers-outer is-hidden-no-js">
+      <div data-dough-tab-selector-triggers-inner class="tab-selector__triggers-inner">
+        <div class="tab-selector__trigger-container is-active" data-dough-tab-selector-trigger-container>
+          <a class="tab-selector__trigger" href="#panel-1" data-dough-tab-selector-trigger="1">
+            <%= t('firms.show.panels.firm.heading') %>
+          </a>
+        </div>
+
+        <% if @search_form.face_to_face? %>
           <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
             <a class="tab-selector__trigger" href="#panel-2" data-dough-tab-selector-trigger="2">
               <%= t('firms.show.panels.offices.heading') %>
               (<%= @firm.total_offices %>)
             </a>
           </div>
-          <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
-            <a class="tab-selector__trigger" href="#panel-3" data-dough-tab-selector-trigger="3">
-              <%= t('firms.show.panels.advisers.heading') %>
-              (<%= @firm.total_advisers %>)
-            </a>
-          </div>
+        <% end %>
+
+        <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
+          <a class="tab-selector__trigger" href="#panel-3" data-dough-tab-selector-trigger="3">
+            <%= t('firms.show.panels.advisers.heading') %>
+            (<%= @firm.total_advisers %>)
+          </a>
         </div>
       </div>
+    </div>
 
-      <div class="tab-selector__target is-active" id="panel-1" data-dough-tab-selector-target="1">
-        <h2 class="tab-selector__target-heading firm__details-heading"><%= t('firms.show.panels.firm.heading') %></h2>
-        <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude, search_form: @search_form } %>
-      </div>
+    <div class="tab-selector__target is-active" id="panel-1" data-dough-tab-selector-target="1">
+      <h2 class="tab-selector__target-heading firm__details-heading"><%= t('firms.show.panels.firm.heading') %></h2>
+      <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude, search_form: @search_form } %>
+    </div>
+
+    <% if @search_form.face_to_face? %>
       <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
         <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.offices.heading') %></h2>
         <%= render partial: 'firms/partials/offices', locals: { firm: @firm, offices: @offices } %>
       </div>
-      <div class="tab-selector__target is-inactive" id="panel-3" data-dough-tab-selector-target="3">
-        <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.offices.heading') %></h2>
-        <%= render partial: 'firms/partials/advisers', locals: { firm: @firm, advisers: @advisers } %>
-      </div>
+    <% end %>
+
+    <div class="tab-selector__target is-inactive" id="panel-3" data-dough-tab-selector-target="3">
+      <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.advisers.heading') %></h2>
+      <%= render partial: 'firms/partials/advisers', locals: { firm: @firm, advisers: @advisers, search_form: @search_form } %>
     </div>
-  <% else %>
-    <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude, search_form: @search_form } %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/firms/partials/_content.html.erb
+++ b/app/views/firms/partials/_content.html.erb
@@ -17,7 +17,7 @@
           <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
             <a class="tab-selector__trigger" href="#panel-3" data-dough-tab-selector-trigger="3">
               <%= t('firms.show.panels.advisers.heading') %>
-              (<%= @firm.total_offices %>)
+              (<%= @firm.total_advisers %>)
             </a>
           </div>
         </div>
@@ -33,6 +33,7 @@
       </div>
       <div class="tab-selector__target is-inactive" id="panel-3" data-dough-tab-selector-target="3">
         <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.offices.heading') %></h2>
+        <%= render partial: 'firms/partials/advisers', locals: { firm: @firm, advisers: @advisers } %>
       </div>
     </div>
   <% else %>

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -2,7 +2,7 @@
   "name": "rad-consumer",
   "dependencies": {
     "dough": "<%= gem_path('dough-ruby') %>",
-    "yeast": "git://github.com/moneyadviceservice/yeast.git#master",
+    "yeast": "git://github.com/moneyadviceservice/yeast.git#a1dad29959e057aae926f92d61b55dd519bed812",
     "requirejs": "2.1.*",
     "jquery": "1.11.*",
     "requirejs-plugins": "~1.0.3"

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -2,7 +2,7 @@
   "name": "rad-consumer",
   "dependencies": {
     "dough": "<%= gem_path('dough-ruby') %>",
-    "yeast": "git://github.com/moneyadviceservice/yeast.git#a1dad29959e057aae926f92d61b55dd519bed812",
+    "yeast": "git://github.com/moneyadviceservice/yeast.git#master",
     "requirejs": "2.1.*",
     "jquery": "1.11.*",
     "requirejs-plugins": "~1.0.3"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -90,9 +90,9 @@ cy:
           disabled_access: Mynediad i’r anabl
           show_more: Dangos mwy o swyddfeydd
         advisers:
-          heading: TBC
-          none: TBC
-          show_more: TBC
+          heading: Cynghorwyr
+          none: Nid oes gwybodaeth am gynghorydd ar gael ar hyn o bryd.
+          show_more: Dangos rhagor o gynghorwyr
 
   skip_links:
     to_main: Skip to main content

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -89,6 +89,8 @@ cy:
           telephone: Ffôn
           disabled_access: Mynediad i’r anabl
           show_more: Dangos mwy o swyddfeydd
+        advisers:
+          heading: TBC
 
   skip_links:
     to_main: Skip to main content

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -91,6 +91,7 @@ cy:
           show_more: Dangos mwy o swyddfeydd
         advisers:
           heading: TBC
+          show_more: TBC
 
   skip_links:
     to_main: Skip to main content

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -91,6 +91,7 @@ cy:
           show_more: Dangos mwy o swyddfeydd
         advisers:
           heading: TBC
+          none: TBC
           show_more: TBC
 
   skip_links:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,7 @@ en:
           show_more: Show more offices
         advisers:
           heading: Advisers
+          none: No adviser information available at this time.
           show_more: Show more advisers
 
   skip_links:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,8 @@ en:
           telephone: Telephone
           disabled_access: Disabled access
           show_more: Show more offices
+        advisers:
+          heading: Advisers
 
   skip_links:
     to_main: Skip to main content

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,7 @@ en:
           show_more: Show more offices
         advisers:
           heading: Advisers
+          show_more: Show more advisers
 
   skip_links:
     to_main: Skip to main content

--- a/lib/geosort.rb
+++ b/lib/geosort.rb
@@ -1,14 +1,10 @@
 module Geosort
   def self.by_distance(initial_location, objects_with_location)
-    obj_distance_pairs = {}
-
     objects_with_location.each do |obj|
       distance = Geocoder::Calculations.distance_between(initial_location.to_a, obj.location.to_a)
-      obj_distance_pairs[obj] = distance
+      obj.distance = distance
     end
 
-    obj_distance_pairs
-      .sort_by { |_key, value| value }
-      .map { |pair| pair[0] }
+    objects_with_location.sort_by { |result| result.distance }
   end
 end

--- a/lib/geosort.rb
+++ b/lib/geosort.rb
@@ -5,6 +5,6 @@ module Geosort
       obj.distance = distance
     end
 
-    objects_with_location.sort_by { |result| result.distance }
+    objects_with_location.sort_by(&:distance)
   end
 end

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe FirmsController, type: :controller do
   let!(:firm) { FactoryGirl.create(:firm) }
   let(:search_form_params) { { 'advice_method' => SearchForm::ADVICE_METHOD_FACE_TO_FACE, 'postcode' => 'EC1N 2TD' } }
-  let(:firm_result_1) { double(offices: []) }
-  let(:firm_result_2) { double(offices: []) }
+  let(:firm_result_1) { double(offices: [], advisers: []) }
+  let(:firm_result_2) { double(offices: [], advisers: []) }
   let(:firm_repository) { double }
 
   describe 'GET #show' do

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe FirmsController, type: :controller do
 
     it "creates a search form with search_form params and the firm's id" do
       VCR.use_cassette(:geocode_search_form_postcode) do
-        allow(SearchForm).to receive(:new).and_return(double(to_query: {}, coordinates: [51.5, -0.1]))
+        allow(SearchForm).to receive(:new).and_return(
+          double(to_query: {}, coordinates: [51.5, -0.1], face_to_face?: true))
         get :show, id: firm.id, locale: :en, search_form: search_form_params
 
         expected_params = search_form_params.merge('firm_id' => firm.id.to_s)
@@ -33,7 +34,7 @@ RSpec.describe FirmsController, type: :controller do
 
     it 'assigns the search form' do
       VCR.use_cassette(:geocode_search_form_postcode) do
-        search_form = double(SearchForm, to_query: {}, coordinates: [51.5, -0.1])
+        search_form = double(SearchForm, to_query: {}, coordinates: [51.5, -0.1], face_to_face?: true)
         allow(SearchForm).to receive(:new).and_return(search_form)
 
         get :show, id: firm.id, locale: :en, search_form: search_form_params

--- a/spec/features/firm_profile_advisers_tab_spec.rb
+++ b/spec/features/firm_profile_advisers_tab_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Firm profile advisers tab', vcr: vcr_options_for_feature(:firm_pr
       given_firm_with_multiple_advisers_has_been_indexed
       and_i_perform_a_phone_or_online_search
       when_i_view_the_firm_profile
-      then_i_should_not_see_the_advisers_tab
+      then_i_should_see_a_number_of_remote_advisers_listed
     end
   end
 
@@ -67,6 +67,10 @@ RSpec.feature 'Firm profile advisers tab', vcr: vcr_options_for_feature(:firm_pr
 
   def then_i_should_see_a_number_of_advisers_listed
     expect(profile_page.advisers.length).to eq(3)
+  end
+
+  def then_i_should_see_a_number_of_remote_advisers_listed
+    expect(profile_page.advisers.length).to eq(1)
   end
 
   def and_they_should_be_ordered_by_closest_to_search_postcode

--- a/spec/features/firm_profile_advisers_tab_spec.rb
+++ b/spec/features/firm_profile_advisers_tab_spec.rb
@@ -20,17 +20,21 @@ RSpec.feature 'Firm profile advisers tab', vcr: vcr_options_for_feature(:firm_pr
       and_i_perform_a_phone_or_online_search
       when_i_view_the_firm_profile
       then_i_should_see_a_number_of_remote_advisers_listed
+      and_they_should_be_ordered_alphabetically
     end
   end
 
   def given_firm_with_multiple_advisers_has_been_indexed
     with_fresh_index! do
       @firm = create(:firm_without_advisers)
-      create(:adviser, firm: @firm, postcode: 'EC1N 2TD', latitude: 51.518148, longitude: -0.108013, travel_distance: 100)
-      create(:adviser, firm: @firm, postcode: 'EC4N 7BP', latitude: 51.511224, longitude: -0.087422, travel_distance: 100)
-      create(:adviser, firm: @firm, postcode: 'EC1N 7SS', latitude: 51.519144, longitude: -0.108927, travel_distance: 100)
+      create(:adviser, name: 'in the middle', firm: @firm, postcode: 'EC1N 2TD', latitude: 51.518148, longitude: -0.108013, travel_distance: 100)
+      create(:adviser, name: 'furthest', firm: @firm, postcode: 'EC4N 7BP', latitude: 51.511224, longitude: -0.087422, travel_distance: 100)
+      create(:adviser, name: 'nearest', firm: @firm, postcode: 'EC1N 7SS', latitude: 51.519144, longitude: -0.108927, travel_distance: 100)
 
-      @remote_firm = create(:firm, :with_remote_advice)
+      @remote_firm = create(:firm_without_advisers, :with_remote_advice)
+      create(:adviser, name: 'C', firm: @remote_firm, postcode: 'EC1N 7SS', latitude: 51.519144, longitude: -0.108927, travel_distance: 100)
+      create(:adviser, name: 'B', firm: @remote_firm, postcode: 'EC4N 7BP', latitude: 51.511224, longitude: -0.087422, travel_distance: 100)
+      create(:adviser, name: 'A', firm: @remote_firm, postcode: 'EC1N 2TD', latitude: 51.518148, longitude: -0.108013, travel_distance: 100)
     end
   end
 
@@ -70,11 +74,14 @@ RSpec.feature 'Firm profile advisers tab', vcr: vcr_options_for_feature(:firm_pr
   end
 
   def then_i_should_see_a_number_of_remote_advisers_listed
-    expect(profile_page.advisers.length).to eq(1)
+    expect(profile_page.advisers.length).to eq(3)
   end
 
   def and_they_should_be_ordered_by_closest_to_search_postcode
-    expect(profile_page.advisers.first.postcode.text).to eq('EC1N')
-    expect(profile_page.advisers.last.postcode.text).to eq('EC4N')
+    expect(profile_page.advisers.map { |a| a.name.text }).to eq(['nearest', 'in the middle', 'furthest'])
+  end
+
+  def and_they_should_be_ordered_alphabetically
+    expect(profile_page.advisers.map { |a| a.name.text }).to eq(%w(A B C))
   end
 end

--- a/spec/features/firm_profile_advisers_tab_spec.rb
+++ b/spec/features/firm_profile_advisers_tab_spec.rb
@@ -1,0 +1,76 @@
+RSpec.feature 'Firm profile advisers tab', vcr: vcr_options_for_feature(:firm_profile_advisers_tab) do
+  let(:landing_page) { LandingPage.new }
+  let(:results_page) { ResultsPage.new }
+  let(:profile_page) { ProfilePage.new }
+
+  scenario 'viewing advisers information for an "in-person" search' do
+    with_elastic_search! do
+      given_firm_with_multiple_advisers_has_been_indexed
+      and_i_perform_an_in_person_search
+      when_i_view_the_firm_profile
+      and_i_select_the_advisers_tab
+      then_i_should_see_a_number_of_advisers_listed
+      and_they_should_be_ordered_by_closest_to_search_postcode
+    end
+  end
+
+  scenario 'viewing advisers information for a "phone or online" search' do
+    with_elastic_search! do
+      given_firm_with_multiple_advisers_has_been_indexed
+      and_i_perform_a_phone_or_online_search
+      when_i_view_the_firm_profile
+      then_i_should_not_see_the_advisers_tab
+    end
+  end
+
+  def given_firm_with_multiple_advisers_has_been_indexed
+    with_fresh_index! do
+      @firm = create(:firm_without_advisers)
+      create(:adviser, firm: @firm, postcode: 'EC1N 2TD', latitude: 51.518148, longitude: -0.108013, travel_distance: 100)
+      create(:adviser, firm: @firm, postcode: 'EC4N 7BP', latitude: 51.511224, longitude: -0.087422, travel_distance: 100)
+      create(:adviser, firm: @firm, postcode: 'EC1N 7SS', latitude: 51.519144, longitude: -0.108927, travel_distance: 100)
+
+      @remote_firm = create(:firm, :with_remote_advice)
+    end
+  end
+
+  def and_i_perform_an_in_person_search
+    landing_page.load
+    landing_page.in_person.tap do |f|
+      f.postcode.set 'EC1N 7SS'
+      f.search.click
+    end
+
+    expect(results_page).to be_displayed
+  end
+
+  def and_i_perform_a_phone_or_online_search
+    landing_page.load
+    landing_page.search_filter.phone_or_online.set true
+    landing_page.search_filter.search.click
+
+    expect(results_page).to be_displayed
+  end
+
+  def when_i_view_the_firm_profile
+    results_page.firms.first.view_profile.click
+    expect(profile_page).to be_displayed
+  end
+
+  def and_i_select_the_advisers_tab
+    profile_page.adviser_tab.click
+  end
+
+  def then_i_should_not_see_the_advisers_tab
+    expect(profile_page).to_not have_adviser_tab
+  end
+
+  def then_i_should_see_a_number_of_advisers_listed
+    expect(profile_page.advisers.length).to eq(3)
+  end
+
+  def and_they_should_be_ordered_by_closest_to_search_postcode
+    expect(profile_page.advisers.first.postcode.text).to eq('EC1N')
+    expect(profile_page.advisers.last.postcode.text).to eq('EC4N')
+  end
+end

--- a/spec/fixtures/vcr_cassettes/firm_profile_advisers_tab.yml
+++ b/spec/fixtures/vcr_cassettes/firm_profile_advisers_tab.yml
@@ -1,0 +1,308 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%207SS,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 10 Mar 2016 15:48:34 GMT
+      Expires:
+      - Fri, 11 Mar 2016 15:48:34 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '523'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EC1N 7SS",
+                       "short_name" : "EC1N 7SS",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Leather Lane",
+                       "short_name" : "Leather Ln",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Greater London",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Leather Ln, London EC1N 7SS, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.5191588,
+                          "lng" : -0.1083228
+                       },
+                       "southwest" : {
+                          "lat" : 51.51883609999999,
+                          "lng" : -0.1101883
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.518938,
+                       "lng" : -0.1088302
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.5203464302915,
+                          "lng" : -0.107906569708498
+                       },
+                       "southwest" : {
+                          "lat" : 51.5176484697085,
+                          "lng" : -0.110604530291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJCxiBSkwbdkgR1X4vcWyDCDs",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 10 Mar 2016 15:48:34 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=EC1N%207SS,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 10 Mar 2016 15:48:56 GMT
+      Expires:
+      - Fri, 11 Mar 2016 15:48:56 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '523'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "EC1N 7SS",
+                       "short_name" : "EC1N 7SS",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Leather Lane",
+                       "short_name" : "Leather Ln",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "London",
+                       "short_name" : "London",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Greater London",
+                       "short_name" : "Greater London",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Leather Ln, London EC1N 7SS, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.5191588,
+                          "lng" : -0.1083228
+                       },
+                       "southwest" : {
+                          "lat" : 51.51883609999999,
+                          "lng" : -0.1101883
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.518938,
+                       "lng" : -0.1088302
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.5203464302915,
+                          "lng" : -0.107906569708498
+                       },
+                       "southwest" : {
+                          "lat" : 51.5176484697085,
+                          "lng" : -0.110604530291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJCxiBSkwbdkgR1X4vcWyDCDs",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 10 Mar 2016 15:48:56 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 10 Mar 2016 15:59:24 GMT
+      Expires:
+      - Fri, 11 Mar 2016 15:59:24 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '406'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "United Kingdom",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 60.8608663,
+                          "lng" : 33.9165549
+                       },
+                       "southwest" : {
+                          "lat" : 34.5626609,
+                          "lng" : -8.649357199999999
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.378051,
+                       "lng" : -3.435973
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 60.856553,
+                          "lng" : 1.7627096
+                       },
+                       "southwest" : {
+                          "lat" : 49.8699654,
+                          "lng" : -8.649357199999999
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJqZHHQhE7WgIReiWIMkOg-MQ",
+                 "types" : [ "country", "political" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Thu, 10 Mar 2016 15:59:24 GMT
+recorded_with: VCR 2.9.3

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -212,4 +212,10 @@ RSpec.describe FirmHelper, type: :helper do
       end
     end
   end
+
+  describe 'trim adviser postcode' do
+    it 'trims the adviser postcode to the characters prior to the space when there is a space' do
+      expect(helper.trim_postcode('EC1N 2TD')).to eq('EC1N')
+    end
+  end
 end

--- a/spec/lib/geosort_spec.rb
+++ b/spec/lib/geosort_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Geocode do
   class ExampleResult
+    attr_accessor :distance
     attr_reader :name, :location
 
     def initialize(name, lat, lon)

--- a/spec/support/adviser_section.rb
+++ b/spec/support/adviser_section.rb
@@ -1,0 +1,3 @@
+class AdviserSection < SitePrism::Section
+  element :postcode, '.t-postcode'
+end

--- a/spec/support/adviser_section.rb
+++ b/spec/support/adviser_section.rb
@@ -1,3 +1,4 @@
 class AdviserSection < SitePrism::Section
+  element :name, '.t-name'
   element :postcode, '.t-postcode'
 end

--- a/spec/support/profile_page.rb
+++ b/spec/support/profile_page.rb
@@ -2,9 +2,11 @@ class ProfilePage < SitePrism::Page
   set_url_matcher %r{/(en|cy)/firms}
 
   sections :offices, OfficeSection, '.t-office'
+  sections :advisers, AdviserSection, '.t-adviser'
 
   # the dough component re-writes the DOM so we can't attach a test class
   element :office_tab, '[data-dough-tab-selector-trigger="2"]'
+  element :adviser_tab, '[data-dough-tab-selector-trigger="3"]'
   element :telephone, '.t-telephone'
   element :email, '.t-email'
 end


### PR DESCRIPTION
![screen shot 2016-03-14 at 11 48 06](https://cloud.githubusercontent.com/assets/271354/13742169/a68a75bc-e9da-11e5-8aff-96831ff65333.png)

This PR adds a tab listing advisers on a firm's profile page. When doing a postcode search each adviser has the distance listed, and a stripped version of the postcode, and they are sorted nearest first. 

FYI there are a few welsh translations that we are waiting on.

When doing a remote search, no distance or postcode are listed and the advisers are sorted alphabetically. 

We also reuse a Dough component to 'Show more advisers'. The first 10 are visible when the page first appears.
