### PR TITLE
[DEV APPROVED] - 7929 expose office website

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'dough-ruby',
     tag: 'v5.22.0.286'
 gem 'geocoder'
 gem 'kaminari'
-gem 'mas-rad_core', '0.1.1'
+gem 'mas-rad_core', '0.1.2'
 gem 'pg'
 gem 'rollbar'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,14 +106,14 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.3)
-    language_list (1.1.0)
+    language_list (1.2.1)
     launchy (2.4.3)
       addressable (~> 2.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mas-rad_core (0.1.1)
+    mas-rad_core (0.1.2)
       active_model_serializers
       geocoder
       httpclient
@@ -219,7 +219,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    statsd-ruby (1.3.0)
+    statsd-ruby (1.4.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -258,7 +258,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   launchy
-  mas-rad_core (= 0.1.1)
+  mas-rad_core (= 0.1.2)
   pg
   pry-rails
   rails (~> 4.2.5.2)
@@ -277,4 +277,4 @@ RUBY VERSION
    ruby 2.2.2p95
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/app/helpers/office_helper.rb
+++ b/app/helpers/office_helper.rb
@@ -8,4 +8,8 @@ module OfficeHelper
       office.address_postcode
     ].join(', ')
   end
+
+  def display_website(office, firm)
+    office.website.present? ? office.website : firm.website_address
+  end
 end

--- a/app/views/firms/partials/_firm_links.html.erb
+++ b/app/views/firms/partials/_firm_links.html.erb
@@ -19,7 +19,7 @@
 
   <% if website_address.present? %>
     <li>
-      <%= link_to ensure_external_link_has_protocol(website_address), class: 'outline-button', target: '_blank' do %>
+      <%= link_to ensure_external_link_has_protocol(website_address), class: 'outline-button t-website', target: '_blank' do %>
         <%= svg_icon :offsite_link, title: t('firms.show.website_address'), class: 'outline-button__svg-icon'
         %><%= t('firms.show.website_address') %>
       <% end %>

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -5,7 +5,7 @@
   <% end %>
   <% if search_form.face_to_face? && @offices.present? %>
     <%= render partial: 'firms/partials/firm_links',
-             locals: { telephone_number: @offices.first.telephone_number, email_address: @offices.first.email_address, website_address: @firm.website_address } %>
+             locals: { telephone_number: @offices.first.telephone_number, email_address: @offices.first.email_address, website_address: display_website(@offices.first, @firm) } %>
   <% else %>
     <%= render partial: 'firms/partials/firm_links',
                locals: { telephone_number: @firm.telephone_number, email_address: @firm.email_address, website_address: @firm.website_address } %>

--- a/app/views/firms/partials/_offices.html.erb
+++ b/app/views/firms/partials/_offices.html.erb
@@ -28,6 +28,12 @@
               %><%= t('firms.show.panels.offices.email_office') %>
             <% end %>
           </div>
+          <div class="office__website">
+            <%= link_to display_website(office, firm), class: 'contact-link' do %>
+              <%= svg_icon :offsite_link, title: t('firms.show.panels.offices.website'), class: 'contact-link__svg-icon'
+              %><%= display_website(office, firm) %>
+            <% end %>
+          </div>
         </div>
       </div>
       <% if office.disabled_access %>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -90,6 +90,7 @@ cy:
           heading: Swyddfeydd
           email_office: E-bostio’r swyddfa
           telephone: Ffôn
+          website: Gwefan
           disabled_access: Mynediad i’r anabl
           show_more: Dangos mwy o swyddfeydd
         advisers:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,7 @@ en:
           heading: Offices
           email_office: Email office
           telephone: Telephone
+          website: Website
           disabled_access: Disabled access
           show_more: Show more offices
         advisers:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160329110348) do
+ActiveRecord::Schema.define(version: 20161216141323) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -208,6 +209,7 @@ ActiveRecord::Schema.define(version: 20160329110348) do
     t.datetime "updated_at",                       null: false
     t.float    "latitude"
     t.float    "longitude"
+    t.string   "website"
   end
 
   create_table "ongoing_advice_fee_structures", force: :cascade do |t|

