### PR TITLE
Add non uk residents filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'dough-ruby',
     tag: 'v5.12.0.267'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.0.107'
+gem 'mas-rad_core', '0.0.109'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.107)
+    mas-rad_core (0.0.109)
       active_model_serializers
       geocoder
       httpclient
@@ -258,7 +258,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
-  mas-rad_core (= 0.0.107)
+  mas-rad_core (= 0.0.109)
   pg
   pry-rails
   rails (~> 4.2.5.2)

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -16,7 +16,7 @@ class SearchForm
     :wills_and_probate
   ]
 
-  OTHER_SERVICES = [:ethical_investing_flag, :sharia_investing_flag]
+  OTHER_SERVICES = [:ethical_investing_flag, :sharia_investing_flag, :non_uk_residents_flag]
 
   attr_accessor :checkbox,
                 :advice_method,

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -103,6 +103,11 @@
               <%= t('firms.show.panels.firm.services.investing.sharia') %>
             </li>
           <% end %>
+          <% if firm.non_uk_residents_flag %>
+            <li class="plain_list__item">
+              <%= t('firms.show.panels.firm.services.non_uk_residents') %>
+            </li>
+          <% end %>
         </ul>
       <% end %>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -82,6 +82,7 @@ cy:
               ethical: Buddsoddiadau moesol
               sharia: Buddsoddiadau sy’n cydymffurfio â Sharia
             languages: Ieithoedd ychwanegol a siaradir gan gynghorwyr
+            non_uk_residents: Cyngor i alltudion y Deyrnas Unedig
             qualifications:
               heading: Cymwysterau a feddir gan gynghorwyr y cwmni
         offices:
@@ -326,6 +327,8 @@ cy:
             title: Buddsoddiadau moesol
           sharia_investing_flag:
             title: Buddsoddiadau sy’n cydymffurfio â Sharia
+          non_uk_residents_flag:
+            title: Cyngor i alltudion y Deyrnas Unedig
       languages:
         heading: 'Hoffwn gael cynghorydd a all siarad yr iaith ganlynol:'
       select_prompt: Dewiswch

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
               ethical: Ethical investments
               sharia: Sharia compliant investments
             languages: Additional languages spoken by advisers
+            non_uk_residents: Advice to UK expatriates
             qualifications:
               heading: Qualifications held by firm advisers
         offices:
@@ -326,6 +327,8 @@ en:
             title: Ethical investments
           sharia_investing_flag:
             title: Sharia compliant investments
+          non_uk_residents_flag:
+            title: Advice to UK expatriates
       languages:
         heading: 'I would like an adviser who can speak the following language:'
       select_prompt: Please select

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160317103053) do
+ActiveRecord::Schema.define(version: 20160329110348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,8 @@ ActiveRecord::Schema.define(version: 20160317103053) do
     t.boolean  "sharia_investing_flag",                    default: false, null: false
     t.text     "languages",                                default: [],    null: false, array: true
     t.integer  "status"
+    t.boolean  "workplace_financial_advice_flag",          default: false, null: false
+    t.boolean  "non_uk_residents_flag",                    default: false, null: false
   end
 
   add_index "firms", ["initial_meeting_duration_id"], name: "index_firms_on_initial_meeting_duration_id", using: :btree
@@ -330,8 +332,10 @@ ActiveRecord::Schema.define(version: 20160317103053) do
     t.integer  "advisers_part_of_ci_securities_and_investments"
     t.integer  "advisers_part_of_cfa_institute"
     t.integer  "advisers_part_of_chartered_accountants"
-    t.datetime "created_at",                                                 null: false
-    t.datetime "updated_at",                                                 null: false
+    t.datetime "created_at",                                                             null: false
+    t.datetime "updated_at",                                                             null: false
+    t.integer  "firms_providing_workplace_financial_advice",                 default: 0
+    t.integer  "firms_providing_non_uk_residents",                           default: 0
   end
 
 end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -111,6 +111,13 @@ RSpec.describe SearchForm do
       end
     end
 
+    context 'non uk residents flag set' do
+      let(:services) { { non_uk_residents_flag: '1' } }
+      it 'contains non_uk_residents_flag' do
+        expect(form.services).to eql([:non_uk_residents_flag])
+      end
+    end
+
     context 'both flags set' do
       let(:services) { { sharia_investing_flag: '1', ethical_investing_flag: '1' } }
       it 'contains both flag' do


### PR DESCRIPTION
Building on the work in this [mas-rad_core PR](https://github.com/moneyadviceservice/mas-rad_core) and [RAD PR](https://github.com/moneyadviceservice/rad)

This PR allows users to filter on :non_uk_residents and also updates the firm profile page if the firm provides this service.

We are currently awaiting final copy on the filter label, checkbox text and tooltip, there after we'll request the welsh translation of the copy.

![screen shot 2016-03-29 at 17 14 58](https://cloud.githubusercontent.com/assets/67151/14115300/442b7fb6-f5d2-11e5-81d2-ad4cfe287d8d.png)