### PR TITLE
[DEV APPROVED] 8367 - Add browserconfig.xml file for IE 11 and Edge

### DIFF
--- a/public/browserconfig.xml
+++ b/public/browserconfig.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<browserconfig>
+    <msapplication>
+    </msapplication>
+</browserconfig>


### PR DESCRIPTION
[TP Link](https://moneyadviceservice.tpondemand.com/entity/8367)

From [Rollbar](https://rollbar.com/rad-consumer-production/rad-consumer-production/items/2/), requests to `/browserconfig.xml` trigger a 404. This is a configuration file Internet Explorer 11 (and presumably Edge) use:

>Browser configuration files (also known as browserconfig) can be used to define pinned site customizations, such as tile backgrounds, badge updates, and tile notifications.

[More information](https://msdn.microsoft.com/library/dn320426(v=vs.85).aspx)

The PR adds an empty `browserconfig.xml` file to avoid the 404. Do we want a proper browserconfig file for pinning the site in Windows devices? There's an online tool by Microsot to create this file: http://www.buildmypinnedsite.com/