### PR TITLE
Fix/recently viewed firms should store both locale urls

### DIFF
--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -19,10 +19,7 @@ class FirmsController < ApplicationController
   end
 
   def store_recently_visited_firm
-    english_search = search_path(search_form: params[:search_form], locale: 'en')
-    welsh_search = search_path(search_form: params[:search_form], locale: 'cy')
-
-    rad_consumer_session.store(@firm, request.original_url, english_search, welsh_search)
+    rad_consumer_session.store(@firm, request.original_url, params)
   end
 
   def sort_advisers(search_form, advisers)

--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -19,7 +19,10 @@ class FirmsController < ApplicationController
   end
 
   def store_recently_visited_firm
-    rad_consumer_session.store(@firm, request.original_url, search_path(search_form: params[:search_form]))
+    english_search = search_path(search_form: params[:search_form], locale: 'en')
+    welsh_search = search_path(search_form: params[:search_form], locale: 'cy')
+
+    rad_consumer_session.store(@firm, request.original_url, english_search, welsh_search)
   end
 
   def sort_advisers(search_form, advisers)

--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -19,7 +19,7 @@ class FirmsController < ApplicationController
   end
 
   def store_recently_visited_firm
-    rad_consumer_session.store(@firm, request.original_url, params)
+    rad_consumer_session.store(@firm, params)
   end
 
   def sort_advisers(search_form, advisers)

--- a/app/models/rad_consumer_session.rb
+++ b/app/models/rad_consumer_session.rb
@@ -10,8 +10,8 @@ class RadConsumerSession
     @store[:recently_visited_firms]
   end
 
-  def search_results_url
-    @store['locale_to_search_path_mappings']
+  def search_results_url(locale)
+    @store['locale_to_search_path_mappings'][locale.to_s]
   end
 
   def store(firm_result, params)

--- a/app/models/rad_consumer_session.rb
+++ b/app/models/rad_consumer_session.rb
@@ -12,7 +12,7 @@ class RadConsumerSession
     @store['most_recent_search_url']
   end
 
-  def store(firm_result, profile_url, most_recent_search_url)
+  def store(firm_result, profile_url, english_search_url, welsh_search_url)
     return if firm_already_present?(firm_result)
     firms.pop if firms.length >= 3
     firms.unshift('id' => firm_result.id,
@@ -21,7 +21,10 @@ class RadConsumerSession
                   'face_to_face?' => firm_result.in_person_advice_methods.present?,
                   'profile_url' => profile_url)
 
-    @store['most_recent_search_url'] = most_recent_search_url
+    @store['most_recent_search_url'] = {
+      'en' => english_search_url,
+      'cy' => welsh_search_url
+    }
   end
 
   private

--- a/app/models/rad_consumer_session.rb
+++ b/app/models/rad_consumer_session.rb
@@ -1,4 +1,6 @@
 class RadConsumerSession
+  include Rails.application.routes.url_helpers
+
   def initialize(store)
     @store = store
     @store[:recently_visited_firms] ||= []
@@ -12,7 +14,7 @@ class RadConsumerSession
     @store['most_recent_search_url']
   end
 
-  def store(firm_result, profile_url, english_search_url, welsh_search_url)
+  def store(firm_result, profile_url, params)
     return if firm_already_present?(firm_result)
     firms.pop if firms.length >= 3
     firms.unshift('id' => firm_result.id,
@@ -22,12 +24,16 @@ class RadConsumerSession
                   'profile_url' => profile_url)
 
     @store['most_recent_search_url'] = {
-      'en' => english_search_url,
-      'cy' => welsh_search_url
+      'en' => search_path_for(params, 'en'),
+      'cy' => search_path_for(params, 'cy')
     }
   end
 
   private
+
+  def search_path_for(params, locale)
+    search_path(search_form: params[:search_form], locale: locale)
+  end
 
   def firm_already_present?(firm_result)
     firms.any? { |firm_hash| firm_result.id == firm_hash['id'] }

--- a/app/models/rad_consumer_session.rb
+++ b/app/models/rad_consumer_session.rb
@@ -11,31 +11,42 @@ class RadConsumerSession
   end
 
   def search_results_url
-    @store['most_recent_search_url']
+    @store['locale_to_search_path_mappings']
   end
 
-  def store(firm_result, profile_url, params)
+  def store(firm_result, params)
     return if firm_already_present?(firm_result)
     firms.pop if firms.length >= 3
     firms.unshift('id' => firm_result.id,
                   'name' => firm_result.name,
                   'closest_adviser' => firm_result.closest_adviser,
                   'face_to_face?' => firm_result.in_person_advice_methods.present?,
-                  'profile_url' => profile_url)
+                  'profile_path' => locale_to_profile_path_mappings(params))
 
