### PR TITLE
[DEV APPROVED] TP: 7733, Comment: Amend wrong URL

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -20,7 +20,7 @@ module SearchHelper
     return if key == 'ignored'
 
     info = t("search.accreditations.items.#{key}")
-    link_to "glossary/##{key}", class: "accreditation t-#{kind}" do
+    link_to glossary_path(locale: locale, anchor: key), class: "accreditation t-#{kind}" do
       image_tag "#{key}.png", alt: info[:title], class: 'accreditation__img'
     end
   end


### PR DESCRIPTION
This amends the link to the Glossary from (for instance)
- 'https://directory.moneyadviceservice.org.uk/en/firms/glossary/#chartered_fp' to 
- 'https://directory.moneyadviceservice.org.uk/en/glossary/#chartered_fp'
i.e. from .../en/... not .../en/firms/...