### PR TITLE
[DEV APPROVED] 9337 Back to results to return to last visited page

### DIFF
--- a/app/controllers/helpers/search_controller.rb
+++ b/app/controllers/helpers/search_controller.rb
@@ -1,6 +1,6 @@
 module Helpers
   module SearchController
-  MAX_RANDOM_SEED_VALUE = 1024
+    MAX_RANDOM_SEED_VALUE = 1024
 
     def search_filter_options_description?
       false
@@ -19,11 +19,15 @@ module Helpers
     def random_search_seed
       session[:random_search_seed] ||= rand(MAX_RANDOM_SEED_VALUE)
     end
-    
+
+    def set_last_visited_page
+      session[:last_visited_page] = params[:page] || 1
+    end
+
     def search_form_params
       params.require(:search_form).merge(random_search_seed: random_search_seed)
     end
-    
+
     def not_found
       {
         file: 'public/404.html',

--- a/app/controllers/helpers/search_controller.rb
+++ b/app/controllers/helpers/search_controller.rb
@@ -1,0 +1,35 @@
+module Helpers
+  module SearchController
+  MAX_RANDOM_SEED_VALUE = 1024
+
+    def search_filter_options_description?
+      false
+    end
+
+    private
+
+    def searchable_view
+      from_results? ? 'search/index' : 'landing_page/show'
+    end
+
+    def from_results?
+      params.key?(:origin)
+    end
+
+    def random_search_seed
+      session[:random_search_seed] ||= rand(MAX_RANDOM_SEED_VALUE)
+    end
+    
+    def search_form_params
+      params.require(:search_form).merge(random_search_seed: random_search_seed)
+    end
+    
+    def not_found
+      {
+        file: 'public/404.html',
+        status: :not_found,
+        layout: false
+      }
+    end
+  end
+end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,41 +1,19 @@
 class SearchController < ApplicationController
-  MAX_RANDOM_SEED_VALUE = 1024
+  include Helpers::SearchController
 
   def index
     @form = SearchForm.new(search_form_params)
+
     if @form.valid?
       @result = FirmRepository.new.search(@form.to_query, page: page)
-      if @result.total_pages < page
-        render file: 'public/404.html',
-               status: :not_found,
-               layout: false
-      end
+
+      return render not_found if @result.total_pages < page
+
+      set_last_visited_page
     else
       render searchable_view
     end
   end
 
-  def search_filter_options_description?
-    false
-  end
-
   helper_method :search_filter_options_description?
-
-  private
-
-  def searchable_view
-    from_results? ? 'search/index' : 'landing_page/show'
-  end
-
-  def from_results?
-    params.key?(:origin)
-  end
-
-  def random_search_seed
-    session[:random_search_seed] ||= rand(MAX_RANDOM_SEED_VALUE)
-  end
-
-  def search_form_params
-    params.require(:search_form).merge(random_search_seed: random_search_seed)
-  end
 end

--- a/app/views/firms/show.html.erb
+++ b/app/views/firms/show.html.erb
@@ -2,12 +2,14 @@
   <div class="l-firm">
     <div class="l-1col">
       <%= heading_tag(t('page_title'), level: 1, class: 'l-firm__profile-heading') %>
-      <span class="firm__back-link">
-        <%= link_to @session_jar.search_results_url(I18n.locale) do %>
-          <%= svg_icon 'pagination-prev', class: 'firm__back-icon'
-          %><%= t('firms.show.go_back') %>
-        <% end %>
-      </span>
+      <% if @session_jar.previous_search? %>
+        <span class="firm__back-link">
+          <%= link_to @session_jar.search_results_url(I18n.locale) do %>
+            <%= svg_icon 'pagination-prev', class: 'firm__back-icon'
+            %><%= t('firms.show.go_back') %>
+          <% end %>
+        </span>
+      <% end %>
     </div>
 
     <div class="l-firm__main">

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,9 @@ if Rails.env.production?
     api_key: ENV['GOOGLE_GEOCODER_API_KEY'],
     cache: Redis.new(url: ENV['REDISTOGO_URL'])
   )
