### PR TITLE
Updating Accreditation and Qualification label and adding tooltip link

### DIFF
--- a/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
+++ b/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
@@ -1,6 +1,7 @@
 <fieldset class="search-filter__qualifications_accreditations search-filter__last-filter">
   <legend class="search-filter__label">
     <%= t('search.filter.qualifications_and_accreditations.heading') %>
+    <%= render 'shared/further_info_trigger', url: t('search.filter.qualifications_and_accreditations.url') %>
   </legend>
 
   <div class="form__group-item">

--- a/app/views/shared/_further_info_trigger.html.erb
+++ b/app/views/shared/_further_info_trigger.html.erb
@@ -1,4 +1,4 @@
-<a href="" class="further-info__trigger" data-further-info-trigger>
+<a href="<%= url if local_assigns[:url] %>" class="further-info__trigger" data-further-info-trigger>
   <svg class="svg-icon further-info__svg-icon" xmlns="http://www.w3.org/2000/svg" style="">
     <use xlink:href="#icon-tooltip"></use>
   </svg>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -307,7 +307,7 @@ cy:
         - text: Neu gallwch gysylltu â chynghorwyr sy’n cynnig y ddau opsiwn i gymharu gwasanaeth a chostau.
         - text: Y peth pwysig i’w gofio yw bod pob un o’r cynghorwyr ar Gyfeirlyfr y Gwasanaeth Cynghori Ariannol – waeth sut y cynigiant gyngor – wedi eu rheoleiddio.  Mae gennych union yr un diogelwch pa un ai’ch bod yn cwrdd â rhywun wyneb yn wyneb neu’n delio ag ef neu hi’n unigol dros y ffôn neu ar-lein.
       qualifications_and_accreditations:
-        heading: TBD
+        heading: 'Hoffwn gael cynghorydd sydd â’r achrediadau / cymwysterau canlynol:'
         label: Hidlo yn Ùl cymhwyster neu achrediad
         url: '/cy/glossary#chartered_fp'
       qualification:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -307,8 +307,9 @@ cy:
         - text: Neu gallwch gysylltu â chynghorwyr sy’n cynnig y ddau opsiwn i gymharu gwasanaeth a chostau.
         - text: Y peth pwysig i’w gofio yw bod pob un o’r cynghorwyr ar Gyfeirlyfr y Gwasanaeth Cynghori Ariannol – waeth sut y cynigiant gyngor – wedi eu rheoleiddio.  Mae gennych union yr un diogelwch pa un ai’ch bod yn cwrdd â rhywun wyneb yn wyneb neu’n delio ag ef neu hi’n unigol dros y ffôn neu ar-lein.
       qualifications_and_accreditations:
-        heading: Achrediadau a chymwysterau
+        heading: TBD
         label: Hidlo yn Ùl cymhwyster neu achrediad
+        url: '/cy/glossary#chartered_fp'
       qualification:
         ordinal:
           '3': Chartered Financial Planner

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -307,8 +307,9 @@ en:
           - text: Or you can contact advisers offering both options to compare service and costs.
           - text: The important thing to remember is that all the advisers on the Money Advice Service Directory – no matter how they offer advice – are fully regulated.  You have exactly the same protection whether you see someone face-to-face or deal with them exclusively by phone or online.
       qualifications_and_accreditations:
-        heading: Accreditations & qualifications
+        heading: 'I would like an adviser with the following accreditations / qualifications:'
         label: Filter by adviser qualification or accreditation
+        url: '/en/glossary/#chartered_fp'
       qualification:
         ordinal:
           '3': Chartered Financial Planner


### PR DESCRIPTION
This is a small PR to update the label on the Accreditation and Qualification filter and added a tooltip link.
We are currently waiting on the welsh translation to arrive.

Before: 
![screen shot 2016-03-15 at 15 36 04](https://cloud.githubusercontent.com/assets/67151/13783520/b31897a2-eac3-11e5-91d0-8908bb3f68ec.png)

After:
![screen shot 2016-03-15 at 15 35 45](https://cloud.githubusercontent.com/assets/67151/13783525/b8b4c5a0-eac3-11e5-83a3-d1fbe36f73fe.png)