### PR TITLE
Always update the search url cache in the session store

### DIFF
--- a/app/models/rad_consumer_session.rb
+++ b/app/models/rad_consumer_session.rb
@@ -15,8 +15,17 @@ class RadConsumerSession
   end
 
   def store(firm_result, params)
-    @store['locale_to_search_path_mappings'] = locale_to_search_path_mappings(params)
+    update_most_recent_search(params)
+    update_recently_visited_firms(firm_result, params)
+  end
 
+  private
+
+  def update_most_recent_search(params)
+    @store['locale_to_search_path_mappings'] = locale_to_search_path_mappings(params)
+  end
+
+  def update_recently_visited_firms(firm_result, params)
     return if firm_already_present?(firm_result)
     firms.pop if firms.length >= 3
     firms.unshift('id' => firm_result.id,
@@ -25,8 +34,6 @@ class RadConsumerSession
                   'face_to_face?' => firm_result.in_person_advice_methods.present?,
                   'profile_path' => locale_to_profile_path_mappings(params))
   end
-
-  private
 
   def firm_already_present?(firm_result)
     firms.any? { |firm_hash| firm_result.id == firm_hash['id'] }

--- a/app/models/rad_consumer_session.rb
+++ b/app/models/rad_consumer_session.rb
@@ -15,6 +15,8 @@ class RadConsumerSession
   end
 
   def store(firm_result, params)
+    @store['locale_to_search_path_mappings'] = locale_to_search_path_mappings(params)
+
     return if firm_already_present?(firm_result)
     firms.pop if firms.length >= 3
     firms.unshift('id' => firm_result.id,
@@ -22,8 +24,6 @@ class RadConsumerSession
                   'closest_adviser' => firm_result.closest_adviser,
                   'face_to_face?' => firm_result.in_person_advice_methods.present?,
                   'profile_path' => locale_to_profile_path_mappings(params))
-
-    @store['locale_to_search_path_mappings'] = locale_to_search_path_mappings(params)
   end
 
   private

--- a/spec/models/rad_consumer_session_spec.rb
+++ b/spec/models/rad_consumer_session_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe RadConsumerSession do
   end
 
   describe '#store' do
-    describe 'most recent search' do
+    describe 'storing most recent search' do
       it 'always stores the most recent search (independently of the firm storing logic)' do
         # Store a firm result and search form params
         subject.store(firm_result(1), params)
@@ -83,7 +83,7 @@ RSpec.describe RadConsumerSession do
       end
     end
 
-    describe 'recently visited firms' do
+    describe 'storing recently visited firms' do
       it 'stores the attributes' do
         subject.store(firm_result(1, name: 'foobar', closest_adviser: 10), params)
 

--- a/spec/models/rad_consumer_session_spec.rb
+++ b/spec/models/rad_consumer_session_spec.rb
@@ -62,46 +62,48 @@ RSpec.describe RadConsumerSession do
     end
   end
 
-  describe 'recently visited firms' do
-    it 'stores the attributes' do
-      subject.store(firm_result(1, name: 'foobar', closest_adviser: 10), params)
-
-      expect(subject.firms.first['id']).to eq(1)
-      expect(subject.firms.first['name']).to eq('foobar')
-      expect(subject.firms.first['closest_adviser']).to eq(10)
-      expect(subject.firms.first['face_to_face?']).to eq(true)
-    end
-
-    context 'remote search' do
+  describe '#store' do
+    describe 'recently visited firms' do
       it 'stores the attributes' do
-        subject.store(firm_result(1, in_person_advice_methods: []), params)
+        subject.store(firm_result(1, name: 'foobar', closest_adviser: 10), params)
 
-        expect(subject.firms.first['face_to_face?']).to eq(false)
+        expect(subject.firms.first['id']).to eq(1)
+        expect(subject.firms.first['name']).to eq('foobar')
+        expect(subject.firms.first['closest_adviser']).to eq(10)
+        expect(subject.firms.first['face_to_face?']).to eq(true)
       end
