### PR TITLE
7873 - Find firm by id on elastic search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'dough-ruby',
     tag: 'v5.22.0.286'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.0.111'
+gem 'mas-rad_core', '0.1.1'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.0.111)
+    mas-rad_core (0.1.1)
       active_model_serializers
       geocoder
       httpclient
@@ -171,7 +171,7 @@ GEM
     rainbow (2.0.0)
     raindrops (0.13.0)
     rake (10.5.0)
-    redis (3.3.1)
+    redis (3.3.3)
     rollbar (1.5.0)
       multi_json (~> 1.3)
     rspec-core (3.2.3)
@@ -258,7 +258,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
-  mas-rad_core (= 0.0.111)
+  mas-rad_core (= 0.1.1)
   pg
   pry-rails
   rails (~> 4.2.5.2)
@@ -277,4 +277,4 @@ RUBY VERSION
    ruby 2.2.2p95
 
 BUNDLED WITH
-   1.12.5
+   1.13.7

--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -1,18 +1,28 @@
 class FirmsController < ApplicationController
   def show
-    @search_form = SearchForm.new(params[:search_form].merge(firm_id: params[:id]))
-    result = FirmRepository.new.search(@search_form.to_query)
-
-    @firm  = result.firms.first
+    @search_form = SearchForm.new(firm_search_params)
+    @firm = FirmResult.new(firm_repository)
     @offices = Geosort.by_distance(@search_form.coordinates, @firm.offices)
     @advisers = sort_advisers(@search_form, @firm.advisers)
-
+    @firm.closest_adviser = closest_adviser
     @latitude, @longitude = @search_form.coordinates
 
     store_recently_visited_firm
   end
 
   private
+
+  def firm_repository
+    FirmRepository.new.find(Firm.find(params[:id]))
+  end
+
+  def firm_search_params
+    (params[:search_form] || {}).merge(firm_id: params[:id])
+  end
+
+  def closest_adviser
+    @advisers.first.try(:distance)
+  end
 
   def rad_consumer_session
     @rad_consumer_session ||= RadConsumerSession.new(session)

--- a/app/models/rad_consumer_session.rb
+++ b/app/models/rad_consumer_session.rb
@@ -11,7 +11,7 @@ class RadConsumerSession
   end
 
   def search_results_url(locale)
-    @store['locale_to_search_path_mappings'][locale.to_s]
+    (@store['locale_to_search_path_mappings'] || {})[locale.to_s]
   end
 
   def store(firm_result, params)

--- a/app/presenters/recently_visited_firm.rb
+++ b/app/presenters/recently_visited_firm.rb
@@ -1,0 +1,17 @@
+class RecentlyVisitedFirm < OpenStruct
+  def self.map(recently_visited_firms)
+    recently_visited_firms.map { |recently_visited_firm| new(recently_visited_firm) }
+  end
+
+  def translated_profile_path
+    profile_path[I18n.locale.to_s]
+  end
+
+  def closest_adviser?
+    face_to_face? && closest_adviser.to_f > 0
+  end
+
+  def phone_or_online_only?
+    !face_to_face?
+  end
+end

--- a/app/views/firms/partials/_recently_visited.html.erb
+++ b/app/views/firms/partials/_recently_visited.html.erb
@@ -4,13 +4,13 @@
                   class: 'l-firm__heading l-firm__heading--collapse') %>
 
   <ol class="l-results__list recently-viewed">
-    <% recently_visited_firms.each do |recently_visited_firm_hash| %>
+    <% RecentlyVisitedFirm.map(recently_visited_firms).each do |recently_visited_firm| %>
       <li class="recently-viewed__item t-firm">
-        <%= link_to recently_visited_firm_hash['name'], recently_visited_firm_hash['profile_path'][I18n.locale.to_s], class: "recently-viewed__item__firm-name" %>
+        <%= link_to recently_visited_firm.name, recently_visited_firm.translated_profile_path, class: "recently-viewed__item__firm-name" %>
 
-        <% if recently_visited_firm_hash['face_to_face?'] %>
-          <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: recently_visited_firm_hash['closest_adviser'], distance_class: 'recently-viewed__item__adviser-distance' }%>
-        <% else %>
+        <% if recently_visited_firm.closest_adviser? %>
+          <%= render partial: 'search/partials/firm/adviser_distance', locals: { distance: recently_visited_firm.closest_adviser, distance_class: 'recently-viewed__item__adviser-distance' }%>
+        <% elsif recently_visited_firm.phone_or_online_only? %>
           <div>
             <%= t('firms.show.recently_visited.remote') %>
           </div>