-    @store['most_recent_search_url'] = {
+    @store['locale_to_search_path_mappings'] = locale_to_search_path_mappings(params)
+  end
+
+  private
+
+  def firm_already_present?(firm_result)
+    firms.any? { |firm_hash| firm_result.id == firm_hash['id'] }
+  end
+
+  def locale_to_search_path_mappings(params)
+    {
       'en' => search_path_for(params, 'en'),
       'cy' => search_path_for(params, 'cy')
     }
   end
 
-  private
-
   def search_path_for(params, locale)
     search_path(search_form: params[:search_form], locale: locale)
   end
 
-  def firm_already_present?(firm_result)
-    firms.any? { |firm_hash| firm_result.id == firm_hash['id'] }
+  def locale_to_profile_path_mappings(params)
+    {
+      'en' => firm_path(params['id'], search_form: params[:search_form], locale: 'en'),
+      'cy' => firm_path(params['id'], search_form: params[:search_form], locale: 'cy')
+    }
   end
 end

--- a/app/views/firms/partials/_recently_visited.html.erb
+++ b/app/views/firms/partials/_recently_visited.html.erb
@@ -6,7 +6,7 @@
   <ol class="l-results__list recently-viewed">
     <% recently_visited_firms.each do |recently_visited_firm_hash| %>
       <li class="recently-viewed__item t-firm">
-        <%= link_to recently_visited_firm_hash['name'], recently_visited_firm_hash['profile_url'], class: "recently-viewed__item__firm-name" %>
+        <%= link_to recently_visited_firm_hash['name'], recently_visited_firm_hash['profile_path'][I18n.locale.to_s], class: "recently-viewed__item__firm-name" %>
 
         <% if recently_visited_firm_hash['face_to_face?'] %>
           <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: recently_visited_firm_hash['closest_adviser'], distance_class: 'recently-viewed__item__adviser-distance' }%>

--- a/app/views/firms/show.html.erb
+++ b/app/views/firms/show.html.erb
@@ -3,7 +3,7 @@
     <div class="l-1col">
       <%= heading_tag(t('page_title'), level: 1, class: 'l-firm__profile-heading') %>
       <span class="firm__back-link">
-        <%= link_to @rad_consumer_session.search_results_url[I18n.locale.to_s] do %>
+        <%= link_to @rad_consumer_session.search_results_url(I18n.locale) do %>
           <%= svg_icon 'pagination-prev', class: 'firm__back-icon'
           %><%= t('firms.show.go_back') %>
         <% end %>

--- a/app/views/firms/show.html.erb
+++ b/app/views/firms/show.html.erb
@@ -3,7 +3,7 @@
     <div class="l-1col">
       <%= heading_tag(t('page_title'), level: 1, class: 'l-firm__profile-heading') %>
       <span class="firm__back-link">
-        <%= link_to @rad_consumer_session.search_results_url do %>
+        <%= link_to @rad_consumer_session.search_results_url[I18n.locale.to_s] do %>
           <%= svg_icon 'pagination-prev', class: 'firm__back-icon'
           %><%= t('firms.show.go_back') %>
         <% end %>

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe FirmsController, type: :controller do
         }
 
         expect_any_instance_of(RadConsumerSession)
-          .to receive(:store).with(firm_result_1, request.original_url, expected_params)
+          .to receive(:store).with(firm_result_1, expected_params)
         get :show, id: firm.id, locale: :en, search_form: search_form_params
       end
     end

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -87,10 +87,18 @@ RSpec.describe FirmsController, type: :controller do
 
     it 'add requested firm in the recentyl_visited list' do
       VCR.use_cassette(:geocode_search_form_postcode) do
-        english_search_url = '/en/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
-        welsh_search_url = '/cy/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        expected_params = {
+          search_form: {
+            'advice_method' => 'face_to_face', 'postcode' => 'EC1N 2TD'
+          },
+          'id' => firm.id.to_s,
+          'locale' => 'en',
+          'controller' => 'firms',
+          'action' => 'show'
+        }
+
         expect_any_instance_of(RadConsumerSession)
-          .to receive(:store).with(firm_result_1, request.original_url, english_search_url, welsh_search_url)
+          .to receive(:store).with(firm_result_1, request.original_url, expected_params)
         get :show, id: firm.id, locale: :en, search_form: search_form_params
       end
     end

--- a/spec/controllers/firms_controller_spec.rb
+++ b/spec/controllers/firms_controller_spec.rb
@@ -87,9 +87,10 @@ RSpec.describe FirmsController, type: :controller do
 
     it 'add requested firm in the recentyl_visited list' do
       VCR.use_cassette(:geocode_search_form_postcode) do