-    end
 
-    it 'stores firms ordered by most recent first' do
-      subject.store(firm_result(1), params)
-      subject.store(firm_result(2), params(2))
+      context 'remote search' do
+        it 'stores the attributes' do
+          subject.store(firm_result(1, in_person_advice_methods: []), params)
 
-      expect(subject.firms[0]['id']).to eq(2)
-      expect(subject.firms[1]['id']).to eq(1)
-    end
+          expect(subject.firms.first['face_to_face?']).to eq(false)
+        end
+      end
 
-    it 'stores no duplicate firms' do
-      subject.store(firm_result(1), params)
-      subject.store(firm_result(1), params)
+      it 'stores firms ordered by most recent first' do
+        subject.store(firm_result(1), params)
+        subject.store(firm_result(2), params(2))
 
-      expect(subject.firms.length).to eq(1)
-    end
+        expect(subject.firms[0]['id']).to eq(2)
+        expect(subject.firms[1]['id']).to eq(1)
+      end
 
-    it 'stores no more than three firms' do
-      subject.store(firm_result(1), params(1))
-      subject.store(firm_result(2), params(2))
-      subject.store(firm_result(3), params(3))
-      subject.store(firm_result(4), params(4))
+      it 'stores no duplicate firms' do
+        subject.store(firm_result(1), params)
+        subject.store(firm_result(1), params)
 
-      expect(subject.firms.map { |f| f['id'] }).to eq([4, 3, 2])
+        expect(subject.firms.length).to eq(1)
+      end
+
+      it 'stores no more than three firms' do
+        subject.store(firm_result(1), params(1))
+        subject.store(firm_result(2), params(2))
+        subject.store(firm_result(3), params(3))
+        subject.store(firm_result(4), params(4))
+
+        expect(subject.firms.map { |f| f['id'] }).to eq([4, 3, 2])
+      end
     end
   end
 end

--- a/spec/models/rad_consumer_session_spec.rb
+++ b/spec/models/rad_consumer_session_spec.rb
@@ -63,6 +63,25 @@ RSpec.describe RadConsumerSession do
   end
 
   describe '#store' do
+    describe 'most recent search' do
+      it 'always stores the most recent search (independently of the firm storing logic)' do
+        # Store a firm result and search form params
+        subject.store(firm_result(1), params)
+
+        expected_path = '/en/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        expect(subject.search_results_url('en')).to eq(expected_path)
+
+        # Store the same firm with different search params as if we are revisiting
+        # the same firm returned from a different search.
+        updated_search_params = params
+        updated_search_params[:search_form]['advice_for_employees_flag'] = '1'
+        subject.store(firm_result(1), updated_search_params)
+
+        expected_path = '/en/search?search_form%5Badvice_for_employees_flag%5D=1&search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        expect(subject.search_results_url('en')).to eq(expected_path)
+      end
+    end
+
     describe 'recently visited firms' do
       it 'stores the attributes' do
         subject.store(firm_result(1, name: 'foobar', closest_adviser: 10), params)

--- a/spec/models/rad_consumer_session_spec.rb
+++ b/spec/models/rad_consumer_session_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe RadConsumerSession do
         updated_search_params[:search_form]['advice_for_employees_flag'] = '1'
         subject.store(firm_result(1), updated_search_params)
 
-        expected_path = '/en/search?search_form%5Badvice_for_employees_flag%5D=1&search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
+        expected_path = '/en/search?search_form%5Badvice_for_employees_flag%5D=1' \
+          '&search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'
         expect(subject.search_results_url('en')).to eq(expected_path)
       end
     end


### PR DESCRIPTION
# What?

We noticed a bug where the back link in the firm profile page wasn't returning us to the most recent search. This change fixes that.

# Why?

There is a guard condition that used to short-circuit the `#store` method if the firm being visited was already in the list of most recently visited firms.

Unfortunately update of the most recent search URL was happening after this guard condition.

So this change separates out the logic for the two concerns so they cannot affect each other anymore.