--- a/spec/fixtures/vcr_cassettes/search_by_firm_name.yml
+++ b/spec/fixtures/vcr_cassettes/search_by_firm_name.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 17 Feb 2017 10:13:34 GMT
+      Expires:
+      - Sat, 18 Feb 2017 10:13:34 GMT
+      Cache-Control:
+      - public, max-age=86400
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '410'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "United Kingdom",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 60.91569999999999,
+                          "lng" : 33.9165549
+                       },
+                       "southwest" : {
+                          "lat" : 34.5614,
+                          "lng" : -8.8988999
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.378051,
+                       "lng" : -3.435973
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 60.85484959999999,
+                          "lng" : 1.762995
+                       },
+                       "southwest" : {
+                          "lat" : 49.8823322,
+                          "lng" : -8.6498934
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJqZHHQhE7WgIReiWIMkOg-MQ",
+                 "types" : [ "country", "political" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Fri, 17 Feb 2017 10:13:34 GMT
+recorded_with: VCR 2.9.3

--- a/spec/models/rad_consumer_session_spec.rb
+++ b/spec/models/rad_consumer_session_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe RadConsumerSession do
   describe '#search_results_url' do
     before { subject.store(firm_result(1), params) }
 
+    context 'when locale mapping is blank' do
+      it 'returns nil' do
+        expect(described_class.new({}).search_results_url('en')).to be(nil)
+      end
+    end
+
     context 'when locale is a string' do
       it 'returns the search_results_url in english' do
         expected_path = '/en/search?search_form%5Badvice_method%5D=face_to_face&search_form%5Bpostcode%5D=EC1N+2TD'

--- a/spec/models/rad_consumer_session_spec.rb
+++ b/spec/models/rad_consumer_session_spec.rb
@@ -1,11 +1,14 @@
 RSpec.describe RadConsumerSession do
   def firm_result(id, name: 'foobar', closest_adviser: 10, in_person_advice_methods: [1, 2])
-    FirmResult.new('_source' => { '_id' => id,
-                                  'registered_name' => name,
-                                  'advisers' => [],
-                                  'offices' => [],
-                                  'in_person_advice_methods' => in_person_advice_methods },
-                   'sort' => [closest_adviser])
+    result = FirmResult.new('_source' => {
+                              '_id' => id,
+                              'registered_name' => name,
+                              'advisers' => [],
+                              'offices' => [],
+                              'in_person_advice_methods' => in_person_advice_methods
+                            })
+    result.closest_adviser = closest_adviser
+    result
   end
 
   def params(id = '1')

--- a/spec/presenters/recently_visited_firm_spec.rb
+++ b/spec/presenters/recently_visited_firm_spec.rb
@@ -1,0 +1,94 @@
+RSpec.describe RecentlyVisitedFirm do
+  let(:recently_visited_firm) do
+    RecentlyVisitedFirm.new(
+      profile_path: {
+        'en' => '/en/firms/3866',
+        'cy' => '/cy/firms/3866'
+      }
+    )
+  end
+
+  describe '#translated_profile_path' do
+    subject { recently_visited_firm.translated_profile_path }
+
+    context 'when english' do
+      before { expect(I18n).to receive(:locale).and_return('en') }
+
+      it 'returns english profile path' do
+        expect(subject).to eq('/en/firms/3866')
+      end
+    end
+
+    context 'when welsh' do
+      before { expect(I18n).to receive(:locale).and_return('cy') }
+
+      it 'returns welsh profile path' do
+        expect(subject).to eq('/cy/firms/3866')
+      end
+    end
+  end
+
+  describe '#closest_adviser?' do
+    subject { recently_visited_firm.closest_adviser? }
+
+    context 'when is face to face' do
+      before do
+        expect(recently_visited_firm).to receive(:face_to_face?).and_return(true)
+      end
+
+      context 'when has closest adviser (user searched by location)' do
+        before do
+          expect(recently_visited_firm).to receive(:closest_adviser).and_return(0.34)
+        end
+
+        it 'returns true' do
+          expect(subject).to be(true)
+        end
+      end
+
+      context 'when does not have closest adviser (user searched by name)' do
+        before do
+          expect(recently_visited_firm).to receive(:closest_adviser).and_return(nil)
+        end
+
+        it 'returns false' do
+          expect(subject).to be(false)
+        end
+      end
+    end
+
+    context 'when is not face to face' do
+      before do
+        expect(recently_visited_firm).to receive(:face_to_face?).and_return(false)
+      end
+
+      it 'returns false' do
+        expect(subject).to be(false)
+      end
+    end
+  end
+
+  describe '#phone_or_online_only?' do
+    subject { recently_visited_firm.phone_or_online_only? }
+
+    context 'when is face to face' do
+      before do
+        expect(recently_visited_firm).to receive(:face_to_face?).and_return(true)
+      end
+
+      it 'returns false' do
+        expect(subject).to be(false)
+      end
+    end
+
+    context 'when is not face to face' do
+      before do
+        expect(recently_visited_firm).to receive(:face_to_face?).and_return(false)
+      end
+
+      it 'returns true' do
+        expect(subject).to be(true)
+      end
+    end
+  end
+end

--- a/spec/support/firm_section.rb
+++ b/spec/support/firm_section.rb
@@ -33,4 +33,8 @@ class FirmSection < SitePrism::Section
   def minimum_pot_size
     root_element.find('.t-minimum-pot-size').text
   end
+
+  def <=>(other)
+    name <=> other.name
+  end
 end

--- a/spec/support/landing_page.rb
+++ b/spec/support/landing_page.rb
@@ -14,6 +14,7 @@ class LandingPage < SitePrism::Page
 
   element :search, '.button--primary'
   element :errors, '.l-landing-page__validation'
+  sections :firms, FirmSection, 'li.t-firm'
 
   def invalid_parameters?
     has_css?('.field_with_errors')


### PR DESCRIPTION
Before the code was using searching for all firms
passing the _id as search all.

Changing to just find the specific id solves the issue.

But generates another problem. The reason that the code
does a search all is because elastic search returns a
_score attribute with the distance as the value from
where the user is located.

This PR includes the fix bug on the recently firms visited sidebar
When user search by name the app should not pass any information
of the near adviser (because the user did not provide any location).

The logic is not using the elastic feature anymore, it is relying on the
Geosort module to get the nearest adviser to show the message
on the sidebar.

**Disclaimer: The Gemfile are using a local mas-rad-core until this PR is merged: https://github.com/moneyadviceservice/mas-rad_core/pull/161
After the merge I will update the Gemfile.**