--- a/spec/features/firm_profile_for_in_person_search_spec.rb
+++ b/spec/features/firm_profile_for_in_person_search_spec.rb
@@ -4,7 +4,20 @@ RSpec.feature 'Firm profile page from an "in-person" search',
   let(:results_page) { ResultsPage.new }
   let(:profile_page) { ProfilePage.new }
 
-  scenario 'viewing office information for an "in-person" search' do
+  scenario 'viewing office information which has its own website for an "in-person" search' do
+    with_elastic_search! do
+      given_firm_with_nearest_office_with_website
+      and_i_perform_an_in_person_search
+      when_i_view_the_firm_profile
+      and_i_select_the_offices_tab
+      then_i_should_see_a_number_of_offices_listed
+      and_they_should_be_ordered_by_closest_to_search_postcode
+      and_the_email_address_for_the_nearest_office_is_prominent
+      and_the_website_for_the_nearest_office_is_prominent
+    end
+  end
+
+  scenario 'viewing office information which has no website for an "in-person" search' do
     with_elastic_search! do
       given_firm_with_multiple_offices_has_been_indexed
       and_i_perform_an_in_person_search
@@ -13,6 +26,7 @@ RSpec.feature 'Firm profile page from an "in-person" search',
       then_i_should_see_a_number_of_offices_listed
       and_they_should_be_ordered_by_closest_to_search_postcode
       and_the_email_address_for_the_nearest_office_is_prominent
+      and_the_website_for_the_firm_is_prominent
     end
   end
 
@@ -36,12 +50,90 @@ RSpec.feature 'Firm profile page from an "in-person" search',
 
   def given_firm_with_multiple_offices_has_been_indexed
     with_fresh_index! do
-      @firm = create(:firm)
+      @firm = create(:firm, website_address: 'http://www.foobar.com')
       create(:adviser, firm: @firm, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616, travel_distance: 100)
-      @firm.main_office.update_attributes!(email_address: 'main.office@example.com', address_line_one: '120 Holborn', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 2TD', latitude: 51.518148, longitude: -0.108013)
-      create(:office, firm: @firm, email_address: 'local.1@example.com', address_line_one: 'Phoenix House', address_line_two: '18 King William St', address_town: 'London', address_county: nil, address_postcode: 'EC4N 7BP', latitude: 51.511224, longitude: -0.087422)
-      create(:office, firm: @firm, email_address: 'local.2@example.com', address_line_one: '12 Leather Ln', address_line_two: 'London', address_town: 'London', address_county: nil, address_postcode: 'EC1N 7SS', latitude: 51.519144, longitude: -0.108927)
+      @firm.main_office.update_attributes!(
+        email_address: 'main.office@example.com',
+        address_line_one: '120 Holborn',
+        address_line_two: 'London',
+        address_town: 'London',
+        address_county: nil,
+        address_postcode: 'EC1N 2TD',
+        latitude: 51.518148,
+        longitude: -0.108013
+      )
+      create(
+        :office,
+        firm: @firm,
+        email_address: 'local.1@example.com',
+        address_line_one: 'Phoenix House',
+        address_line_two: '18 King William St',
+        address_town: 'London',
+        address_county: nil,
+        address_postcode: 'EC4N 7BP',
+        latitude: 51.511224,
+        longitude: -0.087422,
+        website: nil
+      )
 
+      create(
+        :office,
+        firm: @firm,
+        email_address: 'local.2@example.com',
+        address_line_one: '12 Leather Ln',
+        address_line_two: 'London',
+        address_town: 'London',
+        address_county: nil,
+        address_postcode: 'EC1N 7SS',
+        latitude: 51.519144,
+        longitude: -0.108927,
+        website: nil
+      )
+
+      @remote_firm = create(:firm, :with_remote_advice)
+      @remote_firm.main_office.update_attributes!(email_address: 'remote@example.com')
+    end
+  end
+
+  def given_firm_with_nearest_office_with_website
+    with_fresh_index! do
+      @firm = create(:firm, website_address: 'http://www.foobar.com')
+      create(:adviser, firm: @firm, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616, travel_distance: 100)
+      @firm.main_office.update_attributes!(
+        email_address: 'main.office@example.com',
+        address_line_one: '120 Holborn',
+        address_line_two: 'London',
+        address_town: 'London',
+        address_county: nil,
+        address_postcode: 'EC1N 2TD',
+        latitude: 51.518148,
+        longitude: -0.108013
+      )
+      create(
+        :office,
+        firm: @firm,
+        email_address: 'local.1@example.com',
+        address_line_one: 'Phoenix House',
+        address_line_two: '18 King William St',
+        address_town: 'London',
+        address_county: nil,
+        address_postcode: 'EC4N 7BP',
+        latitude: 51.511224,
+        longitude: -0.087422
+      )
+      create(
+        :office,
+        firm: @firm,
+        email_address: 'local.2@example.com',
+        address_line_one: '12 Leather Ln',
+        address_line_two: 'London',
+        address_town: 'London',
+        address_county: nil,
+        address_postcode: 'EC1N 7SS',
+        latitude: 51.519144,
+        longitude: -0.108927,
+        website: 'http://www.office1.com'
+      )
       @remote_firm = create(:firm, :with_remote_advice)
       @remote_firm.main_office.update_attributes!(email_address: 'remote@example.com')
     end
@@ -95,6 +187,14 @@ RSpec.feature 'Firm profile page from an "in-person" search',
 
   def and_the_email_address_for_the_nearest_office_is_prominent
     expect(profile_page.email[:href]).to eq('mailto:local.2@example.com')
+  end
+
+  def and_the_website_for_the_nearest_office_is_prominent
+    expect(profile_page.website[:href]).to eq('http://www.office1.com')
+  end
+
+  def and_the_website_for_the_firm_is_prominent
+    expect(profile_page.website[:href]).to eq(@firm.website_address)
   end
 
   def then_the_email_address_for_the_main_office_is_prominent

--- a/spec/helpers/office_helper_spec.rb
+++ b/spec/helpers/office_helper_spec.rb
@@ -12,15 +12,48 @@ RSpec.describe OfficeHelper, type: :helper do
       'email_address'    => 'postie@example.com',
       'telephone_number' => '5555 555 5555',
       'disabled_access'  => true,
+      'website'          => website,
       'location' => { 'lat' => 51.5180697, 'lon' => -0.1085203 }
     }
   end
