### PR TITLE
[DEV APPROVED]Add workplace advice filter

### DIFF
--- a/app/forms/filters/advice_method.rb
+++ b/app/forms/filters/advice_method.rb
@@ -1,0 +1,39 @@
+module Filters
+  module AdviceMethod
+    ADVICE_METHOD_FACE_TO_FACE = 'face_to_face'
+    ADVICE_METHOD_PHONE_OR_ONLINE = 'phone_or_online'
+
+    attr_accessor :advice_method, :postcode, :coordinates
+
+    def face_to_face?
+      advice_method == ADVICE_METHOD_FACE_TO_FACE
+    end
+
+    def phone_or_online?
+      advice_method == ADVICE_METHOD_PHONE_OR_ONLINE
+    end
+
+    def coordinates
+      @coordinates ||= Geocode.call(postcode)
+    end
+
+    def postcode
+      @postcode if face_to_face?
+    end
+
+    def remote_advice_method_ids
+      phone_or_online? ? OtherAdviceMethod.all.map(&:id) : []
+    end
+
+    private
+
+    def geocode_postcode
+      return if postcode =~ /\A[A-Z\d]{1,4} ?[A-Z\d]{1,3}\z/ && coordinates
+      errors.add(:postcode, I18n.t('search.errors.geocode_failure'))
+    end
+
+    def upcase_postcode
+      postcode.try(:upcase!)
+    end
+  end
+end

--- a/app/forms/filters/language.rb
+++ b/app/forms/filters/language.rb
@@ -1,0 +1,13 @@
+module Filters
+  module Language
+    attr_accessor :language
+
+    def options_for_language
+      languages = Firm.languages_used.map do |iso_639_3|
+        LanguageList::LanguageInfo.find iso_639_3
+      end
+
+      languages.sort_by(&:common_name)
+    end
+  end
+end

--- a/app/forms/filters/pension_pot.rb
+++ b/app/forms/filters/pension_pot.rb
@@ -1,0 +1,17 @@
+module Filters
+  module PensionPot
+    ANY_SIZE_VALUE = 'any'
+
+    attr_accessor :pension_pot_size
+
+    def options_for_pension_pot_sizes
+      InvestmentSize.all.map do |investment_size|
+        [investment_size.localized_name, investment_size.id]
+      end << [I18n.t('search_filter.pension_pot.any_size_option'), ANY_SIZE_VALUE]
+    end
+
+    def any_pension_pot_size?
+      pension_pot_size && pension_pot_size == ANY_SIZE_VALUE
+    end
+  end
+end