-else
+end
+
+if Rails.env.development?
   Geocoder.configure(
     lookup: :google,
     use_https: false,

--- a/lib/session_jar.rb
+++ b/lib/session_jar.rb
@@ -19,6 +19,10 @@ class SessionJar
     update_recently_visited_firms(firm_result, params)
   end
 
+  def previous_search?
+    @store[:last_visited_page].present?
+  end
+
   private
 
   def update_most_recent_search(params)
@@ -47,7 +51,7 @@ class SessionJar
   end
 
   def search_path_for(params, locale)
-    search_path(search_form: params[:search_form], locale: locale)
+    search_path(search_form: params[:search_form], page: @store[:last_visited_page], locale: locale)
   end
 
   def locale_to_profile_path_mappings(params)

--- a/spec/features/landing_face_to_face_search_spec.rb
+++ b/spec/features/landing_face_to_face_search_spec.rb
@@ -3,6 +3,7 @@ RSpec.feature 'Landing page, consumer requires general advice in person',
   let(:landing_page) { LandingPage.new }
   let(:results_page) { ResultsPage.new }
   let(:phone_advice) { create(:other_advice_method, name: 'Advice by telephone', order: 1) }
+  let(:firm_page)    { ProfilePage.new }
 
   scenario 'Using a valid postcode' do
     with_elastic_search! do
@@ -36,6 +37,9 @@ RSpec.feature 'Landing page, consumer requires general advice in person',
       and_i_see_i_am_viewing_firms_one_to_ten_of_twenty_one
       when_i_click_next
       then_i_see_i_am_viewing_firms_eleven_to_twenty_of_twenty_one
+      then_i_click_on_the_first_firm
+      when_i_click('Back to results')
+      then_i_see_i_am_viewing_firms_eleven_to_twenty_of_twenty_one
     end
   end
 
@@ -53,12 +57,20 @@ RSpec.feature 'Landing page, consumer requires general advice in person',
     expect(results_page.firms.count).to eq(10)
   end
 
+  def then_i_click_on_the_first_firm
+    results_page.firms.first.view_profile.click
+  end
+
   def and_i_see_i_am_viewing_firms_one_to_ten_of_twenty_one
     expect(results_page).to be_showing_firms(1, to: 10, of: 21)
   end
 
   def when_i_click_next
     results_page.next_page
+  end
+
+  def when_i_click(link_text)
+    click_link(link_text)
   end
 
   def then_i_see_i_am_viewing_firms_eleven_to_twenty_of_twenty_one
@@ -119,7 +131,7 @@ RSpec.feature 'Landing page, consumer requires general advice in person',
   def when_i_submit_a_invalid_postcode_search
     landing_page.in_person.tap do |section|
       section.face_to_face.set true
-      section.postcode.set 'Z'
+      section.postcode.set 'NOTVALID'
       section.search.click
     end
   end
@@ -127,7 +139,7 @@ RSpec.feature 'Landing page, consumer requires general advice in person',
   def when_i_submit_a_postcode_that_cannot_be_geocoded
     landing_page.in_person.tap do |section|
       section.face_to_face.set true
-      section.postcode.set 'ZZ1 1ZZ'
+      section.postcode.set 'NOTACODE'
       section.search.click
     end
   end

--- a/spec/features/results_face_to_face_search_spec.rb
+++ b/spec/features/results_face_to_face_search_spec.rb
@@ -64,11 +64,11 @@ RSpec.feature 'Results page, consumer requires help with their pension in person
   end
 
   def and_i_enter_an_invalid_postcode
-    results_page.search_form.postcode.set 'B4D'
+    results_page.search_form.postcode.set 'NOTVALID'
   end
 
   def and_i_enter_a_postcode_that_cannot_be_geocoded
-    results_page.search_form.postcode.set 'ZZ1 1ZZ'
+    results_page.search_form.postcode.set 'NOTACODE'
   end
 
   def then_i_see_firms_that_cover_my_postcode

--- a/spec/fixtures/vcr_cassettes/landing_face_to_face_search.yml
+++ b/spec/fixtures/vcr_cassettes/landing_face_to_face_search.yml
@@ -274,4 +274,487 @@ http_interactions:
         }
     http_version: 
   recorded_at: Thu, 21 May 2015 10:06:12 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=RG2%209FL,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Feb 2019 12:07:53 GMT