+
+  let(:website) { 'http://www.postman.com' }
   let(:office_result) { OfficeResult.new(data) }
+  let(:firm_data) { firm_data }
+  let(:firm_result) { FirmResult.new(firm_data) }
 
   describe '#office_address' do
     it 'outputs a ", " concatenated string of the address' do
       expected = 'c/o Postman Pat, Forge Cottage, Greendale, Cumbria, LA8 9BE'
       expect(office_address(office_result)).to eq(expected)
     end
+  end
+
+  describe '#display_website' do
+    context 'when the office has its own website address' do
+      it 'returns the office website' do
+        expected = 'http://www.postman.com'
+        expect(display_website(office_result, firm_result)).to eq(expected)
+      end
+    end
+
+    context 'when the office no website address' do
+      let(:website) { nil }
+
+      it 'returns the firm\'s website' do
+        expected = 'http://www.firmsite.com'
+        expect(display_website(office_result, firm_result)).to eq(expected)
+      end
+    end
+  end
+
+  def firm_data
+    {
+      '_source' => {
+        'offices' => [office_result],
+        'advisers' => [],
+        'website_address' => 'http://www.firmsite.com'
+      }
+    }
   end
 end

--- a/spec/support/profile_page.rb
+++ b/spec/support/profile_page.rb
@@ -9,4 +9,5 @@ class ProfilePage < SitePrism::Page
   element :adviser_tab, '[data-dough-tab-selector-trigger="3"]'
   element :telephone, '.t-telephone'
   element :email, '.t-email'
+  element :website, '.t-website'
 end


### PR DESCRIPTION
This pr addresses [user story 7929](https://moneyadviceservice.tpondemand.com/restui/board.aspx?acid=f363bea37e60ac292c07aaf8b50f0da9#page=board/5624876525867731357&appConfig=eyJhY2lkIjoiREI4ODcwRjkxMDNDRTM2NTlBMzhDNTRBRTVBNUU1N0UifQ==&boardPopup=userstory/7929/silent)

It needs to be deployed in conjunction with [mas-rad_core#162](https://github.com/moneyadviceservice/mas-rad_core/pull/162) and builds on [rad#401](https://github.com/moneyadviceservice/rad/pull/401) which created the ability for admin users to add a specific website for a firm's office.