### PR TITLE
[DEV APPROVED] TP-8587 display correct dialogue

### DIFF
--- a/app/controllers/firms_controller.rb
+++ b/app/controllers/firms_controller.rb
@@ -6,7 +6,7 @@ class FirmsController < ApplicationController
     @advisers = sort_advisers(@search_form, @firm.advisers)
     @firm.closest_adviser = closest_adviser
     @latitude, @longitude = @search_form.coordinates
-
+    @firm_profile_presenter = FirmProfilePresenter.new(@firm)
     store_recently_visited_firm
   end
 

--- a/app/presenters/firm_profile_presenter.rb
+++ b/app/presenters/firm_profile_presenter.rb
@@ -1,0 +1,7 @@
+class FirmProfilePresenter < SimpleDelegator
+  def type_of_advice_method
+    return :face_to_face if in_person_advice_methods.present?
+
+    :remote
+  end
+end

--- a/app/views/firms/partials/_advice_type_section.html.erb
+++ b/app/views/firms/partials/_advice_type_section.html.erb
@@ -1,0 +1,8 @@
+<%= heading_tag(t("firms.show.#{type_of_advice_method}.header"),
+                level: 3,
+                class: 'l-firm__heading l-firm__heading--collapse') %>
+<p>
+  <%= t("firms.show.#{type_of_advice_method}.text").html_safe %>
+
+  <%= render 'firms/partials/guide_link' %>
+</p>

--- a/app/views/firms/partials/_profile_help.html.erb
+++ b/app/views/firms/partials/_profile_help.html.erb
@@ -1,26 +1,4 @@
-<%= render 'firms/partials/recently_visited', search_form: search_form %>
+<%= render 'firms/partials/recently_visited' %>
 
-<% if search_form.face_to_face? %>
-
-  <%= heading_tag(t('firms.show.face_to_face.header'),
-                  level: 3,
-                  class: 'l-firm__heading l-firm__heading--collapse') %>
-  <p>
-    <%= t('firms.show.face_to_face.text') %>
-
-    <%= render 'firms/partials/guide_link' %>
-  </p>
-
-<% else %>
-
-  <%= heading_tag(t('firms.show.remote.header'),
-                  level: 3,
-                  class: 'l-firm__heading l-firm__heading--collapse') %>
-  <p>
-    <%= t('firms.show.remote.text.part_one') %>
-    <strong><%= t('firms.show.remote.text.part_two') %></strong>.
-    <%= t('firms.show.remote.text.part_three') %>
-
-    <%= render 'firms/partials/guide_link' %>
-  </p>
-<% end %>
+<%= render 'firms/partials/advice_type_section',
+  type_of_advice_method: @firm_profile_presenter.type_of_advice_method %>

--- a/app/views/firms/show.html.erb
+++ b/app/views/firms/show.html.erb
@@ -18,7 +18,7 @@
     </div>
 
     <div class="l-firm__side">
-      <%= render 'firms/partials/profile_help', search_form: @search_form %>
+      <%= render 'firms/partials/profile_help' %>
     </div>
   </div>
 </div>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -44,9 +44,7 @@ cy:
       remote:
         header: Cynghorwyr dros y ffôn neu ar-lein yn unig
         text:
-          part_one: "Rydych wedi dewis cwmni sy’n cynnig cyngor"
-          part_two: dros y ffôn neu ar-lein yn unig
-          part_three: "Mae hyn yn golygu llai o gostau i’r cwmni, a chostau llai i chi o ganlyniad. Y peth pwysig i’w gofio yw bod pob un o’r cynghorwyr sydd ar y cyfeirlyfr - waeth sut y cynigiant gyngor – wedi eu rheoleiddio ac yn cynnig yr un diogelwch."
+          part_one: "Rydych wedi dewis cwmni sy’n cynnig cyngor <strong>dros y ffôn neu ar-lein yn unig</strong>. Mae hyn yn golygu llai o gostau i’r cwmni, a chostau llai i chi o ganlyniad. Y peth pwysig i’w gofio yw bod pob un o’r cynghorwyr sydd ar y cyfeirlyfr - waeth sut y cynigiant gyngor – wedi eu rheoleiddio ac yn cynnig yr un diogelwch."
       recently_visited:
         header: CwmnÏau eraill yr edrychoch arnynt
         remote: Dros y ffôn neu ar-lein yn unig

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,10 +43,7 @@ en:
         link_text: see our guide
       remote:
         header: Phone or online only advisers
-        text:
-          part_one: You have chosen a firm that offers advice
-          part_two: by telephone or online only
-          part_three: This often means less overheads for them, and therefore lower costs for you. The important thing to remember is that all the advisers on the directory - no matter how they offer advice – are fully regulated and offer the same protection.
+        text: You have chosen a firm that offers advice <strong> by telephone or online only </strong>. This often means less overheads for them, and therefore lower costs for you. The important thing to remember is that all the advisers on the directory - no matter how they offer advice – are fully regulated and offer the same protection.
       recently_visited:
         header: Other firms you've viewed
         remote: Phone or online only

