### PR TITLE
[DEV APPROVED] 7960 - Add aria-label to information links for screen readers and change their behaviour

### DIFF
--- a/app/assets/stylesheets/components/_icon.scss
+++ b/app/assets/stylesheets/components/_icon.scss
@@ -20,6 +20,25 @@
   height: 25px;
 }
 
+.icon--further-info {
+  display: none;
+  font-weight: 700;
+  font-style: italic;
+  color: $color-green-primary;
+  padding: $baseline-unit;
+
+  &:hover,
+  &:focus,
+  &:visited {
+    text-decoration: none;
+    color: $color-green-primary;
+  }
+
+  .js & {
+    display: inline-block;
+  }
+}
+
 // The 2x versions
 @include device-pixel-ratio() {
   .icon--youtube-black {

--- a/app/views/application/_further_info_trigger.html.erb
+++ b/app/views/application/_further_info_trigger.html.erb
@@ -1,2 +1,3 @@
-<a href="<%= url if local_assigns[:url] %>" class="icon icon--info" data-further-info-trigger aria-label="<%= t('global.further_information') %>">
+<a href="<%= url if local_assigns[:url] %>" class="icon--further-info" role="button" data-further-info-trigger aria-label="<%= t('global.further_information') %>">
+  i
 </a>

--- a/app/views/application/_further_info_trigger.html.erb
+++ b/app/views/application/_further_info_trigger.html.erb
@@ -1,5 +1,2 @@
-<a href="<%= url if local_assigns[:url] %>" class="further-info__trigger" data-further-info-trigger>
-  <svg focusable="false" class="svg-icon further-info__svg-icon" xmlns="http://www.w3.org/2000/svg" style="">
-    <use xlink:href="#icon-tooltip"></use>
-  </svg>
+<a href="<%= url if local_assigns[:url] %>" class="icon icon--info" data-further-info-trigger aria-label="<%= t('global.further_information') %>">
 </a>

--- a/app/views/landing_page/_search_filter.html.erb
+++ b/app/views/landing_page/_search_filter.html.erb
@@ -26,6 +26,7 @@
           <%= t('find_retirement_adviser.heading') %>
           <%= render 'further_info_trigger' %>
         </legend>
+        <%= render 'further_info_content' %>
         <%= render partial: 'search/partials/filters/advice_method', locals: {f: f} %>
         <%= render 'search_button', button_class: "search-filter__button" %>
       </fieldset>

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -14,7 +14,6 @@
 <div class="l-landing-page__find-adviser">
   <div class="l-constrained">
     <section class="l-landing-page__2col search-filter l-landing-page__search-filter t-search-filter" data-further-info>
-      <%= render 'further_info_content' %>
       <%= render 'landing_page/search_filter' %>
     </section>
     <section class="l-landing-page__2col">

--- a/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
+++ b/app/views/search/partials/filters/_qualifications_and_accreditations.html.erb
@@ -1,8 +1,13 @@
-<fieldset class="search-filter__qualifications_accreditations search-filter__last-filter">
+<fieldset class="search-filter__qualifications_accreditations search-filter__last-filter" data-further-info>
   <legend class="search-filter__label">
     <%= t('search.filter.qualifications_and_accreditations.heading') %>
-    <%= render 'further_info_trigger', url: t('search.filter.qualifications_and_accreditations.url') %>
+    <%= render 'further_info_trigger' %>
   </legend>
+
+  <p class="is-hidden further-info__content" data-further-info-target>
+      <%= t('search.filter.qualifications_and_accreditations.tooltip_html') %>
+  </p>
+
 
   <div class="form__group-item">
     <%= f.label :qualification_or_accreditation,

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -5,6 +5,7 @@ cy:
         postcode: Cod post
   global:
     required: Gofynnol
+    further_information: Rhagor o wybodaeth
 
   mas: Y Gwasanaeth Cynghori Ariannol
   mas_home_url: https://www.moneyadviceservice.org.uk/cy
@@ -309,6 +310,8 @@ cy:
         - text: Y peth pwysig i’w gofio yw bod pob un o’r cynghorwyr ar Gyfeirlyfr y Gwasanaeth Cynghori Ariannol – waeth sut y cynigiant gyngor – wedi eu rheoleiddio.  Mae gennych union yr un diogelwch pa un ai’ch bod yn cwrdd â rhywun wyneb yn wyneb neu’n delio ag ef neu hi’n unigol dros y ffôn neu ar-lein.
       qualifications_and_accreditations:
         heading: 'Hoffwn gael cynghorydd sydd â’r achrediadau / cymwysterau canlynol:'
+        tooltip_html: |
+          Dysgwch ragor am achrediadau/cymwysterau cynghorydd trwy glicio  <a href="https://directory.moneyadviceservice.org.uk/cy/glossary" target="_blank">yma</a>.
         label: Hidlo yn Ùl cymhwyster neu achrediad
         url: '/cy/glossary#chartered_fp'
       qualification:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
         postcode: Postcode
   global:
     required: Required
+    further_information: Further information
 
   mas: The Money Advice Service
   mas_home_url: https://www.moneyadviceservice.org.uk/en
@@ -309,6 +310,8 @@ en:
           - text: The important thing to remember is that all the advisers on the Money Advice Service Directory – no matter how they offer advice – are fully regulated.  You have exactly the same protection whether you see someone face-to-face or deal with them exclusively by phone or online.
       qualifications_and_accreditations:
         heading: 'I would like an adviser with the following accreditations / qualifications:'
+        tooltip_html: |
+          Find out more about adviser accreditations/qualifications by clicking <a href="https://directory.moneyadviceservice.org.uk/en/glossary/#chartered_fp" target="_blank">here</a>.
         label: Filter by adviser qualification or accreditation
         url: '/en/glossary/#chartered_fp'
       qualification:


### PR DESCRIPTION
[TP Link](https://moneyadviceservice.tpondemand.com/entity/7960)

**Summary**
Links were found that took users to different locations whether it be another page or opening a pop up layer, however, these read to users that rely on audio feedback as the same i.e. ‘?’. The ‘?’ links did not contain any text that could be relayed to screen reader users.

These icons were changed to "information" icons and the `aria-label` attribute was added:

**Before**:
![image](https://user-images.githubusercontent.com/689327/29721309-959b3900-89b4-11e7-9995-05480f961444.png)

**After**:
![image](https://user-images.githubusercontent.com/689327/29824046-5716fb4e-8cc8-11e7-8717-d4864ffdc13c.png)


The "Adviser qualifications" icon would link to a different page with information. To keep a consistent behaviour between information icons, now it includes a text with a link to the page:
![image](https://user-images.githubusercontent.com/689327/29824100-770d5d94-8cc8-11e7-9674-09b0f147af18.png)



Issues ID: DAC_TECH_Links_Issue1, DAC-USER-SRNVDA-T2-01, DAC-USER-SRJAWS-T2-02

**Pending**
Copy review for the link's text and Welsh translation.