### PR TITLE
[WIP] Fixes cookie overflow issue with recently visited firms

### DIFF
--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -15,8 +15,15 @@ class FirmsController < ApplicationController
   private
 
   def store_recently_visited_firm
+    url = firm_path(
+      params[:id], search_form: {
+        advice_method: params['search_form']['advice_method'],
+        pension_pot_size: params['search_form']['pension_pot_size'],
+        postcode: params['search_form']['postcode']
+      }
+    )
     visited_firms = RecentlyVisitedFirms.new(session)
-    visited_firms.store(@firm, request.original_url)
+    visited_firms.store(@firm, url)
   end
 
   private

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -92,17 +92,19 @@ RSpec.describe FirmsController, type: :controller do
       end
     end
 
-    it 'add requested firm in the recently_visited list' do
-      VCR.use_cassette(:geocode_search_form_postcode) do
-        url = firm_path(
-          firm.id, search_form: {
-            advice_method: search_form_params['advice_method'],
-            pension_pot_size: search_form_params['pension_pot_size'],
-            postcode: search_form_params['postcode']
-          }
-        )
-        expect_any_instance_of(RecentlyVisitedFirms).to receive(:store).with(firm_result_1, url)
-        get :show, id: firm.id, locale: :en, search_form: search_form_params
+    context 'recently_visited list' do
+      it 'adds firm in the recently_visited list AND cuts down the URL so as not to exceed cookie limit of 4k' do
+        VCR.use_cassette(:geocode_search_form_postcode) do
+          url = firm_path(
+            firm.id, search_form: {
+              advice_method: search_form_params['advice_method'],
+              pension_pot_size: search_form_params['pension_pot_size'],
+              postcode: search_form_params['postcode']
+            }
+          )
+          expect_any_instance_of(RecentlyVisitedFirms).to receive(:store).with(firm_result_1, url)
+          get :show, id: firm.id, locale: :en, search_form: search_form_params
+        end
       end
     end
   end

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -1,11 +1,18 @@
 RSpec.describe FirmsController, type: :controller do
   let!(:firm) { FactoryGirl.create(:firm) }
-  let(:search_form_params) { { 'advice_method' => SearchForm::ADVICE_METHOD_FACE_TO_FACE, 'postcode' => 'EC1N 2TD' } }
   let(:offices) { [] }
   let(:advisers) { [] }
   let(:firm_result_1) { double(offices: offices, advisers: advisers) }
   let(:firm_result_2) { double(offices: offices, advisers: advisers) }
   let(:firm_repository) { double }
+
+  let(:search_form_params) do
+    {
+      'advice_method' => SearchForm::ADVICE_METHOD_FACE_TO_FACE,
+      'pension_pot_size' => 'any',
+      'postcode' => 'EC1N 2TD'
+    }
+  end
 
   describe 'GET #show' do
     before do
@@ -85,9 +92,16 @@ RSpec.describe FirmsController, type: :controller do
       end
     end
 
-    it 'add requested firm in the recentyl_visited list' do
+    it 'add requested firm in the recently_visited list' do
       VCR.use_cassette(:geocode_search_form_postcode) do
-        expect_any_instance_of(RecentlyVisitedFirms).to receive(:store).with(firm_result_1, request.original_url)
+        url = firm_path(
+          firm.id, search_form: {
+            advice_method: search_form_params['advice_method'],
+            pension_pot_size: search_form_params['pension_pot_size'],
+            postcode: search_form_params['postcode']
+          }
+        )
+        expect_any_instance_of(RecentlyVisitedFirms).to receive(:store).with(firm_result_1, url)
         get :show, id: firm.id, locale: :en, search_form: search_form_params
       end
     end


### PR DESCRIPTION
So we were storing quite long URLs in the session cookie as part of the recently visited firms feature #278. This led to cookie overflow issues because the file size exceeded 4k. 

This PR strips the URL so that we only store the bare minimum we need to link to the firm profile page, which reduces the cookie file size.

Another solution would be to switch to https://github.com/rails/activerecord-session_store but that feels like a much bigger task. Or use a URL shortener :smile: 