### PR TITLE
[DEV APPROVED] Require OfficeSection and AdviserSection manually on ProfilePage in specs so they're available

### DIFF
--- a/spec/support/profile_page.rb
+++ b/spec/support/profile_page.rb
@@ -1,4 +1,6 @@
 class ProfilePage < SitePrism::Page
+  require_relative './office_section'
+  require_relative './adviser_section'
   set_url_matcher %r{/(en|cy)/firms}
 
   sections :offices, OfficeSection, '.t-office'


### PR DESCRIPTION
I was having this error on Linux when running rspec:
`Uninitialized Constant (NameError)` for OfficeSection and AdviserSection in ProfilePage. Sorting the files when required on `spec_helper.rb` fixed it and it should now have the same behavior on different systems.