### PR TITLE
[DEV APPROVED] 7670 - Switching map and details panels on firm page

### DIFF
--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -1,26 +1,3 @@
-<% if search_form.face_to_face? %>
-  <%= heading_tag(t('firms.show.panels.firm.locations'), level: 3, class: 'l-firm__heading is-hidden-no-js') %>
-
-  <%= firm_map_component(center: {lat: latitude, lng: longitude},
-        adviserPinUrl: image_path('pins/adviser.png'),
-        officePinUrl: image_path('pins/office.png')) do %>
-    <div class="firm__map" data-dough-map></div>
-
-    <ul class="firm__map-pin-items is-hidden">
-      <% firm.advisers.each do |adviser| %>
-        <li data-dough-map-point data-dough-map-point-type="adviser" data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
-          <%= adviser.name %>
-        </li>
-      <% end %>
-      <% firm.offices.each do |office| %>
-        <li data-dough-map-point data-dough-map-point-type="office" data-dough-map-point-lat="<%= office.location.latitude %>" data-dough-map-point-lng="<%= office.location.longitude %>">
-          <%= office_address(office) %>
-        </li>
-      <% end %>
-    </ul>
-  <% end %>
-<% end %>
-
 <%= heading_tag(t('firms.show.panels.firm.services.heading'), level: 3, class: 'l-firm__heading') %>
 <div class="l-2col l-firm__row">
   <div class="l-2col-even">
@@ -85,6 +62,29 @@
     </div>
   </div>
 </div>
+
+<% if search_form.face_to_face? %>
+  <%= heading_tag(t('firms.show.panels.firm.locations'), level: 3, class: 'l-firm__heading is-hidden-no-js') %>
+
+  <%= firm_map_component(center: {lat: latitude, lng: longitude},
+        adviserPinUrl: image_path('pins/adviser.png'),
+        officePinUrl: image_path('pins/office.png')) do %>
+    <div class="firm__map" data-dough-map></div>
+
+    <ul class="firm__map-pin-items is-hidden">
+      <% firm.advisers.each do |adviser| %>
+        <li data-dough-map-point data-dough-map-point-type="adviser" data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
+          <%= adviser.name %>
+        </li>
+      <% end %>
+      <% firm.offices.each do |office| %>
+        <li data-dough-map-point data-dough-map-point-type="office" data-dough-map-point-lat="<%= office.location.latitude %>" data-dough-map-point-lng="<%= office.location.longitude %>">
+          <%= office_address(office) %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>
 
 <% if firm_has_other_services?(firm) || firm.languages.present? %>
   <div class="l-firm__row">


### PR DESCRIPTION
## 7670 - Switching map and details panels on firm page

Redeye has run an AA test on the firm details page on RAD to see if there is an increase in interaction if the map is moved under the text. The test has proven to be positive.
 
Currently, the map is above the text which provide firms details.

| Before | After |
|--------|------|
|![image](https://cloud.githubusercontent.com/assets/13165846/19303770/da3e4aae-9061-11e6-8748-0780bd6c6f9b.png)|![image](https://cloud.githubusercontent.com/assets/13165846/19303716/b17cf11a-9061-11e6-95f2-d145c9d257ea.png)|
