### PR TITLE
Updates .bowerrc file to add ref to bower registry

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory": "vendor/assets/bower_components"
+  "directory": "vendor/assets/bower_components",
+  "registry": "https://registry.bower.io"
 }


### PR DESCRIPTION
This fixes a problem with deploying to Staging. 

We need to point to a new Bower registry for reasons of legacy versions.