### PR TITLE
[DEV APPROVED] 7972 - Accessibility fixes

### DIFF
--- a/app/forms/filters/pension_pot.rb
+++ b/app/forms/filters/pension_pot.rb
@@ -7,7 +7,9 @@ module Filters
     def options_for_pension_pot_sizes
       InvestmentSize.all.map do |investment_size|
         [investment_size.localized_name, investment_size.id]
-      end << [I18n.t('search_filter.pension_pot.any_size_option'), ANY_SIZE_VALUE]
+      end.unshift(
+        [I18n.t('search_filter.pension_pot.any_size_option'), ANY_SIZE_VALUE]
+      )
     end
 
     def any_pension_pot_size?

--- a/app/views/application/_further_info_trigger.html.erb
+++ b/app/views/application/_further_info_trigger.html.erb
@@ -1,5 +1,5 @@
 <a href="<%= url if local_assigns[:url] %>" class="further-info__trigger" data-further-info-trigger>
-  <svg class="svg-icon further-info__svg-icon" xmlns="http://www.w3.org/2000/svg" style="">
+  <svg focusable="false" class="svg-icon further-info__svg-icon" xmlns="http://www.w3.org/2000/svg" style="">
     <use xlink:href="#icon-tooltip"></use>
   </svg>
 </a>

--- a/app/views/application/_search_button.html.erb
+++ b/app/views/application/_search_button.html.erb
@@ -1,6 +1,6 @@
 <button class="button button--primary <%= button_class %>">
   <span class="button--compact__text"><%= t('search.filter.button_text') %></span>
-  <svg title="<%= t('pagination.previous') %>" xmlns="http://www.w3.org/2000/svg" class="pagination__icon">
+  <svg focusable="false" title="<%= t('pagination.previous') %>" xmlns="http://www.w3.org/2000/svg" class="pagination__icon">
     <use xlink:href="#icon-pagination-next"></use>
   </svg>
 </button>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -2,7 +2,7 @@
   <span class="next">
     <%= link_to(url, rel: 'next', class: 'pagination__button pagination__button--next button button--compact') do %>
     <span class="button--compact__text"><%= t('pagination.next').html_safe %></span>
-      <svg title="<%= t('pagination.previous') %>" xmlns="http://www.w3.org/2000/svg" class="pagination__icon">
+      <svg focusable="false" title="<%= t('pagination.previous') %>" xmlns="http://www.w3.org/2000/svg" class="pagination__icon">
         <use xlink:href="#icon-pagination-next"></use>
       </svg>
     <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,7 +1,7 @@
 <% unless current_page.first? %>
   <span class="prev">
     <%= link_to(url, rel: 'prev', class: 'pagination__button pagination__button--prev button button--compact') do %>
-      <svg title="<%= t('pagination.previous') %>" xmlns="http://www.w3.org/2000/svg" class="pagination__icon">
+      <svg focusable="false" title="<%= t('pagination.previous') %>" xmlns="http://www.w3.org/2000/svg" class="pagination__icon">
         <use xlink:href="#icon-pagination-prev"></use>
       </svg>
       <span class="button--compact__text"><%= t('pagination.previous').html_safe %></span>

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 RSpec.describe SearchForm do
   describe 'advice method predicates' do
     let(:form) { described_class.new(advice_method: advice_method) }
@@ -314,8 +315,8 @@ RSpec.describe SearchForm do
       expect(form.options_for_pension_pot_sizes).to include(*tuples)
     end
 
-    it 'returns the any size option as the last element' do
-      expect(form.options_for_pension_pot_sizes.last).to eql([
+    it 'returns the any size option as the first element' do
+      expect(form.options_for_pension_pot_sizes.first).to eql([
         I18n.t('search_filter.pension_pot.any_size_option'), SearchForm::ANY_SIZE_VALUE
       ])
     end


### PR DESCRIPTION
[TP link](https://moneyadviceservice.tpondemand.com/entity/7972)

**Summary**
Two accessibility improvements that were suggested in an accessibility review.

1. SVG elements inside a link or button receive focus independently of the link/button in Internet Explorer. This is confusing for keyboard-only users. Setting `focusable="false"` on the SVG fixes this.
2. A select list had the default option at the bottom. Keyboard-only users expect the default value to be at the top and the others below. We have changed the order of the options to fix this.