--- a/package.json
+++ b/package.json
@@ -10,20 +10,23 @@
     "chai-jquery": "^1.2.3",
     "jscs": "^1.5.4",
     "jshint": "^2.5.5",
-    "karma": "^0.12.2",
+    "karma": "^0.12.23",
     "karma-osx-reporter": "*",
     "karma-chai": "^0.1.0",
     "karma-chai-jquery": "^1.0.0",
     "karma-chrome-launcher": "^0.1.2",
     "karma-cli": "0.0.4",
-    "karma-coverage": "^0.2.4",
+    "karma-coverage": "^0.2.6",
     "karma-html2js-preprocessor": "^0.1.0",
     "karma-jquery": "^0.1.0",
-    "karma-mocha": "^0.1.3",
-    "karma-phantomjs-launcher": "~0.1",
+    "karma-mocha": "^0.1.4",
+    "karma-phantomjs-launcher": ">= 1.0",
     "karma-requirejs": "^0.2.1",
+    "karma-requirejs": "~0.2.0",
     "karma-sinon": "^1.0.3",
+    "mocha": "~1.15.1",
+    "requirejs": "2.1.22",
     "sinon": "^1.9.0",
-    "sinon-chai": "^2.5.0"
+    "sinon-chai": "^2.14.0"
   }
 }

--- a/spec/features/firm_profile_help_spec.rb
+++ b/spec/features/firm_profile_help_spec.rb
@@ -1,0 +1,62 @@
+RSpec.feature 'Help section on a firm profile', :vcr do
+  let(:profile_page) { ProfilePage.new }
+
+  scenario 'viewing information on face to face firm' do
+    with_elastic_search! do
+      given_firm_with_offices
+      when_i_view_the_firm_profile
+      then_i_should_see_how_near_adviser_text
+    end
+  end
+
+  scenario 'viewing information on remote only firm' do
+    with_elastic_search! do
+      given_firm_without_offices
+      when_i_view_the_remote_firm_profile
+      then_i_should_see_phone_or_online_text
+    end
+  end
+
+  def given_firm_with_offices
+    with_fresh_index! do
+      @firm = create(:firm, website_address: 'http://www.foobar.com')
+      create(:adviser, firm: @firm, postcode: 'RG2 8EE', latitude: 51.428473, longitude: -0.943616, travel_distance: 100)
+      @firm.main_office.update_attributes!(
+        email_address: 'main.office@example.com',
+        address_line_one: '120 Holborn',
+        address_line_two: 'London',
+        address_town: 'London',
+        address_county: nil,
+        address_postcode: 'EC1N 2TD',
+        latitude: 51.518148,
+        longitude: -0.108013
+      )
+    end
+  end
+
+  def given_firm_without_offices
+    with_fresh_index! do
+      @remote_firm = create(:firm, :with_remote_advice)
+    end
+  end
+
+  def when_i_view_the_firm_profile
+    profile_page.load(firm: @firm.id)
+    expect(profile_page).to be_displayed
+  end
+
+  def when_i_view_the_remote_firm_profile
+    profile_page.load(firm: @remote_firm.id)
+    expect(profile_page).to be_displayed
+  end
+
+  def then_i_should_see_how_near_adviser_text
+    expect(profile_page.side_info).to have_content('How near is your adviser?')
+    expect(profile_page.side_info).not_to have_content('Phone or online only advisers')
+  end
+
+  def then_i_should_see_phone_or_online_text
+    expect(profile_page.side_info).to have_content('Phone or online only advisers')
+    expect(profile_page.side_info).not_to have_content('How near is your adviser?')
+  end
+end

--- a/spec/features/firm_profile_help_spec.rb
+++ b/spec/features/firm_profile_help_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Help section on a firm profile', :vcr do
       given_firm_with_offices
       when_i_view_the_firm_profile
       then_i_should_see_how_near_adviser_text
+      then_i_should_not_see_phone_or_online_text
     end
   end
 
@@ -14,6 +15,7 @@ RSpec.feature 'Help section on a firm profile', :vcr do
       given_firm_without_offices
       when_i_view_the_remote_firm_profile
       then_i_should_see_phone_or_online_text
+      then_i_should_not_see_how_near_adviser_text
     end
   end
 
@@ -52,11 +54,17 @@ RSpec.feature 'Help section on a firm profile', :vcr do
 
   def then_i_should_see_how_near_adviser_text
     expect(profile_page.side_info).to have_content('How near is your adviser?')
+  end
+
+  def then_i_should_not_see_phone_or_online_text
     expect(profile_page.side_info).not_to have_content('Phone or online only advisers')
