### PR TITLE
[DEV APPROVED]Set Ubuntu version to Precise for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 sudo: false
 cache: bundler
+dist: precise
 rvm:
   - 2.2.2
 services:


### PR DESCRIPTION
The build is not working in Travis. We found this issue while working on #324 and fixed it there but that branch won't be merged.

**Reason**
Travis is rolling out a newer version of Ubuntu, the Elasticsearch version is probably different because search results are returning nil. This is the message for failing builds:
>This job ran on our Trusty environment, which is gradually becoming our default Linux environment. Read all about this [in our blog: Trusty as a default Linux is coming](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default) and take note that you can add `dist: precise` in your .travis.yml file to continue using Precise. 