-        search_url = '/en/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        english_search_url = '/en/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        welsh_search_url = '/cy/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
         expect_any_instance_of(RadConsumerSession)
-          .to receive(:store).with(firm_result_1, request.original_url, search_url)
+          .to receive(:store).with(firm_result_1, request.original_url, english_search_url, welsh_search_url)
         get :show, id: firm.id, locale: :en, search_form: search_form_params
       end
     end

--- a/spec/models/rad_consumer_session_spec.rb
+++ b/spec/models/rad_consumer_session_spec.rb
@@ -20,59 +20,70 @@ RSpec.describe RadConsumerSession do
     }
   end
 
-  def expected_path(locale)
+  def expected_search_path(locale)
     "/#{locale}/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD"
+  end
+
+  def expected_firm_profile_path(id, locale)
+    "/#{locale}/firms/#{id}?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD"
   end
 
   subject { described_class.new({}) }
 
   describe '#search_results_url' do
     it 'returns the most_recent_search_url' do
-      subject.store(firm_result(1), '/profile-url', params)
-      expect(subject.search_results_url['en']).to eq(expected_path('en'))
-      expect(subject.search_results_url['cy']).to eq(expected_path('cy'))
+      subject.store(firm_result(1), params)
+      expect(subject.search_results_url['en']).to eq(expected_search_path('en'))
+      expect(subject.search_results_url['cy']).to eq(expected_search_path('cy'))
+    end
+  end
+
+  describe 'profile_path' do
+    it 'returns the most_recent_search_url' do
+      subject.store(firm_result(1), params)
+      expect(subject.firms[0]['profile_path']['en']).to eq(expected_firm_profile_path(1, 'en'))
+      expect(subject.firms[0]['profile_path']['cy']).to eq(expected_firm_profile_path(1, 'cy'))
     end
   end
 
   describe 'recently visited firms' do
     it 'stores the attributes' do
-      subject.store(firm_result(1, name: 'foobar', closest_adviser: 10), 'url', params)
+      subject.store(firm_result(1, name: 'foobar', closest_adviser: 10), params)
 
       expect(subject.firms.first['id']).to eq(1)
       expect(subject.firms.first['name']).to eq('foobar')
       expect(subject.firms.first['closest_adviser']).to eq(10)
       expect(subject.firms.first['face_to_face?']).to eq(true)
-      expect(subject.firms.first['profile_url']).to eq('url')
     end
 
     context 'remote search' do
       it 'stores the attributes' do
-        subject.store(firm_result(1, in_person_advice_methods: []), 'url', params)
+        subject.store(firm_result(1, in_person_advice_methods: []), params)
 
         expect(subject.firms.first['face_to_face?']).to eq(false)
       end
     end
 
     it 'stores firms ordered by most recent first' do
-      subject.store(firm_result(1), 'url', params)
-      subject.store(firm_result(2), 'url', params(2))
+      subject.store(firm_result(1), params)
+      subject.store(firm_result(2), params(2))
 
       expect(subject.firms[0]['id']).to eq(2)
       expect(subject.firms[1]['id']).to eq(1)
     end
 
     it 'stores no duplicate firms' do
-      subject.store(firm_result(1), 'url', params)
-      subject.store(firm_result(1), 'url', params)
+      subject.store(firm_result(1), params)
+      subject.store(firm_result(1), params)
 
       expect(subject.firms.length).to eq(1)
     end
 
     it 'stores no more than three firms' do
-      subject.store(firm_result(1), 'url', params(1))
-      subject.store(firm_result(2), 'url', params(2))
-      subject.store(firm_result(3), 'url', params(3))
-      subject.store(firm_result(4), 'url', params(4))
+      subject.store(firm_result(1), params(1))
+      subject.store(firm_result(2), params(2))
+      subject.store(firm_result(3), params(3))
+      subject.store(firm_result(4), params(4))
 
       expect(subject.firms.map { |f| f['id'] }).to eq([4, 3, 2])
     end

--- a/spec/models/rad_consumer_session_spec.rb
+++ b/spec/models/rad_consumer_session_spec.rb
@@ -8,20 +8,22 @@ RSpec.describe RadConsumerSession do
                    'sort' => [closest_adviser])
   end
 
-  let(:search_url) { '/en/search' }
+  let(:english_search_url) { '/en/search' }
+  let(:welsh_search_url) { '/cy/search' }
 
   subject { described_class.new({}) }
 
   describe '#search_results_url' do
     it 'returns the most_recent_search_url' do
-      subject.store(firm_result(1), '/profile-url', '/search/en/my-last-search')
-      expect(subject.search_results_url).to eq('/search/en/my-last-search')
+      subject.store(firm_result(1), '/profile-url', '/en/search/my-last-search', '/cy/search/my-last-search')
+      expect(subject.search_results_url['en']).to eq('/en/search/my-last-search')
+      expect(subject.search_results_url['cy']).to eq('/cy/search/my-last-search')
     end
   end
 
   describe 'recently visited firms' do
     it 'stores the attributes' do
