### PR TITLE
[DEV APPROVED] BUG: Display office tab for search results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'launchy'
   gem 'pry-rails'
+  gem 'rb-readline'
   gem 'rspec-rails', '3.6.0'
   gem 'rubocop'
   gem 'site_prism'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rb-readline (0.5.5)
     redis (3.3.5)
     rollbar (2.15.5)
       multi_json
@@ -277,6 +278,7 @@ DEPENDENCIES
   pg (< 1.0)
   pry-rails
   rails (~> 4.2.10)
+  rb-readline
   redis (~> 3.3.5)
   rollbar (~> 2.15.5)
   rspec-rails (= 3.6.0)

--- a/app/views/firms/partials/_content.html.erb
+++ b/app/views/firms/partials/_content.html.erb
@@ -7,16 +7,12 @@
             <%= t('firms.show.panels.firm.heading') %>
           </a>
         </div>
-
-        <% if @search_form.face_to_face? %>
-          <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
-            <a class="tab-selector__trigger" href="#panel-2" data-dough-tab-selector-trigger="2">
-              <%= t('firms.show.panels.offices.heading') %>
-              (<%= @firm.total_offices %>)
-            </a>
-          </div>
-        <% end %>
-
+        <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
+          <a class="tab-selector__trigger" href="#panel-2" data-dough-tab-selector-trigger="2">
+            <%= t('firms.show.panels.offices.heading') %>
+            (<%= @firm.total_offices %>)
+          </a>
+        </div>
         <div class="tab-selector__trigger-container is-inactive" data-dough-tab-selector-trigger-container>
           <a class="tab-selector__trigger" href="#panel-3" data-dough-tab-selector-trigger="3">
             <%= t('firms.show.panels.advisers.heading') %>
@@ -30,14 +26,12 @@
       <h2 class="tab-selector__target-heading firm__details-heading"><%= t('firms.show.panels.firm.heading') %></h2>
       <%= render partial: 'firms/partials/firm_details', locals: { firm: @firm, latitude: @latitude, longitude: @longitude, search_form: @search_form } %>
     </div>
-
-    <% if @search_form.face_to_face? %>
-      <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
-        <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.offices.heading') %></h2>
-        <%= render partial: 'firms/partials/offices', locals: { firm: @firm, offices: @offices } %>
-      </div>
-    <% end %>
-
+    
+    <div class="tab-selector__target is-inactive" id="panel-2" data-dough-tab-selector-target="2">
+      <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.offices.heading') %></h2>
+      <%= render partial: 'firms/partials/offices', locals: { firm: @firm, offices: @offices } %>
+    </div>
+    
     <div class="tab-selector__target is-inactive" id="panel-3" data-dough-tab-selector-target="3">
       <h2 class="tab-selector__target-heading"><%= t('firms.show.panels.advisers.heading') %></h2>
       <%= render partial: 'firms/partials/advisers', locals: { firm: @firm, advisers: @advisers, search_form: @search_form } %>

--- a/app/views/firms/partials/_firm_details.html.erb
+++ b/app/views/firms/partials/_firm_details.html.erb
@@ -63,27 +63,25 @@
   </div>
 </div>
 
-<% if search_form.face_to_face? %>
-  <%= heading_tag(t('firms.show.panels.firm.locations'), level: 3, class: 'l-firm__heading is-hidden-no-js') %>
+<%= heading_tag(t('firms.show.panels.firm.locations'), level: 3, class: 'l-firm__heading is-hidden-no-js') %>
 
-  <%= firm_map_component(center: {lat: latitude, lng: longitude},
-        adviser_pin_url: image_path('pins/adviser.png'),
-        office_pin_url: image_path('pins/office.png')) do %>
-    <div class="firm__map" data-dough-map></div>
+<%= firm_map_component(center: {lat: latitude, lng: longitude},
+      adviser_pin_url: image_path('pins/adviser.png'),
+      office_pin_url: image_path('pins/office.png')) do %>
+  <div class="firm__map" data-dough-map></div>
 
-    <ul class="firm__map-pin-items is-hidden">
-      <% firm.advisers.each do |adviser| %>
-        <li data-dough-map-point data-dough-map-point-type="adviser" data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
-          <%= adviser.name %>
-        </li>
-      <% end %>
-      <% firm.offices.each do |office| %>
-        <li data-dough-map-point data-dough-map-point-type="office" data-dough-map-point-lat="<%= office.location.latitude %>" data-dough-map-point-lng="<%= office.location.longitude %>">
-          <%= office_address(office) %>
-        </li>
-      <% end %>
-    </ul>
-  <% end %>
+  <ul class="firm__map-pin-items is-hidden">
+    <% firm.advisers.each do |adviser| %>
+      <li data-dough-map-point data-dough-map-point-type="adviser" data-dough-map-point-lat="<%= adviser.location.latitude %>" data-dough-map-point-lng="<%= adviser.location.longitude %>">
+        <%= adviser.name %>
+      </li>
+    <% end %>
+    <% firm.offices.each do |office| %>
+      <li data-dough-map-point data-dough-map-point-type="office" data-dough-map-point-lat="<%= office.location.latitude %>" data-dough-map-point-lng="<%= office.location.longitude %>">
+        <%= office_address(office) %>
+      </li>
+    <% end %>
+  </ul>
 <% end %>
 
 <% if firm_has_other_services?(firm) || firm.languages.present? %>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,9 @@ if Rails.env.production?
     api_key: ENV['GOOGLE_GEOCODER_API_KEY'],
     cache: Redis.new(url: ENV['REDISTOGO_URL'])
   )
-else
+end
+
+if Rails.env.development?
   Geocoder.configure(
     lookup: :google,
     use_https: false,


### PR DESCRIPTION
[TP 9300](https://moneyadviceservice.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiRkRBMzk3RTBGNjU3NDg1RDM4QzczMTJFNzI5MDFBN0MifQ==&searchPopup=bug/9300)

#### REQUIREMENT
The offices tab and location map are only displaying for results returned by `In Person` searches. This tab should be displayed for all search options, `Phone or Online` and `Search for a firm by name`. 

#### SOLUTION
The views use a conditional that checks if the search was a `face to face` search to determine if the offices tab and location map should be displayed. I have removed the conditional.