### PR TITLE
[DEV APPROVED] Updates modernizr include to handle Sprockets upgrade from 2 to 3

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,4 +35,8 @@ module ApplicationHelper
   def feature_enabled?(flag_name)
     ENV[flag_name] == 'true'
   end
+
+  def load_modernizr
+    Sprockets::Railtie.build_environment(Rails.application, true)['modernizr/modernizr'].to_s.html_safe
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -146,7 +146,7 @@
   <!--<![endif]-->
 
   <script>
-    <%= raw Rails.application.assets['modernizr/modernizr'] %>
+    <%= load_modernizr %>
   </script>
 </head>
 <body id="top">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,4 +23,10 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '#load_modernizr' do
+    it 'returns raw text of Modernizr library' do
+      expect(helper.load_modernizr).to match(/Modernizr/)
+    end
+  end
 end


### PR DESCRIPTION
As of sprockets v3 Rails.application.assets is no longer defined in production. (github issue). 

The purpose of this line is to read the contents of a raw file in dough and then inject the link to that file straight into the view.