### PR TITLE
Add meta tag to force IE out of compatibility mode

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
 <html lang="<%= I18n.locale %>">
 <head>
   <title><%= page_tag('title_tag') %></title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="description" content="<%= page_tag('meta_tag_description') %>">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Requires IE to use the latest version, as per  `frontend`.

See http://twigstechtips.blogspot.co.uk/2010/03/css-ie8-meta-tag-to-disable.html