### PR TITLE
Consumer App: Upgrade to dough 5.12 and integrate latest frontend CSS from the CDN

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,12 @@ gem 'active_model_serializers'
 gem 'activerecord-session_store'
 gem 'autoprefixer-rails'
 gem 'bowndler', github: 'moneyadviceservice/bowndler'
+# Dough assets are loaded from a CDN instead of from the Gem. Do make sure that the CDN version
+# is the same as the Gem version.
 gem 'dough-ruby',
     github: 'moneyadviceservice/dough',
     require: 'dough',
-    ref: 'cf08913'
+    tag: 'v5.12.0.267'
 gem 'geocoder'
 gem 'kaminari'
 gem 'mas-rad_core', '0.0.107'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,10 +7,10 @@ GIT
 
 GIT
   remote: git://github.com/moneyadviceservice/dough.git
-  revision: cf089138b49435ee2e5f3f10a477500e93edd951
-  ref: cf08913
+  revision: c27e7846616b0e7965817d97f1432dee9bb49aa8
+  tag: v5.12.0.267
   specs:
-    dough-ruby (5.1.0)
+    dough-ruby (5.12.0)
       activesupport
       rails (>= 3.2)
       sass-rails (~> 4.0.0)

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -32,6 +32,7 @@
 @import 'components/education';
 @import 'components/firm';
 @import 'components/further_info';
+@import 'components/icon';
 @import 'components/keyword';
 @import 'components/list_numbers';
 @import 'components/locale';

--- a/app/assets/stylesheets/components/_icon.scss
+++ b/app/assets/stylesheets/components/_icon.scss
@@ -1,0 +1,36 @@
+// Temporarily adds black definitions for the social sharing icons that were
+// changed to point to white ones in frontend as part of:
+// https://github.com/moneyadviceservice/frontend/pull/1256
+
+.icon--youtube-black {
+  background-position: -4px -70px;
+  width: 30px;
+  height: 30px;
+}
+
+.icon--facebook-black {
+  background-position: -36px -70px;
+  width: 24px;
+  height: 24px;
+}
+
+.icon--twitter-black {
+  background-position: -69px -70px;
+  width: 26px;
+  height: 25px;
+}
+
+// The 2x versions
+@include device-pixel-ratio() {
+  .icon--youtube-black {
+    background-position: -4px -4px;
+  }
+
+  .icon--facebook-black {
+    background-position: -40px -4px;
+  }
+
+  .icon--twitter-black {
+    background-position: -70px -3px;
+  }
+}

--- a/app/assets/stylesheets/layouts/_header.scss
+++ b/app/assets/stylesheets/layouts/_header.scss
@@ -12,5 +12,9 @@
 .l-header__locale {
   @include column(4);
   float: right;
-  margin-top: $baseline-unit*4;
+  margin-top: $baseline-unit*2.5;
+
+  @include respond-to($mq-m) {
+    margin-top: $baseline-unit*4;
+  }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -269,17 +269,17 @@
 
             <div class="contact-panel__button-container">
               <a class="button contact-panel__button contact-panel__button--sharing t-twitter-link" lang="en" href="https://twitter.com/YourMoneyAdvice">
-                <span class="icon icon--twitter"></span>
+                <span class="icon icon--twitter-black"></span>
                 <span class="visually-hidden"><%= t('contact_panels.social.twitter') %></span>
               </a>
 
               <a class="button contact-panel__button contact-panel__button--sharing t-facebook-link" lang="en" href="https://www.facebook.com/MoneyAdviceService?ref=mas">
-                <span class="icon icon--facebook"></span>
+                <span class="icon icon--facebook-black"></span>
                 <span class="visually-hidden"><%= t('contact_panels.social.facebook') %></span>
               </a>
 
               <a class="button contact-panel__button contact-panel__button--sharing t-youtube-link" lang="en" href="https://www.youtube.com/user/MoneyAdviceService">
-                <span class="icon icon--youtube"></span>
+                <span class="icon icon--youtube-black"></span>
                 <span class="visually-hidden"><%= t('contact_panels.social.youtube') %></span>
               </a>
             </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,17 +17,18 @@
 
   <%= favicon_link_tag 'favicon.ico' %>
 
-  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/basic-d9d6ce6d2f790984f07aff8009901a29.css" media="screen" rel="stylesheet" />
+  <% # Dough assets are loaded from a CDN instead of from the Gem. Do make sure that the CDN version is the same as the Gem version. %>
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/basic-c6f0bc03dbe96c1cc8b39033ef43f72f.css" media="screen" rel="stylesheet" />
 
   <!--[if ( gte IE 7 ) & ( lte IE 8 ) & (!IEMobile) ]>
-  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/font_files-ff703b1d1494bc230ea71275731abdde.css" media="screen" rel="stylesheet" />
-  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_fixed-ec3120ee9d7ff3a43394b5e68669525f.css" media="all" rel="stylesheet" />
-  <script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/html5shiv/dist/html5shiv-fee07e49a2d47f6e8f4f18d64a93ed5e.js"></script>
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/dough/assets/stylesheets/font_files-dcbb90df70309af8f6ceeaff0db9a5af.css" media="screen" rel="stylesheet" />
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_fixed-1cca1e76da0e2d48be990410a432379f.css" media="all" rel="stylesheet" />
+  <script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/html5shiv/dist/html5shiv-ccc40f0f8bab80e89dfead2f99f6efdf.js"></script>
   <script>var responsiveStyle = false;</script>
   <![endif]-->
 
   <!--[if ( !IE ) | ( gte IE 9 ) ]><!-->
-  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_responsive-6ee3e18dd34ca469b3528cdcd0a411c4.css" media="only all" rel="stylesheet" />
+  <link href="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/enhanced_responsive-d8208fa73813e571e25d02f662719e85.css" media="only all" rel="stylesheet" />
   <script>var responsiveStyle = true;</script>
   <!--<![endif]-->
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="l-header" role="banner">
-  <div class="l-constrained">
+  <div class="l-constrained l-header__content">
     <div class="mas-logo">
       <a class="mas-logo__link" href="/">
         <img alt="Money Advice Service" class="mas-logo__img" src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/logo-sprite-en-f13de50d8bcd8dbbabfbe56b441a8633.png">


### PR DESCRIPTION
Brings this app up to date with the frontend and the latest Dough.

* Swaps to using tags to track versions of Dough so it's easy to see the exact version we are referencing.
* Yeast is still configured to track master in bower.json.erb so all fresh deployments naturally get the latest version anyway.
* Updated the URLs for assets we import from frontend via the CDN by looking at the page source for http://www.moneyadviceservice.org.uk today.
* Made changes necessary to integrate [social icon updates](https://github.com/moneyadviceservice/frontend/pull/1256) and the new [mobile sticky header](https://github.com/moneyadviceservice/frontend/pull/1365). 

Broadly tested using BrowserStack on:

* IE8, IE11
* iPhone 6, iPad
* Galaxy S6
* FF latest
* Safari latest
* Chrome latest

![screen shot 2016-03-23 at 18 19 29](https://cloud.githubusercontent.com/assets/306583/13996088/1e0c5330-f124-11e5-9a5d-936825f367f2.png)

:point_up:  The sharing icons disappeared when we last updated the CSS from the CDN and are currently blank buttons on the live site ( :exclamation: ). This change brings them back for the old version of the footer. We will update the footer to match frontend as a separate piece of work.

![screen shot 2016-03-23 at 18 20 23](https://cloud.githubusercontent.com/assets/306583/13996122/43b7d190-f124-11e5-8732-cf5f12881053.png)
