### PR TITLE
[DEV APPROVED] Making conditional smarter to display Other Services

### DIFF
--- a/app/helpers/firm_helper.rb
+++ b/app/helpers/firm_helper.rb
@@ -1,6 +1,7 @@
 module FirmHelper
   def firm_has_investing_types?(firm)
-    firm.ethical_investing_flag || firm.sharia_investing_flag
+    firm.ethical_investing_flag || firm.sharia_investing_flag ||
+      firm.workplace_financial_advice_flag || firm.non_uk_residents_flag
   end
 
   def firm_language_list(language_codes)

--- a/spec/helpers/firm_helper_spec.rb
+++ b/spec/helpers/firm_helper_spec.rb
@@ -4,46 +4,63 @@ RSpec.describe FirmHelper, type: :helper do
   let(:firm) { double }
 
   describe 'firm_has_investing_types?' do
+    let(:ethical_investing_flag) { false }
+    let(:sharia_investing_flag) { false }
+    let(:workplace_financial_advice_flag) { false }
+    let(:non_uk_residents_flag) { false }
+
     subject { helper.firm_has_investing_types?(firm) }
 
-    context 'it has neither sharia or ethical investing' do
-      before do
-        allow(firm).to receive(:ethical_investing_flag).and_return(false)
-        allow(firm).to receive(:sharia_investing_flag).and_return(false)
-      end
+    before do
+      allow(firm).to receive(:ethical_investing_flag).and_return(ethical_investing_flag)
+      allow(firm).to receive(:sharia_investing_flag).and_return(sharia_investing_flag)
+      allow(firm).to receive(:workplace_financial_advice_flag).and_return(workplace_financial_advice_flag)
+      allow(firm).to receive(:non_uk_residents_flag).and_return(non_uk_residents_flag)
+    end
 
+    context 'it has neither sharia, ethical investing, workplace or non uk residents' do
       it 'returns false' do
         expect(subject).to eq(false)
       end
     end
 
-    context 'it has sharia but not ethical investing' do
-      before do
-        allow(firm).to receive(:ethical_investing_flag).and_return(false)
-        allow(firm).to receive(:sharia_investing_flag).and_return(true)
-      end
+    context 'it has sharia only' do
+      let(:sharia_investing_flag) { true }
 
       it 'returns true' do
         expect(subject).to eq(true)
       end
     end
 
-    context 'it has ethical but not sharia investing' do
-      before do
-        allow(firm).to receive(:ethical_investing_flag).and_return(true)
-        allow(firm).to receive(:sharia_investing_flag).and_return(false)
-      end
+    context 'it has ethical only' do
+      let(:ethical_investing_flag) { true }
 
       it 'returns true' do
         expect(subject).to eq(true)
       end
     end
 
-    context 'it has ethical and sharia investing' do
-      before do
-        allow(firm).to receive(:ethical_investing_flag).and_return(true)
-        allow(firm).to receive(:sharia_investing_flag).and_return(true)
+    context 'it has workplace only' do
+      let(:workplace_financial_advice_flag) { true }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
       end
+    end
+
+    context 'it has non uk residents only' do
+      let(:non_uk_residents_flag) { true }
+
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'it has multiple options' do
+      let(:ethical_investing_flag) { true }
+      let(:sharia_investing_flag) { true }
+      let(:workplace_financial_advice_flag) { true }
+      let(:non_uk_residents_flag) { true }
 
       it 'returns true' do
         expect(subject).to eq(true)


### PR DESCRIPTION
In a previous PR we added Workplace financial advice and Non UK residents to the firm profile page.

I didn't notice a conditional wrapping this in the view, which needs to know if Workplace financial advice or Non UK residents are set. This PR updates the : firm_has_investing_types? method that the conditional calls.
