### PR TITLE
Pointing CDN to older version of assets on CDN

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,17 +17,17 @@
 
   <%= favicon_link_tag 'favicon.ico' %>
 
-  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/basic-c6f0bc03dbe96c1cc8b39033ef43f72f.css" media="screen" rel="stylesheet" />
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/basic-d9d6ce6d2f790984f07aff8009901a29.css" media="screen" rel="stylesheet" />
 
   <!--[if ( gte IE 7 ) & ( lte IE 8 ) & (!IEMobile) ]>
-  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/font_files-dcbb90df70309af8f6ceeaff0db9a5af.css" media="screen" rel="stylesheet" />
-  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_fixed-a29cec672e787c77b507eb06b8793384.css" media="all" rel="stylesheet" />
-  <script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/html5shiv/dist/html5shiv-ccc40f0f8bab80e89dfead2f99f6efdf.js"></script>
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/font_files-ff703b1d1494bc230ea71275731abdde.css" media="screen" rel="stylesheet" />
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_fixed-ec3120ee9d7ff3a43394b5e68669525f.css" media="all" rel="stylesheet" />
+  <script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/html5shiv/dist/html5shiv-fee07e49a2d47f6e8f4f18d64a93ed5e.js"></script>
   <script>var responsiveStyle = false;</script>
   <![endif]-->
 
   <!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
-  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_responsive-8ca8df163c8e0afa00849c3bf43f19e8.css" media="only all" rel="stylesheet" />
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_responsive-6ee3e18dd34ca469b3528cdcd0a411c4.css" media="only all" rel="stylesheet" />
   <script>var responsiveStyle = true;</script>
   <!--<![endif]-->
 


### PR DESCRIPTION
When migrating CDN we grabbed the wrong version of the assets.
This PR maintains the new CDN, and reverts to the old version of the assets.

Before:
![screen shot 2016-03-15 at 11 54 55](https://cloud.githubusercontent.com/assets/67151/13776983/147679f2-eaa5-11e5-8ad5-6be1a890b86c.png)

After:
![screen shot 2016-03-15 at 11 54 32](https://cloud.githubusercontent.com/assets/67151/13776988/1b46a680-eaa5-11e5-9f09-dcfbfd7b6eaa.png)
