### PR TITLE
Restyle tabs for mobile

### DIFF
--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -43,6 +43,7 @@
 @import 'components/recently_viewed';
 @import 'components/result';
 @import 'components/search_filter';
+@import 'components/tab_selector';
 @import 'components/video';
 
 @import 'print';

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -54,6 +54,10 @@ $office-tick-fill-color: $color-green-secondary;
 $pagination-icon-color: #010202;
 $pagination-text-color: $color-black;
 
+$profile-tab-border-color: $color-green-medium;
+$profile-mobile-selected-tab-background-color: $color-blue-light;
+$profile-non-mobile-selected-tab-background-color: $color-white;
+
 $recently-viewed-firm-border-color: $color-grey-pale;
 $recently-viewed-firm-border-radius: 5px;
 $recently-viewed-firm-border-shadow-color: $color-grey-light;

--- a/app/assets/stylesheets/components/tab_selector.scss
+++ b/app/assets/stylesheets/components/tab_selector.scss
@@ -1,0 +1,11 @@
+.tab-selector__trigger.is-active {
+  border: none;
+}
+
+.tab-selector__triggers-inner.is-inactive {
+  border: none;
+}
+
+.tab-selector__trigger-container .tab-selector__trigger:after {
+  border-bottom: none;
+}

--- a/app/assets/stylesheets/components/tab_selector.scss
+++ b/app/assets/stylesheets/components/tab_selector.scss
@@ -1,11 +1,54 @@
-.tab-selector__trigger.is-active {
-  border: none;
-}
+/* removing default styling for mobile views */
 
 .tab-selector__triggers-inner.is-inactive {
-  border: none;
+  border-bottom: none;
+}
+
+.tab-selector__triggers-inner.is-active {
+  border-bottom: none;
 }
 
 .tab-selector__trigger-container .tab-selector__trigger:after {
   border-bottom: none;
 }
+
+/* adding mobile styling */
+.tab-selector__trigger {
+  margin-top: $baseline-unit;
+}
+
+.tab-selector__trigger.is-inactive {
+  border: 1px solid $profile-tab-border-color;
+  border-radius: 5px;
+}
+
+.tab-selector__trigger-container.is-active .tab-selector__trigger.is-active {
+  border: 1px solid $profile-tab-border-color;
+  border-radius: 5px;
+  background-color: $profile-mobile-selected-tab-background-color;
+}
+
+/* adding non-mobile styles */
+
+.tab-selector__triggers-outer {
+  @include respond-to($mq-m) {
+    border-bottom: 1px solid $profile-tab-border-color;
+  }
+}
+
+.tab-selector__trigger-container.is-active .tab-selector__trigger.is-active {
+  @include respond-to($mq-m) {
+    border: 1px solid $profile-tab-border-color;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom: 0;
+    background-color: $profile-non-mobile-selected-tab-background-color;
+  }
+}
+
+.tab-selector__trigger.is-inactive {
+  @include respond-to($mq-m) {
+    border: none;
+  }
+}
+


### PR DESCRIPTION
The PR is to stop wrapping of tabs on mobile :point_down: 

![http://g.recordit.co/pW5ZEXOaaS.gif](http://g.recordit.co/pW5ZEXOaaS.gif)

Now, when entering mobile sized screens buttons are presented rather than tabs.

![http://g.recordit.co/RPVWY9PP05.gif](http://g.recordit.co/RPVWY9PP05.gif)

When loading the page, Dough arrives first with it's tab styling.
Progressive enhancement is somewhat curtailed by having the desktop styling already in place.
To make this work we took the following approach: (and ordered the scss file in the same manner for clarity)
1: Undo/Nullify the dough styling
2: Add mobile styling
3: Add > mobile styling

This is very clunky and any feedback would be appreciated.
