### PR TITLE
[DEV APPROVED] 7971 - Underline telephone links on focus as well as hover

### DIFF
--- a/app/assets/stylesheets/components/_outline_button.scss
+++ b/app/assets/stylesheets/components/_outline_button.scss
@@ -13,7 +13,7 @@
   &[href^="tel:"] {
     color: $color-blue-medium;
 
-    &:hover {
+    &:hover, &:focus {
       text-decoration: underline;
     }
   }


### PR DESCRIPTION
[TP link](https://moneyadviceservice.tpondemand.com/entity/7971)

**Summary**
This is an accessibility requirement. The telephone link on the firms#show page were underlined on hover, but unchanged on focus. Keyboard-only users who navigate using the tab key need visual feedback when a link has focus, so this was flagged up as confusing in the accessibility review. This has been fixed by giving these links underlining on focus as well.