### PR TITLE
[DEV APPROVED] 7328 - Removing newsletter from footer and updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Consumer search for the Retirement Adviser Directory
 * [Node.js](http://nodejs.org/)
 * [Bundler](http://bundler.io)
 * [PostgreSQL](http://www.postgresql.org/)
-* [Elasticsearch >= 1.2](https://www.elastic.co/products/elasticsearch)
+* [Elasticsearch 1.5 or 1.7](https://www.elastic.co/products/elasticsearch) - install with `brew install elasticsearch17`
 * [RAD](https://github.com/moneyadviceservice/rad) (for PostgreSQL set up)
 
 ## Installation
@@ -40,17 +40,25 @@ extra seed data required.**
 
 ---
 
+
+### Set up database
+
 Setup the database connection:
 
 ```sh
 $ cp config/example.database.yml config/database.yml
 ```
-
 Be sure to remove or modify the `username` attribute.
 
-Make sure Elasticsearch is running.
+Download a backup of the Production DB and load it into your local DB. Follow the instructions for how to [load it into your local development database here:](https://moneyadviceserviceuk.atlassian.net/wiki/pages/viewpage.action?pageId=63635527#DatabaseTasks(PostgreSQL)-Loadintoyourlocaldevelopmentdatabase)
 
-Push the index. For the production environment replace `rad_development` with
+### Set up Elasticsearch
+
+Make sure Elasticsearch is running. 
+
+__After starting Elasticsearch, verify the version - if you navigate to http://localhost:9200/ the `version.number` should be 1.7.x__
+
+Push the index by running the following command. For the production environment replace `rad_development` with
 `rad_production`:
 
 ```sh
@@ -59,8 +67,13 @@ $ curl -XPOST http://127.0.0.1:9200/rad_development -d @elastic_search_mapping.j
 
 Once you've pushed the index, run the following rake task to populate it:
 ```sh
-rake firms:index
+bundle exec rake firms:index
 ```
+If you navigate to your [local Elasticsearch instance](http://localhost:9200/rad_development/firms/_search) you should now be able to see the list of firms.
+
+There are additional notes on Elasticsearch tasks on the [MAS wiki](https://moneyadviceserviceuk.atlassian.net/wiki/display/RRAD/Elasticsearch+Tasks)
+
+### Google Maps API
 
 For the firm profile maps to work, you will need to provide a Google Maps API
 key in `.env`. You can find an example at `.env.example`.

--- a/app/assets/stylesheets/_enhanced.scss
+++ b/app/assets/stylesheets/_enhanced.scss
@@ -31,6 +31,7 @@
 @import 'components/contact_link';
 @import 'components/education';
 @import 'components/firm';
+@import 'components/footer-primary';
 @import 'components/further_info';
 @import 'components/icon';
 @import 'components/keyword';

--- a/app/assets/stylesheets/components/_footer-primary.scss
+++ b/app/assets/stylesheets/components/_footer-primary.scss
@@ -1,0 +1,13 @@
+.footer-primary__list {
+  text-align: right;
+  list-style: none;
+  padding: 0 $baseline-unit;
+}
+
+.footer-primary__list-item {
+  text-align: left;
+  @include respond-to($mq-m) {
+    display: inline-block;
+    margin: $baseline-unit;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -294,46 +294,15 @@
   <footer class="l-footer">
     <div class="l-footer-primary t-footer-primary">
       <div class="l-constrained">
-
-        <div class="l-footer-primary__left">
-          <form accept-charset="UTF-8" action="/en/newsletter-subscription" class="newsletter-signup t-newsletter" data-remote="true" method="post">
-            <div style="display:none">
-              <input name="utf8" type="hidden" value="&#x2713;" />
-            </div>
-
-            <input id="authenticity_token" name="authenticity_token" type="hidden" value="jeMmyTCj0dxGGMlOBX36RByXc9uH5VZe4/2aGpTnnoI=" />
-            <h2 aria-level="2" class="newsletter-signup__heading" role="heading"><%= t('footer_primary.newsletter.heading') %></h2>
-
-            <ul class="newsletter-signup__benefits-list list-benefits">
-              <%= t('footer_primary.newsletter.benefits_html') %>
-            </ul>
-
-            <fieldset class="newsletter-signup__form js-newsletter-form" id="newsletter_signup">
-                <a href="https://www.moneyadviceservice.org.uk/en/static/contact-us#newsletter_signup" class="t-newsletter-button button newsletter-signup__button newsletter-signup__button--third-party button--normal-white-space"><%= t('footer_primary.newsletter.sign_up') %></a>
-            </fieldset>
-          </form>
-        </div>
-
-        <div class="l-footer-primary__right">
-          <nav role="navigation" aria-label="footer">
-            <ul class="l-footer-primary__list l-footer-primary__list--left">
-              <% t('footer_primary.links_left').each do |item| %>
-              <li class="footer-primary__list-item">
-                <a href="<%= item[:url] %>"><%= item[:title] %></a>
-              </li>
-              <% end %>
-            </ul>
-
-            <ul class="l-footer-primary__list l-footer-primary__list--right">
-              <% t('footer_primary.links_right').each do |item| %>
-              <li class="footer-primary__list-item">
-                <a href="<%= item[:url] %>"><%= raw item[:title] %></a>
-              </li>
-              <% end %>
-            </ul>
-          </nav>
-        </div>
-
+        <nav role="navigation" aria-label="footer">
+          <ul class="footer-primary__list">
+            <% t('footer_primary.links').each do |item| %>
+            <li class="footer-primary__list-item">
+              <a href="<%= item[:url] %>"><%= raw item[:title] %></a>
+            </li>
+            <% end %>
+          </ul>
+        </nav>
       </div>
     </div>
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -143,14 +143,7 @@ cy:
       contact_html: Am ragor o ffyrdd i gysylltu, ewch i'n tudalen <a href="/cy/static/cysylltu-a-ni">cysylltwch â ni</a>
 
   footer_primary:
-    newsletter:
-      heading: Newyddlen
-      benefits_html: |
-        <li>Offer da a newyddion am arian</li>
-        <li>Diolch am gofrestru</li>
-        <li>Awgrymiadau da ar reoli arian</li>
-      sign_up: Tanysgrifiwch i'n newyddlen rhad ac am ddim
-    links_left:
+    links:
       - title: Amdanom ni
         url: https://www.moneyadviceservice.org.uk/cy/static/amdanom-ni
       - title: Canolfan y cyfryngau
@@ -159,7 +152,6 @@ cy:
         url: https://www.moneyadviceservice.org.uk/cy/categories/Partners
       - title: Swyddi
         url: https://www.moneyadviceservice.org.uk/cy/static/swyddi
-    links_right:
       - title: Ein gwaith dyledion
         url: https://www.moneyadviceservice.org.uk/cy/categories/our-debt-work
       - title: Offer a chyfrifianellau

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,14 +143,7 @@ en:
       contact_html: For more ways to get in touch, go to our <a href="https://www.moneyadviceservice.org.uk/en/static/contact-us">contact us</a> page.
 
   footer_primary:
-    newsletter:
-      heading: Newsletter
-      benefits_html: |
-        <li>Top tips on managing money</li>
-        <li>Useful tools and money news</li>
-        <li>All free and unbiased</li>
-      sign_up: Sign up to our free newsletter
-    links_left:
+    links:
       - title: About us
         url: https://www.moneyadviceservice.org.uk/en/static/about-us
       - title: Media centre
@@ -159,7 +152,6 @@ en:
         url: https://www.moneyadviceservice.org.uk/en/categories/partners
       - title: Jobs
         url: https://www.moneyadviceservice.org.uk/en/static/jobs
-    links_right:
       - title: Our debt work
         url: https://www.moneyadviceservice.org.uk/en/categories/our-debt-work
       - title: Tools &amp; calculators


### PR DESCRIPTION
[Ticket 7328](https://moneyadviceservice.tpondemand.com/entity/7328) involves removing the MAS newsletter section from the RAD footer:

## Before: 
![image](https://cloud.githubusercontent.com/assets/14920201/15570580/c3e91bb2-232e-11e6-9b40-9b5f7737b719.png)

## After:
![image](https://cloud.githubusercontent.com/assets/14920201/15570543/77685adc-232e-11e6-9dc3-bc99e34e5b7d.png)

Whilst making the changes, we had setup issues with Elasticsearch so this PR also contains some extra steps in the Readme to avoid these problems (cc @munckymagik @JiggyPete).