### PR TITLE
[DEV APPROVED]7963, 7964 - Accessibility: Remove 'or' heading from search filter

### DIFF
--- a/app/views/search/partials/filters/_advice_method.html.erb
+++ b/app/views/search/partials/filters/_advice_method.html.erb
@@ -44,13 +44,18 @@
           value: SearchForm::ADVICE_METHOD_PHONE_OR_ONLINE,
           class: 'search-filter__advice-label' %>
       </div>
+
+      <%
+        # This auxiliary div is needed to get consistent spacing between the
+        # sections. If we don't add it, then the form__group-item:last-child
+        # style is used and the margin-bottom is set to 0
+       %>
+      <div class="form__group-item"></div>
     <% end %>
   </section>
 
   <section id='search_firm_name'>
 
-  <h3 class="search-filter__alt-title"><%= t('search.filter.receive_advice.alternative') %></h3>
-  
   <%= f.form_row(:firm_name) do %>
     <%= f.errors_for :firm_name %>
 


### PR DESCRIPTION
[TP Link 1963](https://moneyadviceservice.tpondemand.com/entity/7963)
[TP Link 1964](https://moneyadviceservice.tpondemand.com/entity/7964)

**Summary**

*How would you like to receive  advice?* search filter: When navigating out of context to read the buttons, the search button says ‘or search button.’ ‘Search button’ is clearer.  Consider removing the ‘or’ from the options as this is not really required.

**Solution**
When just removing the `<h3>` text, we have some spacing issues:

![image](https://user-images.githubusercontent.com/689327/29275464-16512f88-8103-11e7-9d3a-effff44c0279.png)

On the "Phone or Online" option the `margin-bottom` property is being set to `0`. This is coming from dough because this is a `form__group-item:last-child` element. It doesn't happen with "In Person" and "Search for a firm by name" because they have an extra hidden `form__group-item` element each to input a postcode or firm name respectively. So they get a `0.75rem` margin-bottom value.

This fix adds an empty `<div class="form__group-item"></div>` to "Phone or Online". Otherwise it would have to be changed in `dough` and since it's a very general class, it probably affects many elements.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/689327/29275388-dd0c15b2-8102-11e7-98f2-2feb06b0ee15.png)

After:
![image](https://user-images.githubusercontent.com/689327/29275370-d1385de0-8102-11e7-907e-f4907f469803.png)