+      Expires:
+      - Wed, 13 Feb 2019 12:07:53 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '554'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=372
+      Cache-Control:
+      - public, max-age=86400
+      Age:
+      - '76963'
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "RG2 9FL",
+                       "short_name" : "RG2 9FL",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Cirrus Drive",
+                       "short_name" : "Cirrus Dr",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Shinfield",
+                       "short_name" : "Shinfield",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Reading",
+                       "short_name" : "Reading",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Wokingham",
+                       "short_name" : "Wokingham",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "England",
+                       "short_name" : "England",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Cirrus Dr, Shinfield, Reading RG2 9FL, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.4189602,
+                          "lng" : -0.9503157
+                       },
+                       "southwest" : {
+                          "lat" : 51.4180633,
+                          "lng" : -0.9522227
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.41841429999999,
+                       "lng" : -0.9512296
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.4198607302915,
+                          "lng" : -0.9499202197084979
+                       },
+                       "southwest" : {
+                          "lat" : 51.4171627697085,
+                          "lng" : -0.952618180291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ4_UU462cdkgRDA1RtCdMqYc",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Feb 2019 09:30:36 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=RG2%209FL,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Feb 2019 12:07:53 GMT
+      Expires:
+      - Wed, 13 Feb 2019 12:07:53 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '554'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=372
+      Cache-Control:
+      - public, max-age=86400
+      Age:
+      - '76963'
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "RG2 9FL",
+                       "short_name" : "RG2 9FL",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Cirrus Drive",
+                       "short_name" : "Cirrus Dr",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Shinfield",
+                       "short_name" : "Shinfield",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Reading",
+                       "short_name" : "Reading",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Wokingham",
+                       "short_name" : "Wokingham",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "England",
+                       "short_name" : "England",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Cirrus Dr, Shinfield, Reading RG2 9FL, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.4189602,
+                          "lng" : -0.9503157
+                       },
+                       "southwest" : {
+                          "lat" : 51.4180633,
+                          "lng" : -0.9522227
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.41841429999999,
+                       "lng" : -0.9512296
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.4198607302915,
+                          "lng" : -0.9499202197084979
+                       },
+                       "southwest" : {
+                          "lat" : 51.4171627697085,
+                          "lng" : -0.952618180291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ4_UU462cdkgRDA1RtCdMqYc",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Feb 2019 09:30:36 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=RG2%209FL,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Feb 2019 12:07:53 GMT
+      Expires:
+      - Wed, 13 Feb 2019 12:07:53 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '554'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=372
+      Cache-Control:
+      - public, max-age=86400
+      Age:
+      - '76964'
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "RG2 9FL",
+                       "short_name" : "RG2 9FL",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Cirrus Drive",
+                       "short_name" : "Cirrus Dr",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Shinfield",
+                       "short_name" : "Shinfield",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Reading",
+                       "short_name" : "Reading",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Wokingham",
+                       "short_name" : "Wokingham",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "England",
+                       "short_name" : "England",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Cirrus Dr, Shinfield, Reading RG2 9FL, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.4189602,
+                          "lng" : -0.9503157
+                       },
+                       "southwest" : {
+                          "lat" : 51.4180633,
+                          "lng" : -0.9522227
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.41841429999999,
+                       "lng" : -0.9512296
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.4198607302915,
+                          "lng" : -0.9499202197084979
+                       },
+                       "southwest" : {
+                          "lat" : 51.4171627697085,
+                          "lng" : -0.952618180291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ4_UU462cdkgRDA1RtCdMqYc",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Feb 2019 09:30:37 GMT
+- request:
+    method: get
+    uri: http://maps.googleapis.com/maps/api/geocode/json?address=RG2%209FL,%20United%20Kingdom&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Feb 2019 12:07:53 GMT
+      Expires:
+      - Wed, 13 Feb 2019 12:07:53 GMT
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      Content-Length:
+      - '554'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=372
+      Cache-Control:
+      - public, max-age=86400
+      Age:
+      - '76964'
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "RG2 9FL",
+                       "short_name" : "RG2 9FL",
+                       "types" : [ "postal_code" ]
+                    },
+                    {
+                       "long_name" : "Cirrus Drive",
+                       "short_name" : "Cirrus Dr",
+                       "types" : [ "route" ]
+                    },
+                    {
+                       "long_name" : "Shinfield",
+                       "short_name" : "Shinfield",
+                       "types" : [ "locality", "political" ]
+                    },
+                    {
+                       "long_name" : "Reading",
+                       "short_name" : "Reading",
+                       "types" : [ "postal_town" ]
+                    },
+                    {
+                       "long_name" : "Wokingham",
+                       "short_name" : "Wokingham",
+                       "types" : [ "administrative_area_level_2", "political" ]
+                    },
+                    {
+                       "long_name" : "England",
+                       "short_name" : "England",
+                       "types" : [ "administrative_area_level_1", "political" ]
+                    },
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "Cirrus Dr, Shinfield, Reading RG2 9FL, UK",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 51.4189602,
+                          "lng" : -0.9503157
+                       },
+                       "southwest" : {
+                          "lat" : 51.4180633,
+                          "lng" : -0.9522227
+                       }
+                    },
+                    "location" : {
+                       "lat" : 51.41841429999999,
+                       "lng" : -0.9512296
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 51.4198607302915,
+                          "lng" : -0.9499202197084979
+                       },
+                       "southwest" : {
+                          "lat" : 51.4171627697085,
+                          "lng" : -0.952618180291502
+                       }
+                    }
+                 },
+                 "place_id" : "ChIJ4_UU462cdkgRDA1RtCdMqYc",
+                 "types" : [ "postal_code" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Wed, 13 Feb 2019 09:30:37 GMT

--- a/spec/lib/session_jar_spec.rb
+++ b/spec/lib/session_jar_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe SessionJar do
   end
 
   subject { described_class.new({}) }
+  let(:page) { '2' }
 
   describe '#search_results_url' do
     before { subject.store(firm_result(1), params) }
@@ -35,6 +36,14 @@ RSpec.describe SessionJar do
     context 'when locale mapping is blank' do
       it 'returns nil' do
         expect(described_class.new({}).search_results_url('en')).to be(nil)
+      end
+    end
+
+    context 'when :last_visited_page key is present' do
+      subject { described_class.new(last_visited_page: page) }
+
+      it 'adds the page to the search query params' do
+        expect(subject.search_results_url('en')).to match(/\/en\/search\?page=2/)
       end
     end
 
@@ -133,6 +142,14 @@ RSpec.describe SessionJar do
 
         expect(subject.firms.map { |f| f['id'] }).to eq([4, 3, 2])
       end
+    end
+  end
+
+  describe '#previous_search?' do
+    subject { described_class.new(last_visited_page: page) }
+
+    it 'returns true if :last_visited_page key is present' do
+      expect(subject.previous_search?).to eq true
     end
   end
 end


### PR DESCRIPTION
[TP Card](https://moneyadviceservice.tpondemand.com/entity/9337-rad-back-to-results-to-return)

## Context

- In the current implementation the last visited page is not memoized and the user, when clicking 'Back to results' after viewing a Firm's profile is always taken to the first page (if the search is paginated)
- More info in each commit

## This PR

- The last visited page is now saved in the session, allowing the link to redirect to the latest visited page. 
- The link now does not appear if the user landed on the Firm's profile externally (not from a paginated search)

## Testing

- Some considerations as the previous VCR cassettes were recorded in 2015, when the API behaved differently and requests could be made without a key (apparently). I have kept the same behaviour (recording cassettes and removing the key form the URL) to allow future refactoring easier and to keep the suite consistent
- **Because of this**, the `Geocoder` has to be disabled for test env or else all requests are attempted with the key in `.env`
- TODO: Might be good to move the feature specs to Cucumber and stub the `Geocoder` instead of having cassettes