### PR TITLE
Stop hiding current firm in recently viewed firms list

### DIFF
--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -40,10 +40,8 @@ module FirmHelper
     end
   end
 
-  def recently_visited_firms(current_firm)
-    session[:recently_visited_firms].reject do |recently_visited_firm_hash|
-      recently_visited_firm_hash['id'] == current_firm.id
-    end
+  def recently_visited_firms
+    session[:recently_visited_firms]
   end
 
   def trim_postcode(postcode)

--- a/app/views/firms/partials/_recently_visited.html.erb
+++ b/app/views/firms/partials/_recently_visited.html.erb
@@ -1,10 +1,10 @@
-<% if recently_visited_firms(@firm).present? %>
+<% if recently_visited_firms.present? %>
   <%= heading_tag(t('firms.show.recently_visited.header'),
                   level: 3,
                   class: 'l-firm__heading l-firm__heading--collapse') %>
 
   <ol class="l-results__list recently-viewed">
-    <% recently_visited_firms(@firm).each do |recently_visited_firm_hash| %>
+    <% recently_visited_firms.each do |recently_visited_firm_hash| %>
       <li class="recently-viewed__item t-firm">
         <%= link_to recently_visited_firm_hash['name'], recently_visited_firm_hash['url'], class: "recently-viewed__item__firm-name" %>
 

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -188,28 +188,11 @@ RSpec.describe FirmHelper, type: :helper do
         { 'id' => 3 }
       ]
 
-      current_firm = double('id' => 5)
-      expect(helper.recently_visited_firms(current_firm)).to eql([
+      expect(helper.recently_visited_firms).to eql([
         { 'id' => 1 },
         { 'id' => 2 },
         { 'id' => 3 }
       ])
-    end
-
-    context 'when viewing firm that is already in recently_visited_firms list' do
-      it 'removes the current_firm from the list being displayed' do
-        session[:recently_visited_firms] = [
-          { 'id' => 1 },
-          { 'id' => 2 },
-          { 'id' => 3 }
-        ]
-
-        current_firm = double('id' => 2)
-        expect(helper.recently_visited_firms(current_firm)).to eql([
-          { 'id' => 1 },
-          { 'id' => 3 }
-        ])
-      end
     end
   end
 


### PR DESCRIPTION
When visiting a firm profile page, we were excluding that firm form the recently visited firm list

![screen shot 2016-03-15 at 16 44 58](https://cloud.githubusercontent.com/assets/67151/13785909/62388e00-eacd-11e5-9a15-bf32bdae8ed9.png)

As the list is only shown on firm profile pages this means that at most only 2 firms will be displayed, when we are supposed to display 3.

This PR removes the logic that hides the current firm from the list.

![screen shot 2016-03-15 at 16 44 39](https://cloud.githubusercontent.com/assets/67151/13785949/882f9284-eacd-11e5-882a-5cbb0b529f85.png)
