### PR TITLE
8462 change webchat to load new chat window

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -192,6 +192,7 @@
 <script src="https://masjumpprdstorage.blob.core.windows.net/responsive-assets/a/webchat-8a47f66c98f9abd3ce2afd710aff5891.js"></script>
 <script type='text/javascript'>
   sWODomain = 'www.moneyadviceservice.org.uk';
+  sWOChatstart = 'https://webchat.moneyadviceservice.org.uk/newchat/chat.aspx';
 
   sWOImageLoaded = function() {
 


### PR DESCRIPTION
the current web chat link on RAD opens the default WhosOn branded web chat windows, this change adds the sWOChatStart variable to the application for the webchat.js script so the web chat link on RAD opens the new Mas branded chat window