+  end
+
+  def then_i_should_not_see_how_near_adviser_text
+    expect(profile_page.side_info).not_to have_content('How near is your adviser?')
   end
 
   def then_i_should_see_phone_or_online_text
     expect(profile_page.side_info).to have_content('Phone or online only advisers')
-    expect(profile_page.side_info).not_to have_content('How near is your adviser?')
   end
 end

--- a/spec/fixtures/vcr_cassettes/Help_section_on_a_firm_profile/viewing_information_on_face_to_face_firm.yml
+++ b/spec/fixtures/vcr_cassettes/Help_section_on_a_firm_profile/viewing_information_on_face_to_face_firm.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 11 Oct 2017 14:30:04 GMT
+      Expires:
+      - Thu, 12 Oct 2017 14:30:04 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '376'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - public, max-age=86400
+      Age:
+      - '143'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "United Kingdom",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 60.91569999999999,
+                          "lng" : 33.9165549
+                       },
+                       "southwest" : {
+                          "lat" : 34.5614,
+                          "lng" : -8.8988999
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.378051,
+                       "lng" : -3.435973
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 60.91569999999999,
+                          "lng" : 33.9165549
+                       },
+                       "southwest" : {
+                          "lat" : 34.5614,
+                          "lng" : -8.8988999
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJqZHHQhE7WgIReiWIMkOg-MQ",
+                 "types" : [ "country", "political" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 11 Oct 2017 14:32:27 GMT
+recorded_with: VCR 2.9.3

--- a/spec/fixtures/vcr_cassettes/Help_section_on_a_firm_profile/viewing_information_on_remote_only_firm.yml
+++ b/spec/fixtures/vcr_cassettes/Help_section_on_a_firm_profile/viewing_information_on_remote_only_firm.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 11 Oct 2017 14:30:04 GMT
+      Expires:
+      - Thu, 12 Oct 2017 14:30:04 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '376'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Cache-Control:
+      - public, max-age=86400
+      Age:
+      - '143'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "United Kingdom",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 60.91569999999999,
+                          "lng" : 33.9165549
+                       },
+                       "southwest" : {
+                          "lat" : 34.5614,
+                          "lng" : -8.8988999
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.378051,
+                       "lng" : -3.435973
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 60.91569999999999,
+                          "lng" : 33.9165549
+                       },
+                       "southwest" : {
+                          "lat" : 34.5614,
+                          "lng" : -8.8988999
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJqZHHQhE7WgIReiWIMkOg-MQ",
+                 "types" : [ "country", "political" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 11 Oct 2017 14:32:27 GMT
+recorded_with: VCR 2.9.3

--- a/spec/presenters/firm_profile_presenter_spec.rb
+++ b/spec/presenters/firm_profile_presenter_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe FirmProfilePresenter do
+  subject do
+    described_class.new(firm_result)
+  end
+
+  let(:firm_result) { double(FirmResult) }
+
+  describe '#type_of_advice_method' do
+    context 'face to face available' do
+      it do
+        expect(firm_result).to receive(:in_person_advice_methods).and_return([1, 2, 3])
+        expect(subject.type_of_advice_method).to eq(:face_to_face)
+      end
+    end
+
+    context 'face to face not available' do
+      it do
+        expect(firm_result).to receive(:in_person_advice_methods).and_return([])
+        expect(subject.type_of_advice_method).to eq(:remote)
+      end
+    end
+  end
+end

--- a/spec/presenters/firm_profile_presenter_spec.rb
+++ b/spec/presenters/firm_profile_presenter_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe FirmProfilePresenter do
 
   describe '#type_of_advice_method' do
     context 'face to face available' do
-      it do
+      it 'returns face_to_face' do
         expect(firm_result).to receive(:in_person_advice_methods).and_return([1, 2, 3])
         expect(subject.type_of_advice_method).to eq(:face_to_face)
       end
     end
 
     context 'face to face not available' do
-      it do
+      it 'returns remote' do
         expect(firm_result).to receive(:in_person_advice_methods).and_return([])
         expect(subject.type_of_advice_method).to eq(:remote)
       end

--- a/spec/support/profile_page.rb
+++ b/spec/support/profile_page.rb
@@ -1,6 +1,7 @@
 class ProfilePage < SitePrism::Page
   require_relative './office_section'
   require_relative './adviser_section'
+  set_url '/en/firms/{firm}'
   set_url_matcher %r{/(en|cy)/firms}
 
   sections :offices, OfficeSection, '.t-office'
@@ -12,4 +13,5 @@ class ProfilePage < SitePrism::Page
   element :telephone, '.t-telephone'
   element :email, '.t-email'
   element :website, '.t-website'
+  element :side_info, '.l-firm__side'
 end


### PR DESCRIPTION
https://moneyadviceservice.tpondemand.com/entity/8587

This ticket addresses the dialogue shown on a firms profile page, regardless of which search a user used to arrive at the profile.

If the firm offers face to face consultation then the message provided will reflect this.
If the firm *only* offers remote consultation then the message will reflect this.