### PR TITLE
[DEV APPROVED] 7957 - Add aria-hidden property to svg icon to hide from VoiceOver

### DIFF
--- a/app/views/search/partials/firm/_adviser_distance.html.erb
+++ b/app/views/search/partials/firm/_adviser_distance.html.erb
@@ -1,5 +1,5 @@
 <div class="firm__adviser-distance <%= distance_class if local_assigns[:distance_class] %> t-distance_to_the_nearest_adviser">
-  <%= svg_icon :map_pin, class: 'firm__adviser-distance-pin' %>
+  <%= svg_icon :map_pin, { class: 'firm__adviser-distance-pin', 'aria-hidden' => 'true' } %>
   <%= t('search.result.adviser') %>
   <%= closest_adviser_text(distance) %>
 </div>


### PR DESCRIPTION
[TP Link](https://moneyadviceservice.tpondemand.com/entity/7957)

![image](https://user-images.githubusercontent.com/689327/29215325-7acdc312-7ea2-11e7-8fab-f590635bdd6d.png)

The pin image on search results next to "has an adviser X miles away" is being read as "image" for VoiceOver users, which is confusing. Since the image is not required and the text surrounding it is sufficient, `aria-hidden=true` was added to hide it from screen readers.