--- a/app/forms/filters/qualification_or_accreditation.rb
+++ b/app/forms/filters/qualification_or_accreditation.rb
@@ -1,0 +1,49 @@
+module Filters
+  module QualificationOrAccreditation
+    attr_accessor :qualification_or_accreditation
+
+    def options_for_qualifications_and_accreditations
+      (options_for(Qualification) + options_for(Accreditation)).sort
+    end
+
+    def selected_qualification_id
+      selected_filter_id_for(Qualification)
+    end
+
+    def selected_accreditation_id
+      selected_filter_id_for(Accreditation)
+    end
+
+    private
+
+    def options_for(model)
+      filters = filters_for(model)
+      model
+        .where(order: filters.keys)
+        .pluck(:order, :id)
+        .map { |order, id| [filters[order], "#{prefix_for(model)}#{id}"] }
+    end
+
+    def prefix_for(model)
+      model.model_name.singular[0]
+    end
+
+    def filters_for(model)
+      key_to_i = -> (k, v) { [k.to_s.to_i, v] }
+      I18n.t("search.filter.#{model.model_name.i18n_key}.ordinal").map(&key_to_i).to_h
+    end
+
+    def selected_filter_id_for(model)
+      is_desired_type = ->(prefix, item) { !!item[/^#{prefix}/] }
+      extract_id = ->(item) { item[1..-1] }
+      type_prefix = prefix_for(model)
+
+      [qualification_or_accreditation]
+        .compact
+        .select(&is_desired_type.curry[type_prefix])
+        .map(&extract_id)
+        .map(&:to_i)
+        .first
+    end
+  end
+end

--- a/app/forms/filters/service.rb
+++ b/app/forms/filters/service.rb
@@ -1,0 +1,21 @@
+module Filters
+  module Service
+    OTHER_SERVICES = [:ethical_investing_flag, :sharia_investing_flag, :non_uk_residents_flag]
+    WORKPLACE_SERVICES = [:setting_up_workplace_pension_flag,
+                          :existing_workplace_pension_flag,
+                          :advice_for_employees_flag]
+
+    attr_accessor(*OTHER_SERVICES)
+    attr_accessor(*WORKPLACE_SERVICES)
+
+    def services
+      result = selected_checkbox_attributes(OTHER_SERVICES)
+      result += [:workplace_financial_advice_flag] if selected_checkbox_attributes(WORKPLACE_SERVICES).present?
+      result
+    end
+
+    def services?
+      services.any?
+    end
+  end
+end

--- a/app/forms/filters/type_of_advice.rb
+++ b/app/forms/filters/type_of_advice.rb
@@ -1,0 +1,26 @@
+module Filters
+  module TypeOfAdvice
+    TYPES_OF_ADVICE = [
+      :pension_transfer,
+      :retirement_income_products,
+      :options_when_paying_for_care,
+      :equity_release,
+      :inheritance_tax_planning,
+      :wills_and_probate
+    ]
+
+    attr_accessor(*TYPES_OF_ADVICE)
+
+    def types_of_advice
+      selected_checkbox_attributes TYPES_OF_ADVICE
+    end
+
+    def types_of_advice?
+      types_of_advice.any?
+    end
+
+    def retirement_income_products?
+      retirement_income_products == '1'
+    end
+  end
+end

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -3,6 +3,7 @@ class SearchForm
   include ActiveModel::Validations::Callbacks
 
   include ::Filters::PensionPot
+  include ::Filters::QualificationOrAccreditation
   include ::Filters::Language
 
   ADVICE_METHOD_FACE_TO_FACE = 'face_to_face'
@@ -27,7 +28,6 @@ class SearchForm
                 :postcode,
                 :coordinates,
                 :firm_id,
-                :qualification_or_accreditation,
                 :random_search_seed,
                 *TYPES_OF_ADVICE,
                 *OTHER_SERVICES,
@@ -49,10 +49,6 @@ class SearchForm
 
   def coordinates
     @coordinates ||= Geocode.call(postcode)
-  end
-
-  def options_for_qualifications_and_accreditations
-    (options_for(Qualification) + options_for(Accreditation)).sort
   end
 
   def retirement_income_products?
@@ -81,14 +77,6 @@ class SearchForm
     phone_or_online? ? OtherAdviceMethod.all.map(&:id) : []
   end
 
-  def selected_qualification_id
-    selected_filter_id_for(Qualification)
-  end
-
-  def selected_accreditation_id
-    selected_filter_id_for(Accreditation)
-  end
-
   def postcode
     @postcode if face_to_face?
   end
@@ -108,37 +96,7 @@ class SearchForm
     postcode.try(:upcase!)
   end
 
-  def prefix_for(model)
-    model.model_name.singular[0]
-  end
-
-  def filters_for(model)
-    key_to_i = -> (k, v) { [k.to_s.to_i, v] }
-    I18n.t("search.filter.#{model.model_name.i18n_key}.ordinal").map(&key_to_i).to_h
-  end
-
-  def options_for(model)
-    filters = filters_for(model)
-    model
-      .where(order: filters.keys)
-      .pluck(:order, :id)
-      .map { |order, id| [filters[order], "#{prefix_for(model)}#{id}"] }
-  end
-
   def selected_checkbox_attributes(attribute_names)
     attribute_names.select { |type| public_send(type) == '1' }
-  end
-
-  def selected_filter_id_for(model)
-    is_desired_type = ->(prefix, item) { !!item[/^#{prefix}/] }
-    extract_id = ->(item) { item[1..-1] }
-    type_prefix = prefix_for(model)
-
-    [qualification_or_accreditation]
-      .compact
-      .select(&is_desired_type.curry[type_prefix])
-      .map(&extract_id)
-      .map(&:to_i)
-      .first
   end
 end

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -7,31 +7,15 @@ class SearchForm
   include ::Filters::PensionPot
   include ::Filters::QualificationOrAccreditation
   include ::Filters::Language
-
-  OTHER_SERVICES = [:ethical_investing_flag, :sharia_investing_flag, :non_uk_residents_flag]
-  WORKPLACE_SERVICES = [:setting_up_workplace_pension_flag,
-                        :existing_workplace_pension_flag,
-                        :advice_for_employees_flag]
+  include ::Filters::Service
 
   attr_accessor :checkbox,
                 :firm_id,
-                :random_search_seed,
-                *OTHER_SERVICES,
-                *WORKPLACE_SERVICES
+                :random_search_seed
 
   before_validation :upcase_postcode, if: :face_to_face?
   validates :advice_method, presence: true
   validate :geocode_postcode, if: :face_to_face?
-
-  def services
-    result = selected_checkbox_attributes(OTHER_SERVICES)
-    result += [:workplace_financial_advice_flag] if selected_checkbox_attributes(WORKPLACE_SERVICES).present?
-    result
-  end
-
-  def services?
-    services.any?
-  end
 
   def to_query
     SearchFormSerializer.new(self).to_json

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -3,6 +3,7 @@ class SearchForm
   include ActiveModel::Validations::Callbacks
 
   include ::Filters::PensionPot
+  include ::Filters::Language
 
   ADVICE_METHOD_FACE_TO_FACE = 'face_to_face'
   ADVICE_METHOD_PHONE_OR_ONLINE = 'phone_or_online'
@@ -27,7 +28,6 @@ class SearchForm
                 :coordinates,
                 :firm_id,
                 :qualification_or_accreditation,
-                :language,
                 :random_search_seed,
                 *TYPES_OF_ADVICE,
                 *OTHER_SERVICES,
@@ -53,14 +53,6 @@ class SearchForm
 
   def options_for_qualifications_and_accreditations
     (options_for(Qualification) + options_for(Accreditation)).sort
-  end
-
-  def options_for_language
-    languages = Firm.languages_used.map do |iso_639_3|
-      LanguageList::LanguageInfo.find iso_639_3
-    end
-
-    languages.sort_by(&:common_name)
   end
 
   def retirement_income_products?

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -2,10 +2,10 @@ class SearchForm
   include ActiveModel::Model
   include ActiveModel::Validations::Callbacks
 
+  include ::Filters::PensionPot
+
   ADVICE_METHOD_FACE_TO_FACE = 'face_to_face'
   ADVICE_METHOD_PHONE_OR_ONLINE = 'phone_or_online'
-
-  ANY_SIZE_VALUE = 'any'
 
   TYPES_OF_ADVICE = [
     :pension_transfer,
@@ -25,7 +25,6 @@ class SearchForm
                 :advice_method,
                 :postcode,
                 :coordinates,
-                :pension_pot_size,
                 :firm_id,
                 :qualification_or_accreditation,
                 :language,
@@ -52,12 +51,6 @@ class SearchForm
     @coordinates ||= Geocode.call(postcode)
   end
 
-  def options_for_pension_pot_sizes
-    InvestmentSize.all.map do |investment_size|
-      [investment_size.localized_name, investment_size.id]
-    end << [I18n.t('search_filter.pension_pot.any_size_option'), ANY_SIZE_VALUE]
-  end
-
   def options_for_qualifications_and_accreditations
     (options_for(Qualification) + options_for(Accreditation)).sort
   end
@@ -68,10 +61,6 @@ class SearchForm
     end
 
     languages.sort_by(&:common_name)
-  end
-
-  def any_pension_pot_size?
-    pension_pot_size && pension_pot_size == ANY_SIZE_VALUE
   end
 
   def retirement_income_products?

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -16,7 +16,10 @@ class SearchForm
     :wills_and_probate
   ]
 
-  OTHER_SERVICES = [:ethical_investing_flag, :sharia_investing_flag, :non_uk_residents_flag, :workplace_financial_advice_flag]
+  OTHER_SERVICES = [:ethical_investing_flag, :sharia_investing_flag, :non_uk_residents_flag]
+  WORKPLACE_SERVICES = [:setting_up_workplace_pension_flag,
+                        :existing_workplace_pension_flag,
+                        :advice_for_employees_flag]
 
   attr_accessor :checkbox,
                 :advice_method,
@@ -28,7 +31,8 @@ class SearchForm
                 :language,
                 :random_search_seed,
                 *TYPES_OF_ADVICE,
-                *OTHER_SERVICES
+                *OTHER_SERVICES,
+                *WORKPLACE_SERVICES
 
   before_validation :upcase_postcode, if: :face_to_face?
 
@@ -83,7 +87,9 @@ class SearchForm
   end
 
   def services
-    selected_checkbox_attributes OTHER_SERVICES
+    result = selected_checkbox_attributes(OTHER_SERVICES)
+    result += [:workplace_financial_advice_flag] if selected_checkbox_attributes(WORKPLACE_SERVICES).present?
+    result
   end
 
   def services?

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -16,7 +16,7 @@ class SearchForm
     :wills_and_probate
   ]
 
-  OTHER_SERVICES = [:ethical_investing_flag, :sharia_investing_flag, :non_uk_residents_flag]
+  OTHER_SERVICES = [:ethical_investing_flag, :sharia_investing_flag, :non_uk_residents_flag, :workplace_financial_advice_flag]
 
   attr_accessor :checkbox,
                 :advice_method,

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -3,18 +3,10 @@ class SearchForm
   include ActiveModel::Validations::Callbacks
 
   include ::Filters::AdviceMethod
+  include ::Filters::TypeOfAdvice
   include ::Filters::PensionPot
   include ::Filters::QualificationOrAccreditation
   include ::Filters::Language
-
-  TYPES_OF_ADVICE = [
-    :pension_transfer,
-    :retirement_income_products,
-    :options_when_paying_for_care,
-    :equity_release,
-    :inheritance_tax_planning,
-    :wills_and_probate
-  ]
 
   OTHER_SERVICES = [:ethical_investing_flag, :sharia_investing_flag, :non_uk_residents_flag]
   WORKPLACE_SERVICES = [:setting_up_workplace_pension_flag,
@@ -24,25 +16,12 @@ class SearchForm
   attr_accessor :checkbox,
                 :firm_id,
                 :random_search_seed,
-                *TYPES_OF_ADVICE,
                 *OTHER_SERVICES,
                 *WORKPLACE_SERVICES
 
   before_validation :upcase_postcode, if: :face_to_face?
   validates :advice_method, presence: true
   validate :geocode_postcode, if: :face_to_face?
-
-  def retirement_income_products?
-    retirement_income_products == '1'
-  end
-
-  def types_of_advice
-    selected_checkbox_attributes TYPES_OF_ADVICE
-  end
-
-  def types_of_advice?
-    types_of_advice.any?
-  end
 
   def services
     result = selected_checkbox_attributes(OTHER_SERVICES)

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -108,6 +108,11 @@
               <%= t('firms.show.panels.firm.services.non_uk_residents') %>
             </li>
           <% end %>
+          <% if firm.workplace_financial_advice_flag %>
+            <li class="plain_list__item">
+              <%= t('firms.show.panels.firm.services.investing.workplace_financial_advice') %>
+            </li>
+          <% end %>
         </ul>
       <% end %>
 

--- a/app/views/search/partials/_search_filter.html.erb
+++ b/app/views/search/partials/_search_filter.html.erb
@@ -47,6 +47,11 @@
           </div>
         <% end %>
 
+        <div class="l-results__filter search-filter__section">
+          <%= render 'search/partials/filters/workplace_financial_advice', f: f %>
+          <hr class="search-filter__divider">
+        </div>
+
         <div class="l-results__filter-button-container search-filter__section">
           <%= render 'shared/search_button', button_class: "l-results__filter-button" %>
         </div>

--- a/app/views/search/partials/filters/_workplace_financial_advice.html.erb
+++ b/app/views/search/partials/filters/_workplace_financial_advice.html.erb
@@ -1,0 +1,9 @@
+<legend class="search-filter__label">
+  <%= t('search.filter.workplace_financial_advice_flag.heading') %>
+</legend>
+<div class="form__group-item">
+  <%= f.check_box 'workplace_financial_advice_flag', class: "form__group-input t-workplace_financial_advice_flag search-filter__checkbox" %>
+  <%= f.label 'workplace_financial_advice_flag', class: 'search-filter__option' do %>
+    <%= raw t('search.filter.workplace_financial_advice_flag.title') %>
+  <% end %>
+</div>

--- a/app/views/search/partials/filters/_workplace_financial_advice.html.erb
+++ b/app/views/search/partials/filters/_workplace_financial_advice.html.erb
@@ -1,17 +1,24 @@
-<fieldset class="search-filter__pension_pot" data-further-info>
+<fieldset class="search-filter__pension_pot">
   <legend class="search-filter__label">
     <%= t('search.filter.workplace_financial_advice_flag.heading') %>
-    <%= render 'shared/further_info_trigger' %>
   </legend>
 
-  <p class="is-hidden further-info__content" data-further-info-target>
-    <%= t('search.filter.workplace_financial_advice_flag.tooltip') %>
-  </p>
-
   <div class="form__group-item">
-    <%= f.check_box 'workplace_financial_advice_flag', class: "form__group-input t-workplace_financial_advice_flag search-filter__checkbox" %>
-    <%= f.label 'workplace_financial_advice_flag', class: 'search-filter__option' do %>
-      <%= raw t('search.filter.workplace_financial_advice_flag.title') %>
+    <%= f.check_box 'setting_up_workplace_pension_flag', class: "form__group-input t-setting_up_workplace_pension search-filter__checkbox" %>
+    <%= f.label 'setting_up_workplace_pension', class: 'search-filter__option' do %>
+      <%= t('search.filter.workplace_financial_advice_flag.setting_up_workplace_pension') %>
+    <% end %>
+  </div>
+  <div class="form__group-item">
+    <%= f.check_box 'existing_workplace_pension_flag', class: "form__group-input t-existing_workplace_pension_flag search-filter__checkbox" %>
+    <%= f.label 'existing_workplace_pension_flag', class: 'search-filter__option' do %>
+      <%= t('search.filter.workplace_financial_advice_flag.existing_workplace_pension') %>
+    <% end %>
+  </div>
+  <div class="form__group-item">
+    <%= f.check_box 'advice_for_employees_flag', class: "form__group-input t-advice_for_employees_flag search-filter__checkbox" %>
+    <%= f.label 'advice_for_employees_flag', class: 'search-filter__option' do %>
+      <%= t('search.filter.workplace_financial_advice_flag.advice_for_employees') %>
     <% end %>
   </div>
 </fieldset>

--- a/app/views/search/partials/filters/_workplace_financial_advice.html.erb
+++ b/app/views/search/partials/filters/_workplace_financial_advice.html.erb
@@ -1,9 +1,17 @@
-<legend class="search-filter__label">
-  <%= t('search.filter.workplace_financial_advice_flag.heading') %>
-</legend>
-<div class="form__group-item">
-  <%= f.check_box 'workplace_financial_advice_flag', class: "form__group-input t-workplace_financial_advice_flag search-filter__checkbox" %>
-  <%= f.label 'workplace_financial_advice_flag', class: 'search-filter__option' do %>
-    <%= raw t('search.filter.workplace_financial_advice_flag.title') %>
-  <% end %>
-</div>
+<fieldset class="search-filter__pension_pot" data-further-info>
+  <legend class="search-filter__label">
+    <%= t('search.filter.workplace_financial_advice_flag.heading') %>
+    <%= render 'shared/further_info_trigger' %>
+  </legend>
+
+  <p class="is-hidden further-info__content" data-further-info-target>
+    <%= t('search.filter.workplace_financial_advice_flag.tooltip') %>
+  </p>
+
+  <div class="form__group-item">
+    <%= f.check_box 'workplace_financial_advice_flag', class: "form__group-input t-workplace_financial_advice_flag search-filter__checkbox" %>
+    <%= f.label 'workplace_financial_advice_flag', class: 'search-filter__option' do %>
+      <%= raw t('search.filter.workplace_financial_advice_flag.title') %>
+    <% end %>
+  </div>
+</fieldset>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -329,6 +329,8 @@ cy:
             title: Buddsoddiadau sy’n cydymffurfio â Sharia
           non_uk_residents_flag:
             title: Cyngor i alltudion y Deyrnas Unedig
+          workplace_financial_advice_flag:
+            title: Cyngor ariannol yn y gweithle
       languages:
         heading: 'Hoffwn gael cynghorydd a all siarad yr iaith ganlynol:'
       select_prompt: Dewiswch

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -334,6 +334,7 @@ cy:
         heading: 'Hoffwn gael cynghorydd a all siarad yr iaith ganlynol:'
       workplace_financial_advice_flag:
         heading: TBD
+        tooltip: TBD
         title: Cyngor ariannol yn y gweithle
       select_prompt: Dewiswch
       button_text: Chwilio

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -333,9 +333,10 @@ cy:
       languages:
         heading: 'Hoffwn gael cynghorydd a all siarad yr iaith ganlynol:'
       workplace_financial_advice_flag:
-        heading: TBD
-        tooltip: TBD
-        title: Cyngor ariannol yn y gweithle
+        heading: "Rydw i'n gyflogwr. Hoffwn gael help gyda:"
+        setting_up_workplace_pension: Sefydlu cynllun pensiwn gweithle
+        existing_workplace_pension: Cynllun pensiwn gweithle presennol
+        advice_for_employees: Cyngor ariannol ar gyfer fy nghyflogeion
       select_prompt: Dewiswch
       button_text: Chwilio
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -330,10 +330,11 @@ cy:
             title: Buddsoddiadau sy’n cydymffurfio â Sharia
           non_uk_residents_flag:
             title: Cyngor i alltudion y Deyrnas Unedig
-          workplace_financial_advice_flag:
-            title: Cyngor ariannol yn y gweithle
       languages:
         heading: 'Hoffwn gael cynghorydd a all siarad yr iaith ganlynol:'
+      workplace_financial_advice_flag:
+        heading: TBD
+        title: Cyngor ariannol yn y gweithle
       select_prompt: Dewiswch
       button_text: Chwilio
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -81,6 +81,7 @@ cy:
               heading: Gwasanaethau Eraill
               ethical: Buddsoddiadau moesol
               sharia: Buddsoddiadau sy’n cydymffurfio â Sharia
+              workplace_financial_advice: Cyngor ariannol yn y gweithle
             languages: Ieithoedd ychwanegol a siaradir gan gynghorwyr
             non_uk_residents: Cyngor i alltudion y Deyrnas Unedig
             qualifications:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -329,6 +329,8 @@ en:
             title: Sharia compliant investments
           non_uk_residents_flag:
             title: Advice to UK expatriates
+          workplace_financial_advice_flag:
+            title: Workplace financial advice
       languages:
         heading: 'I would like an adviser who can speak the following language:'
       select_prompt: Please select

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -333,7 +333,8 @@ en:
       languages:
         heading: 'I would like an adviser who can speak the following language:'
       workplace_financial_advice_flag:
-        heading: 'I would like an adviser who specialises in providing financial advice through employers in the workplace:'
+        heading: 'I would like an adviser who provides financial advice to employers:'
+        tooltip: Tooltip
         title: Workplace financial advice
       select_prompt: Please select
       button_text: Search

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,10 +330,11 @@ en:
             title: Sharia compliant investments
           non_uk_residents_flag:
             title: Advice to UK expatriates
-          workplace_financial_advice_flag:
-            title: Workplace financial advice
       languages:
         heading: 'I would like an adviser who can speak the following language:'
+      workplace_financial_advice_flag:
+        heading: 'I would like an adviser who specialises in providing financial advice through employers in the workplace:'
+        title: Workplace financial advice
       select_prompt: Please select
       button_text: Search
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
               heading: Other services
               ethical: Ethical investments
               sharia: Sharia compliant investments
+              workplace_financial_advice: Workplace financial advice
             languages: Additional languages spoken by advisers
             non_uk_residents: Advice to UK expatriates
             qualifications:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -333,9 +333,10 @@ en:
       languages:
         heading: 'I would like an adviser who can speak the following language:'
       workplace_financial_advice_flag:
-        heading: 'I would like an adviser who provides financial advice to employers:'
-        tooltip: Tooltip
-        title: Workplace financial advice
+        heading: 'I am an employer. I would like help with:'
+        setting_up_workplace_pension: Setting up a workplace pension scheme
+        existing_workplace_pension: An existing workplace pension scheme
+        advice_for_employees: Financial advice for my employees
       select_prompt: Please select
       button_text: Search
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20160329110348) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -118,10 +118,25 @@ RSpec.describe SearchForm do
       end
     end
 
-    context 'both flags set' do
-      let(:services) { { sharia_investing_flag: '1', ethical_investing_flag: '1' } }
+    context 'workplace financial advice flag set' do
+      let(:services) { { workplace_financial_advice_flag: '1' } }
+      it 'contains workplace_financial_advice_flag' do
+        expect(form.services).to eql([:workplace_financial_advice_flag])
+      end
+    end
+
+    context 'all flags set' do
+      let(:services) do
+        { sharia_investing_flag: '1',
+          ethical_investing_flag: '1',
+          workplace_financial_advice_flag: '1'
+        }
+      end
+
       it 'contains both flag' do
-        expect(form.services).to eql([:ethical_investing_flag, :sharia_investing_flag])
+        expect(form.services).to eql([:ethical_investing_flag,
+                                      :sharia_investing_flag,
+                                      :workplace_financial_advice_flag])
       end
     end
   end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -118,10 +118,38 @@ RSpec.describe SearchForm do
       end
     end
 
-    context 'workplace financial advice flag set' do
-      let(:services) { { workplace_financial_advice_flag: '1' } }
-      it 'contains workplace_financial_advice_flag' do
-        expect(form.services).to eql([:workplace_financial_advice_flag])
+    context 'workplace financial advice flag service set' do
+      context 'setting_up_workplace_pension_flag' do
+        let(:services) { { setting_up_workplace_pension_flag: '1' } }
+        it 'contains workplace_financial_advice_flag' do
+          expect(form.services).to eql([:workplace_financial_advice_flag])
+        end
+      end
+      context 'existing_workplace_pension_flag' do
+        let(:services) { { existing_workplace_pension_flag: '1' } }
+        it 'contains workplace_financial_advice_flag' do
+          expect(form.services).to eql([:workplace_financial_advice_flag])
+        end
+      end
+      context 'advice_for_employees_flag' do
+        let(:services) { { advice_for_employees_flag: '1' } }
+        it 'contains workplace_financial_advice_flag' do
+          expect(form.services).to eql([:workplace_financial_advice_flag])
+        end
+      end
+
+      context 'multiple workplace financial advice options' do
+        let(:services) do
+          {
+            setting_up_workplace_pension_flag: '1',
+            existing_workplace_pension_flag: '1',
+            advice_for_employees_flag: '1'
+          }
+        end
+
+        it 'contains one workplace_financial_advice_flag' do
+          expect(form.services).to eql([:workplace_financial_advice_flag])
+        end
       end
     end
 
@@ -129,7 +157,7 @@ RSpec.describe SearchForm do
       let(:services) do
         { sharia_investing_flag: '1',
           ethical_investing_flag: '1',
-          workplace_financial_advice_flag: '1'
+          setting_up_workplace_pension_flag: '1'
         }
       end
 

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe SearchForm do
   describe '#types_of_advice' do
     let(:form) { described_class.new(types_of_advice) }
 
-    SearchForm::TYPES_OF_ADVICE.each do |advice_type|
+    Filters::TypeOfAdvice::TYPES_OF_ADVICE.each do |advice_type|
       context "#{advice_type} set" do
         let(:types_of_advice) { { advice_type => '1' } }
         it "contains #{advice_type}" do

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SearchForm do
     end
 
     context 'when advice method is face to face' do
-      let(:advice_method) { SearchForm::ADVICE_METHOD_FACE_TO_FACE }
+      let(:advice_method) { Filters::AdviceMethod::ADVICE_METHOD_FACE_TO_FACE }
 
       describe '#face_to_face?' do
         it 'returns truthy' do
@@ -26,7 +26,7 @@ RSpec.describe SearchForm do
     end
 
     context 'when advice method is phone or online' do
-      let(:advice_method) { SearchForm::ADVICE_METHOD_PHONE_OR_ONLINE }
+      let(:advice_method) { Filters::AdviceMethod::ADVICE_METHOD_PHONE_OR_ONLINE }
 
       describe '#face_to_face?' do
         it 'returns falsey' do
@@ -43,7 +43,9 @@ RSpec.describe SearchForm do
   end
 
   context 'for the face to face advice method' do
-    let(:form) { described_class.new(advice_method: SearchForm::ADVICE_METHOD_FACE_TO_FACE, postcode: 'rg2 1aa') }
+    let(:form) do
+      described_class.new(advice_method: Filters::AdviceMethod::ADVICE_METHOD_FACE_TO_FACE, postcode: 'rg2 1aa')
+    end
 
     it 'upcases the postcode before validation' do
       VCR.use_cassette(:rg2_1aa) do
@@ -201,7 +203,7 @@ RSpec.describe SearchForm do
     end
 
     context 'when the advice method is face to face' do
-      let(:advice_method) { SearchForm::ADVICE_METHOD_FACE_TO_FACE }
+      let(:advice_method) { Filters::AdviceMethod::ADVICE_METHOD_FACE_TO_FACE }
 
       context 'and a correctly formatted postcode is present' do
         before { form.postcode = 'RG2 1AA' }
@@ -244,7 +246,7 @@ RSpec.describe SearchForm do
     end
 
     context 'when advice method is phone or online' do
-      let(:advice_method) { SearchForm::ADVICE_METHOD_PHONE_OR_ONLINE }
+      let(:advice_method) { Filters::AdviceMethod::ADVICE_METHOD_PHONE_OR_ONLINE }
 
       it 'passes on phone and online' do
         phone = OtherAdviceMethod.create name: 'phone'


### PR DESCRIPTION
Building on the work in this [mas-rad_core PR](https://github.com/moneyadviceservice/mas-rad_core/pull/152) and [RAD PR](https://github.com/moneyadviceservice/rad/pull/387)

This PR allows users to filter on :workplace_financial_advice and also updates the firm profile page if the firm provides this service.

We are currently awaiting final copy on the filter label, there after we'll request the welsh translation of the copy.

![screen shot 2016-03-29 at 11 35 28](https://cloud.githubusercontent.com/assets/67151/14105510/e60e51e8-f5a3-11e5-8a24-867154d1cabe.png)
