### PR TITLE
[DEV APPROVED] 7958, 7969 - Add legend to advice search form for assistive technologies

### DIFF
--- a/app/assets/stylesheets/components/_search_filter.scss
+++ b/app/assets/stylesheets/components/_search_filter.scss
@@ -5,7 +5,7 @@
 
 .search-filter--container {
   @include row(12);
-  padding-top: $baseline-unit*3;
+  padding-top: $baseline-unit*2;
 }
 
 .search-filter--container .l-results__filter {

--- a/app/assets/stylesheets/layouts/_landing_page.scss
+++ b/app/assets/stylesheets/layouts/_landing_page.scss
@@ -104,9 +104,11 @@
 }
 
 .l-landing-page__search-filter__header {
-  margin-top: $baseline-unit*2;
-  margin-left: $baseline-unit*3;
-  margin-bottom: 0;
+  @extend %font-heading-heavy;
+  color: $color-green-primary;
+  margin-top: 0;
+  margin-left: 0;
+  margin-bottom: $baseline-unit*3;
 
   @include respond-to($mq-m) {
     @include body(24, 28);

--- a/app/views/landing_page/_search_filter.html.erb
+++ b/app/views/landing_page/_search_filter.html.erb
@@ -1,10 +1,10 @@
-<%= form_for @form, url: search_path, 
-                    method: :get, 
-                    html: {class: 'form form--collapse t-in-person', 
-                           novalidate: true}, 
-                    data: {search_filter: '', 
+<%= form_for @form, url: search_path,
+                    method: :get,
+                    html: {class: 'form form--collapse t-in-person',
+                           novalidate: true},
+                    data: {search_filter: '',
                            dough_component: 'Validation',
-                           'dough-validation-config' => 
+                           'dough-validation-config' =>
                            '{"showInlineValidation":false, "showValidationSummaryLinks":false}'
                             },
                     builder: Dough::Forms::Builders::Validation do |f| %>
@@ -22,6 +22,10 @@
   <div class="search-filter--container">
     <div class="l-results__filter">
       <fieldset class="form__group search-filter__section">
+        <legend class="l-landing-page__search-filter__header">
+          <%= t('find_retirement_adviser.heading') %>
+          <%= render 'further_info_trigger' %>
+        </legend>
         <%= render partial: 'search/partials/filters/advice_method', locals: {f: f} %>
         <%= render 'search_button', button_class: "search-filter__button" %>
       </fieldset>

--- a/app/views/landing_page/show.html.erb
+++ b/app/views/landing_page/show.html.erb
@@ -14,10 +14,6 @@
 <div class="l-landing-page__find-adviser">
   <div class="l-constrained">
     <section class="l-landing-page__2col search-filter l-landing-page__search-filter t-search-filter" data-further-info>
-      <h2 class="l-landing-page__search-filter__header">
-        <%= t('find_retirement_adviser.heading') %>
-        <%= render 'further_info_trigger' %>
-      </h2>
       <%= render 'further_info_content' %>
       <%= render 'landing_page/search_filter' %>
     </section>


### PR DESCRIPTION
TP Links:
[7958](https://moneyadviceservice.tpondemand.com/entity/7958)
[7969](https://moneyadviceservice.tpondemand.com/entity/7969)

This addresses an accessibility problem flagged up in 7958: all `<fieldset>` elements must have a `<legend>` element as their first child. Semantically what was previously an `<h2>` tag should be a `<legend>`.

This also addresses an accessibility issue from 7969, that the ‘help’ icon should not be part of a heading tag. 

Previous conversation: #327 