### PR TITLE
[DEV APPROVED] [9599] Open office website URL in a new window

### DIFF
--- a/app/helpers/office_helper.rb
+++ b/app/helpers/office_helper.rb
@@ -16,7 +16,7 @@ module OfficeHelper
   end
 
   def website_url(office, firm)
-    user_uri = URI(display_website(office, firm))
+    user_uri = URI(display_website(office, firm).strip)
 
     case user_uri
     when ->(uri) { uri.to_s.blank? } then nil

--- a/app/views/firms/partials/_offices.html.erb
+++ b/app/views/firms/partials/_offices.html.erb
@@ -29,7 +29,7 @@
             <% end %>
           </div>
           <div class="office__website">
-            <%= link_to website_url(office, firm), class: 'contact-link' do %>
+            <%= link_to website_url(office, firm), class: 'contact-link', target: '_blank' do %>
               <%= svg_icon :offsite_link, title: t('firms.show.panels.offices.website'), class: 'contact-link__svg-icon'
               %><%= display_website(office, firm) %>
             <% end %>

--- a/spec/helpers/office_helper_spec.rb
+++ b/spec/helpers/office_helper_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe OfficeHelper, type: :helper do
       end
     end
 
+    context 'when the url has extra spaces' do
+      let(:website) { 'http://www.with-scheme.com ' }
+
+      it 'strips the return before calling URI' do
+        expected = 'http://www.with-scheme.com'
+        expect(website_url(office_result, firm_result)).to eq(expected)
+      end
+    end
+
     context 'when the website is not present' do
       let(:website) { nil }
 


### PR DESCRIPTION
Relates to: [TP Card ](https://moneyadviceservice.tpondemand.com/entity/9599-rad-convert-office-url-to-absolute)

## Context

I have overlooked the second requirement in the ticket, which asks for the link to open in a new window.

## Edge case

- While doing a sanity test I have discovered
  that URI breaks if given a string with lingering spaces. i.e:
  'www.somewhere.com '