-      subject.store(firm_result(1, name: 'foobar', closest_adviser: 10), 'url', search_url)
+      subject.store(firm_result(1, name: 'foobar', closest_adviser: 10), 'url', english_search_url, welsh_search_url)
 
       expect(subject.firms.first['id']).to eq(1)
       expect(subject.firms.first['name']).to eq('foobar')
@@ -32,32 +34,32 @@ RSpec.describe RadConsumerSession do
 
     context 'remote search' do
       it 'stores the attributes' do
-        subject.store(firm_result(1, in_person_advice_methods: []), 'url', search_url)
+        subject.store(firm_result(1, in_person_advice_methods: []), 'url', english_search_url, welsh_search_url)
 
         expect(subject.firms.first['face_to_face?']).to eq(false)
       end
     end
 
     it 'stores firms ordered by most recent first' do
-      subject.store(firm_result(1), 'url', search_url)
-      subject.store(firm_result(2), 'url', search_url)
+      subject.store(firm_result(1), 'url', english_search_url, welsh_search_url)
+      subject.store(firm_result(2), 'url', english_search_url, welsh_search_url)
 
       expect(subject.firms[0]['id']).to eq(2)
       expect(subject.firms[1]['id']).to eq(1)
     end
 
     it 'stores no duplicate firms' do
-      subject.store(firm_result(1), 'url', search_url)
-      subject.store(firm_result(1), 'url', search_url)
+      subject.store(firm_result(1), 'url', english_search_url, welsh_search_url)
+      subject.store(firm_result(1), 'url', english_search_url, welsh_search_url)
 
       expect(subject.firms.length).to eq(1)
     end
 
     it 'stores no more than three firms' do
-      subject.store(firm_result(1), 'url', search_url)
-      subject.store(firm_result(2), 'url', search_url)
-      subject.store(firm_result(3), 'url', search_url)
-      subject.store(firm_result(4), 'url', search_url)
+      subject.store(firm_result(1), 'url', english_search_url, welsh_search_url)
+      subject.store(firm_result(2), 'url', english_search_url, welsh_search_url)
+      subject.store(firm_result(3), 'url', english_search_url, welsh_search_url)
+      subject.store(firm_result(4), 'url', english_search_url, welsh_search_url)
 
       expect(subject.firms.map { |f| f['id'] }).to eq([4, 3, 2])
     end

--- a/spec/models/rad_consumer_session_spec.rb
+++ b/spec/models/rad_consumer_session_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe RadConsumerSession do
     }
   end
 
-  def expected_search_path(locale)
-    "/#{locale}/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD"
-  end
-
   def expected_firm_profile_path(id, locale)
     "/#{locale}/firms/#{id}?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD"
   end
@@ -31,10 +27,30 @@ RSpec.describe RadConsumerSession do
   subject { described_class.new({}) }
 
   describe '#search_results_url' do
-    it 'returns the most_recent_search_url' do
-      subject.store(firm_result(1), params)
-      expect(subject.search_results_url['en']).to eq(expected_search_path('en'))
-      expect(subject.search_results_url['cy']).to eq(expected_search_path('cy'))
+    before { subject.store(firm_result(1), params) }
+
+    context 'when locale is a string' do
+      it 'returns the search_results_url in english' do
+        expected_path = '/en/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        expect(subject.search_results_url('en')).to eq(expected_path)
+      end
+
+      it 'returns the search_results_url in welsh' do
+        expected_path = '/cy/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        expect(subject.search_results_url('cy')).to eq(expected_path)
+      end
+    end
+
+    context 'when locale is a symbol' do
+      it 'returns the search_results_url in english' do
+        expected_path = '/en/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        expect(subject.search_results_url(:en)).to eq(expected_path)
+      end
+
+      it 'returns the search_results_url in welsh' do
+        expected_path = '/cy/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        expect(subject.search_results_url(:cy)).to eq(expected_path)
+      end
     end
   end
 


### PR DESCRIPTION
The PR resolves two similar issues with the Recently Viewed Firms functionality.

Previously the RadConsumerSession was storing links for the search_results and the last 3 visited firm profiles. The gotcha was when storing links they were in the locale the page was being viewed in.

The issue being that if someone views a number of firms and navigates between them using the Recently Viewed Firms functionality AND changes the language (english/welsh) when they next select a firm they will see the profile in the language it was added in - not the language the user currently wants to view the site in.

The short version is we've made it store links to support both locales.

[Gif Demo](http://recordit.co/0vwgf9yCIX)