### PR TITLE
[WIP] - 7958, 7969 - Add legend to advice search form for assistive technologies

### DIFF
--- a/app/assets/stylesheets/layouts/_landing_page.scss
+++ b/app/assets/stylesheets/layouts/_landing_page.scss
@@ -104,6 +104,8 @@
 }
 
 .l-landing-page__search-filter__header {
+  @extend %font-heading-heavy;
+  color: $color-green-primary;
   margin-top: $baseline-unit*2;
   margin-left: $baseline-unit*3;
   margin-bottom: 0;

--- a/app/views/landing_page/_search_filter.html.erb
+++ b/app/views/landing_page/_search_filter.html.erb
@@ -1,10 +1,10 @@
-<%= form_for @form, url: search_path, 
-                    method: :get, 
-                    html: {class: 'form form--collapse t-in-person', 
-                           novalidate: true}, 
-                    data: {search_filter: '', 
+<%= form_for @form, url: search_path,
+                    method: :get,
+                    html: {class: 'form form--collapse t-in-person',
+                           novalidate: true},
+                    data: {search_filter: '',
                            dough_component: 'Validation',
-                           'dough-validation-config' => 
+                           'dough-validation-config' =>
                            '{"showInlineValidation":false, "showValidationSummaryLinks":false}'
                             },
                     builder: Dough::Forms::Builders::Validation do |f| %>
@@ -20,9 +20,8 @@
   <%= f.hidden_field :pension_pot_size, value: SearchForm::ANY_SIZE_VALUE %>
 
   <div class="search-filter--container">
-    <div class="l-results__filter">
+    <div class="l-results__filter" role="group" aria-labelledby="find_retirement_adviser_heading">
       <fieldset class="form__group search-filter__section">
-        <legend class='visually-hidden'><%= t('find_retirement_adviser.heading') %></legend>
         <%= render partial: 'search/partials/filters/advice_method', locals: {f: f} %>
         <%= render 'search_button', button_class: "search-filter__button" %>
       </fieldset>

--- a/app/views/landing_page/_search_filter.html.erb
+++ b/app/views/landing_page/_search_filter.html.erb
@@ -22,6 +22,7 @@
   <div class="search-filter--container">
     <div class="l-results__filter">
       <fieldset class="form__group search-filter__section">
+        <legend class='visually-hidden'><%= t('find_retirement_adviser.heading') %></legend>
         <%= render partial: 'search/partials/filters/advice_method', locals: {f: f} %>
         <%= render 'search_button', button_class: "search-filter__button" %>
       </fieldset>

--- a/app/views/landing_page/_search_filter.html.erb
+++ b/app/views/landing_page/_search_filter.html.erb
@@ -20,7 +20,7 @@
   <%= f.hidden_field :pension_pot_size, value: SearchForm::ANY_SIZE_VALUE %>
 
   <div class="search-filter--container">
-    <div class="l-results__filter" role="group" aria-labelledby="find_retirement_adviser_heading">
+    <div class="l-results__filter">
       <fieldset class="form__group search-filter__section">
         <%= render partial: 'search/partials/filters/advice_method', locals: {f: f} %>
         <%= render 'search_button', button_class: "search-filter__button" %>

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -14,10 +14,10 @@
 <div class="l-landing-page__find-adviser">
   <div class="l-constrained">
     <section class="l-landing-page__2col search-filter l-landing-page__search-filter t-search-filter" data-further-info>
-      <h2 class="l-landing-page__search-filter__header" id="find_retirement_adviser_heading">
+      <legend class="l-landing-page__search-filter__header">
         <%= t('find_retirement_adviser.heading') %>
         <%= render 'further_info_trigger' %>
-      </h2>
+      </legend>
       <%= render 'further_info_content' %>
       <%= render 'landing_page/search_filter' %>
     </section>

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -14,7 +14,7 @@
 <div class="l-landing-page__find-adviser">
   <div class="l-constrained">
     <section class="l-landing-page__2col search-filter l-landing-page__search-filter t-search-filter" data-further-info>
-      <h2 class="l-landing-page__search-filter__header">
+      <h2 class="l-landing-page__search-filter__header" id="find_retirement_adviser_heading">
         <%= t('find_retirement_adviser.heading') %>
         <%= render 'further_info_trigger' %>
       </h2>


### PR DESCRIPTION
[TP Link](https://moneyadviceservice.tpondemand.com/entity/7958)

The story proposes `ensure that the first element within the <fieldset is the <legend> and that this is used to describe the purpose of the radio button group` as a solution. A first approach was to add a legend tag with "How would you like to receive advice?" to the form to describe the purpose of the radio button group. However, it has to have a `visually-hidden` class so the title doesn't show up twice:
![image](https://user-images.githubusercontent.com/689327/29216637-35f128ec-7ea7-11e7-93cb-4899697c19bb.png)

A different approach would be to use the legend as the title using the h2 classes. This doesn't seem to have any issues in regards to the position of html tags, but there are some important styling differences:
![image](https://user-images.githubusercontent.com/689327/29216677-5c612f90-7ea7-11e7-85b7-0cb8ddd42e4b.png)

I researched to see if it was valid to use `<legend><h2>Title</h2></legend>` but it seems this HTML isn't valid [unless using HTML 5.2](https://w3c.github.io/html/sec-forms.html#the-legend-element). Digging deeper into this, there seems to be two valid approaches for grouping controls for accessibility, the second one being [associating related controls with WAI-ARIA](https://www.w3.org/WAI/tutorials/forms/grouping/#associating-related-controls-with-wai-aria). This doesn't change the style at all, but it might be an issue on the validator since the fieldset is still present but without a legend tab (and removing this would probably need a lot of frontend rework to keep the visual style).
![image](https://user-images.githubusercontent.com/689327/29216400-7b0686e4-7ea6-11e7-86ed-d1665346815a.png)

The first solution is probably good enough, but it feels like the second one is better.