### PR TITLE
10546 - Fix bogus geocoding bug in profile

### DIFF
--- a/app/services/helpers/params_parser.rb
+++ b/app/services/helpers/params_parser.rb
@@ -61,19 +61,11 @@ module Helpers::ParamsParser
       id: params[:id],
       name: params[:firm_name],
       advice_method: params[:advice_method],
-      coordinates: extract_coordinates(params),
+      coordinates: params[:coordinates]&.map(&:to_f),
       filters: extract_filters(params),
       page: params[:page] || DEFAULT_PAGE,
       seed: params[:random_search_seed]
     }
-  end
-
-  def extract_coordinates(params)
-    if params[:coordinates]&.any?
-      params[:coordinates].map(&:to_f)
-    else
-      Geocode.call(params[:postcode])
-    end
   end
 
   def extract_filters(params)

--- a/features/cassettes/algolia/firm-profile/view-general-firm-information/post/1/indexes/firm-advisers-test/query.yml
+++ b/features/cassettes/algolia/firm-profile/view-general-firm-information/post/1/indexes/firm-advisers-test/query.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 25 Apr 2019 15:32:03 GMT
+      - Wed, 05 Jun 2019 10:46:20 GMT
       X-Algolia-Api-Key:
       - "<API_KEY>"
       X-Algolia-Application-Id:
@@ -29,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 25 Apr 2019 15:32:03 GMT
+      - Wed, 05 Jun 2019 10:46:20 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
@@ -56,7 +56,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 25 Apr 2019 15:32:03 GMT
+  recorded_at: Wed, 05 Jun 2019 10:46:20 GMT
 - request:
     method: post
     uri: https://bhpslyij2l-dsn.algolia.net/1/indexes/firm-advisers-test/query
@@ -71,7 +71,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 25 Apr 2019 15:32:03 GMT
+      - Wed, 05 Jun 2019 10:46:20 GMT
       X-Algolia-Api-Key:
       - "<API_KEY>"
       X-Algolia-Application-Id:
@@ -86,7 +86,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 25 Apr 2019 15:32:03 GMT
+      - Wed, 05 Jun 2019 10:46:20 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Transfer-Encoding:
@@ -116,13 +116,13 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 25 Apr 2019 15:32:03 GMT
+  recorded_at: Wed, 05 Jun 2019 10:46:20 GMT
 - request:
     method: post
     uri: https://bhpslyij2l-dsn.algolia.net/1/indexes/firm-advisers-test/query
     body:
       encoding: UTF-8
-      string: '{"params":"aroundLatLng=%5B55.378051%2C-3.435973%5D\u0026distinct=false\u0026facetFilters=%5B%22firm.id%3A1%22%5D\u0026getRankingInfo=true\u0026page=0\u0026hitsPerPage=1000\u0026query="}'
+      string: '{"params":"aroundLatLng=\u0026distinct=false\u0026facetFilters=%5B%22firm.id%3A1%22%5D\u0026getRankingInfo=false\u0026page=0\u0026hitsPerPage=1000\u0026query="}'
     headers:
       User-Agent:
       - Algolia for Ruby (1.25.2); Ruby (2.5.3)
@@ -131,7 +131,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 25 Apr 2019 15:32:04 GMT
+      - Wed, 05 Jun 2019 10:46:20 GMT
       X-Algolia-Api-Key:
       - "<API_KEY>"
       X-Algolia-Application-Id:
@@ -146,7 +146,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 25 Apr 2019 15:32:04 GMT
+      - Wed, 05 Jun 2019 10:46:20 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Transfer-Encoding:
@@ -173,13 +173,13 @@ http_interactions:
         Klocko","postcode":"EC1N 2TD","travel_distance":100,"qualification_ids":[],"accreditation_ids":[],"firm":{"id":1,"registered_name":"Test
         Firm Central London","postcode_searchable":true,"website_address":"http://example.net/test-firm-central-london","telephone_number":"07111
         333 135","email_address":"office135@example.org","free_initial_meeting":true,"minimum_fixed_fee":0,"retirement_income_products_flag":true,"pension_transfer_flag":false,"long_term_care_flag":false,"equity_release_flag":true,"inheritance_tax_and_estate_planning_flag":false,"wills_and_probate_flag":false,"other_advice_methods":[],"investment_sizes":[1],"in_person_advice_methods":[2],"adviser_qualification_ids":[3,4],"adviser_accreditation_ids":[1,2],"ethical_investing_flag":false,"sharia_investing_flag":false,"workplace_financial_advice_flag":true,"non_uk_residents_flag":false,"languages":["ita"],"total_offices":2,"total_advisers":2},"objectID":"2","_highlightResult":{"firm":{"registered_name":{"value":"Test
-        Firm Central London","matchLevel":"none","matchedWords":[]}}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":1,"geoDistance":482477,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":1,"matchedGeoLocation":{"lat":51.518,"lng":-0.1086,"distance":482477}}},{"_geoloc":{"lat":51.51193,"lng":-0.095115},"name":"Caitlyn
+        Firm Central London","matchLevel":"none","matchedWords":[]}}}},{"_geoloc":{"lat":51.51193,"lng":-0.095115},"name":"Caitlyn
         Kohler","postcode":"EC4V 4AY","travel_distance":100,"qualification_ids":[3,4],"accreditation_ids":[1,2],"firm":{"id":1,"registered_name":"Test
         Firm Central London","postcode_searchable":true,"website_address":"http://example.net/test-firm-central-london","telephone_number":"07111
         333 135","email_address":"office135@example.org","free_initial_meeting":true,"minimum_fixed_fee":0,"retirement_income_products_flag":true,"pension_transfer_flag":false,"long_term_care_flag":false,"equity_release_flag":true,"inheritance_tax_and_estate_planning_flag":false,"wills_and_probate_flag":false,"other_advice_methods":[],"investment_sizes":[1],"in_person_advice_methods":[2],"adviser_qualification_ids":[3,4],"adviser_accreditation_ids":[1,2],"ethical_investing_flag":false,"sharia_investing_flag":false,"workplace_financial_advice_flag":true,"non_uk_residents_flag":false,"languages":["ita"],"total_offices":2,"total_advisers":2},"objectID":"1","_highlightResult":{"firm":{"registered_name":{"value":"Test
-        Firm Central London","matchLevel":"none","matchedWords":[]}}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":0,"geoDistance":483492,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":1,"matchedGeoLocation":{"lat":51.5119,"lng":-0.0952,"distance":483492}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=%5B55.378051%2C-3.435973%5D&distinct=false&facetFilters=%5B%22firm.id%3A1%22%5D&getRankingInfo=true&page=0&hitsPerPage=1000&query=","automaticRadius":"16169862","serverUsed":"c11-eu-2.algolia.net","indexUsed":"firm-advisers-test","parsedQuery":"","timeoutCounts":false,"timeoutHits":false}
+        Firm Central London","matchLevel":"none","matchedWords":[]}}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=&distinct=false&facetFilters=%5B%22firm.id%3A1%22%5D&getRankingInfo=false&page=0&hitsPerPage=1000&query="}
 
 '
     http_version: 
-  recorded_at: Thu, 25 Apr 2019 15:32:04 GMT
+  recorded_at: Wed, 05 Jun 2019 10:46:20 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/algolia/firm-profile/view-general-firm-information/post/1/indexes/firm-offices-test/query.yml
+++ b/features/cassettes/algolia/firm-profile/view-general-firm-information/post/1/indexes/firm-offices-test/query.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://bhpslyij2l-dsn.algolia.net/1/indexes/firm-offices-test/query
     body:
       encoding: UTF-8
-      string: '{"params":"aroundLatLng=%5B55.378051%2C-3.435973%5D\u0026facetFilters=%5B%22firm_id%3A1%22%5D\u0026getRankingInfo=true\u0026page=0\u0026hitsPerPage=1000\u0026query="}'
+      string: '{"params":"aroundLatLng=\u0026facetFilters=%5B%22firm_id%3A1%22%5D\u0026getRankingInfo=false\u0026page=0\u0026hitsPerPage=1000\u0026query="}'
     headers:
       User-Agent:
       - Algolia for Ruby (1.25.2); Ruby (2.5.3)
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 25 Apr 2019 15:32:04 GMT
+      - Wed, 05 Jun 2019 10:46:20 GMT
       X-Algolia-Api-Key:
       - "<API_KEY>"
       X-Algolia-Application-Id:
@@ -29,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 25 Apr 2019 15:32:04 GMT
+      - Wed, 05 Jun 2019 10:46:20 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Transfer-Encoding:
@@ -59,16 +59,16 @@ http_interactions:
         Wyman Parkways","matchLevel":"none","matchedWords":[]},"address_line_two":{"value":"Suite
         863","matchLevel":"none","matchedWords":[]},"address_town":{"value":"Devanhaven","matchLevel":"none","matchedWords":[]},"address_county":{"value":"Illinois","matchLevel":"none","matchedWords":[]},"address_postcode":{"value":"EC1N
         2TD","matchLevel":"none","matchedWords":[]},"email_address":{"value":"office789@example.org","matchLevel":"none","matchedWords":[]},"telephone_number":{"value":"07111
-        333 789","matchLevel":"none","matchedWords":[]},"website":{"value":"http://example.net/offices/789","matchLevel":"none","matchedWords":[]}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":1,"geoDistance":482477,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":1,"matchedGeoLocation":{"lat":51.518,"lng":-0.1086,"distance":482477}}},{"_geoloc":{"lat":51.51193,"lng":-0.095115},"firm_id":1,"address_line_one":"493
+        333 789","matchLevel":"none","matchedWords":[]},"website":{"value":"http://example.net/offices/789","matchLevel":"none","matchedWords":[]}}},{"_geoloc":{"lat":51.51193,"lng":-0.095115},"firm_id":1,"address_line_one":"493
         Tremblay Pass","address_line_two":"Apt. 746","address_town":"Kaseyview","address_county":"Alaska","address_postcode":"EC4V
         4AY","email_address":"office135@example.org","telephone_number":"07111 333
         135","disabled_access":true,"website":"http://example.net/offices/135","objectID":"1","_highlightResult":{"_geoloc":{"lat":{"value":"51.51193","matchLevel":"none","matchedWords":[]},"lng":{"value":"-0.095115","matchLevel":"none","matchedWords":[]}},"firm_id":{"value":"1","matchLevel":"none","matchedWords":[]},"address_line_one":{"value":"493
         Tremblay Pass","matchLevel":"none","matchedWords":[]},"address_line_two":{"value":"Apt.
         746","matchLevel":"none","matchedWords":[]},"address_town":{"value":"Kaseyview","matchLevel":"none","matchedWords":[]},"address_county":{"value":"Alaska","matchLevel":"none","matchedWords":[]},"address_postcode":{"value":"EC4V
         4AY","matchLevel":"none","matchedWords":[]},"email_address":{"value":"office135@example.org","matchLevel":"none","matchedWords":[]},"telephone_number":{"value":"07111
-        333 135","matchLevel":"none","matchedWords":[]},"website":{"value":"http://example.net/offices/135","matchLevel":"none","matchedWords":[]}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":0,"geoDistance":483492,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":1,"matchedGeoLocation":{"lat":51.5119,"lng":-0.0952,"distance":483492}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=%5B55.378051%2C-3.435973%5D&facetFilters=%5B%22firm_id%3A1%22%5D&getRankingInfo=true&page=0&hitsPerPage=1000&query=","automaticRadius":"16169862","serverUsed":"c11-eu-2.algolia.net","indexUsed":"firm-offices-test","parsedQuery":"","timeoutCounts":false,"timeoutHits":false}
+        333 135","matchLevel":"none","matchedWords":[]},"website":{"value":"http://example.net/offices/135","matchLevel":"none","matchedWords":[]}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":2,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=&facetFilters=%5B%22firm_id%3A1%22%5D&getRankingInfo=false&page=0&hitsPerPage=1000&query="}
 
 '
     http_version: 
-  recorded_at: Thu, 25 Apr 2019 15:32:04 GMT
+  recorded_at: Wed, 05 Jun 2019 10:46:20 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/algolia/firm-profile/viewing-multiple-firm-profiles/post/1/indexes/firm-advisers-test/query.yml
+++ b/features/cassettes/algolia/firm-profile/viewing-multiple-firm-profiles/post/1/indexes/firm-advisers-test/query.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 25 Apr 2019 15:32:09 GMT
+      - Wed, 05 Jun 2019 10:46:25 GMT
       X-Algolia-Api-Key:
       - "<API_KEY>"
       X-Algolia-Application-Id:
@@ -29,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 25 Apr 2019 15:32:09 GMT
+      - Wed, 05 Jun 2019 10:46:25 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
@@ -56,7 +56,7 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 25 Apr 2019 15:32:09 GMT
+  recorded_at: Wed, 05 Jun 2019 10:46:25 GMT
 - request:
     method: post
     uri: https://bhpslyij2l-dsn.algolia.net/1/indexes/firm-advisers-test/query
@@ -71,7 +71,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 25 Apr 2019 15:32:09 GMT
+      - Wed, 05 Jun 2019 10:46:25 GMT
       X-Algolia-Api-Key:
       - "<API_KEY>"
       X-Algolia-Application-Id:
@@ -86,7 +86,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 25 Apr 2019 15:32:09 GMT
+      - Wed, 05 Jun 2019 10:46:26 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Transfer-Encoding:
@@ -116,13 +116,13 @@ http_interactions:
 
 '
     http_version: 
-  recorded_at: Thu, 25 Apr 2019 15:32:09 GMT
+  recorded_at: Wed, 05 Jun 2019 10:46:26 GMT
 - request:
     method: post
     uri: https://bhpslyij2l-dsn.algolia.net/1/indexes/firm-advisers-test/query
     body:
       encoding: UTF-8
-      string: '{"params":"aroundLatLng=%5B55.378051%2C-3.435973%5D\u0026distinct=false\u0026facetFilters=%5B%22firm.id%3A2%22%5D\u0026getRankingInfo=true\u0026page=0\u0026hitsPerPage=1000\u0026query="}'
+      string: '{"params":"aroundLatLng=\u0026distinct=false\u0026facetFilters=%5B%22firm.id%3A2%22%5D\u0026getRankingInfo=false\u0026page=0\u0026hitsPerPage=1000\u0026query="}'
     headers:
       User-Agent:
       - Algolia for Ruby (1.25.2); Ruby (2.5.3)
@@ -131,7 +131,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 25 Apr 2019 15:32:10 GMT
+      - Wed, 05 Jun 2019 10:46:26 GMT
       X-Algolia-Api-Key:
       - "<API_KEY>"
       X-Algolia-Application-Id:
@@ -146,7 +146,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 25 Apr 2019 15:32:10 GMT
+      - Wed, 05 Jun 2019 10:46:26 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Transfer-Encoding:
@@ -173,13 +173,13 @@ http_interactions:
         Walker","postcode":"E1 0AE","travel_distance":100,"qualification_ids":[],"accreditation_ids":[],"firm":{"id":2,"registered_name":"Test
         Firm East London","postcode_searchable":true,"website_address":"http://example.net/test-firm-east-london","telephone_number":"07111
         333 417","email_address":"office417@example.com","free_initial_meeting":true,"minimum_fixed_fee":0,"retirement_income_products_flag":true,"pension_transfer_flag":false,"long_term_care_flag":false,"equity_release_flag":true,"inheritance_tax_and_estate_planning_flag":false,"wills_and_probate_flag":false,"other_advice_methods":[],"investment_sizes":[2],"in_person_advice_methods":[2],"adviser_qualification_ids":[3],"adviser_accreditation_ids":[1],"ethical_investing_flag":false,"sharia_investing_flag":false,"workplace_financial_advice_flag":false,"non_uk_residents_flag":false,"languages":["ita","fra"],"total_offices":1,"total_advisers":2},"objectID":"4","_highlightResult":{"firm":{"registered_name":{"value":"Test
-        Firm East London","matchLevel":"none","matchedWords":[]}}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":3,"geoDistance":484907,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":1,"matchedGeoLocation":{"lat":51.5106,"lng":-0.0529,"distance":484907}}},{"_geoloc":{"lat":51.510643,"lng":-0.052898},"name":"Ms.
+        Firm East London","matchLevel":"none","matchedWords":[]}}}},{"_geoloc":{"lat":51.510643,"lng":-0.052898},"name":"Ms.
         Wyman Sawayn","postcode":"E1 0AE","travel_distance":100,"qualification_ids":[3],"accreditation_ids":[1],"firm":{"id":2,"registered_name":"Test
         Firm East London","postcode_searchable":true,"website_address":"http://example.net/test-firm-east-london","telephone_number":"07111
         333 417","email_address":"office417@example.com","free_initial_meeting":true,"minimum_fixed_fee":0,"retirement_income_products_flag":true,"pension_transfer_flag":false,"long_term_care_flag":false,"equity_release_flag":true,"inheritance_tax_and_estate_planning_flag":false,"wills_and_probate_flag":false,"other_advice_methods":[],"investment_sizes":[2],"in_person_advice_methods":[2],"adviser_qualification_ids":[3],"adviser_accreditation_ids":[1],"ethical_investing_flag":false,"sharia_investing_flag":false,"workplace_financial_advice_flag":false,"non_uk_residents_flag":false,"languages":["ita","fra"],"total_offices":1,"total_advisers":2},"objectID":"3","_highlightResult":{"firm":{"registered_name":{"value":"Test
-        Firm East London","matchLevel":"none","matchedWords":[]}}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":2,"geoDistance":484907,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":1,"matchedGeoLocation":{"lat":51.5106,"lng":-0.0529,"distance":484907}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=%5B55.378051%2C-3.435973%5D&distinct=false&facetFilters=%5B%22firm.id%3A2%22%5D&getRankingInfo=true&page=0&hitsPerPage=1000&query=","automaticRadius":"16169862","serverUsed":"c11-eu-2.algolia.net","indexUsed":"firm-advisers-test","parsedQuery":"","timeoutCounts":false,"timeoutHits":false}
+        Firm East London","matchLevel":"none","matchedWords":[]}}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=&distinct=false&facetFilters=%5B%22firm.id%3A2%22%5D&getRankingInfo=false&page=0&hitsPerPage=1000&query="}
 
 '
     http_version: 
-  recorded_at: Thu, 25 Apr 2019 15:32:10 GMT
+  recorded_at: Wed, 05 Jun 2019 10:46:26 GMT
 recorded_with: VCR 4.0.0

--- a/features/cassettes/algolia/firm-profile/viewing-multiple-firm-profiles/post/1/indexes/firm-offices-test/query.yml
+++ b/features/cassettes/algolia/firm-profile/viewing-multiple-firm-profiles/post/1/indexes/firm-offices-test/query.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://bhpslyij2l-dsn.algolia.net/1/indexes/firm-offices-test/query
     body:
       encoding: UTF-8
-      string: '{"params":"aroundLatLng=%5B55.378051%2C-3.435973%5D\u0026facetFilters=%5B%22firm_id%3A2%22%5D\u0026getRankingInfo=true\u0026page=0\u0026hitsPerPage=1000\u0026query="}'
+      string: '{"params":"aroundLatLng=\u0026facetFilters=%5B%22firm_id%3A2%22%5D\u0026getRankingInfo=false\u0026page=0\u0026hitsPerPage=1000\u0026query="}'
     headers:
       User-Agent:
       - Algolia for Ruby (1.25.2); Ruby (2.5.3)
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 25 Apr 2019 15:32:10 GMT
+      - Wed, 05 Jun 2019 10:46:26 GMT
       X-Algolia-Api-Key:
       - "<API_KEY>"
       X-Algolia-Application-Id:
@@ -29,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 25 Apr 2019 15:32:10 GMT
+      - Wed, 05 Jun 2019 10:46:26 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Transfer-Encoding:
@@ -59,9 +59,9 @@ http_interactions:
         Kiehn Mountain","matchLevel":"none","matchedWords":[]},"address_line_two":{"value":"Suite
         507","matchLevel":"none","matchedWords":[]},"address_town":{"value":"New Roderick","matchLevel":"none","matchedWords":[]},"address_county":{"value":"Vermont","matchLevel":"none","matchedWords":[]},"address_postcode":{"value":"E1
         0AE","matchLevel":"none","matchedWords":[]},"email_address":{"value":"office417@example.com","matchLevel":"none","matchedWords":[]},"telephone_number":{"value":"07111
-        333 417","matchLevel":"none","matchedWords":[]},"website":{"value":"http://example.net/offices/417","matchLevel":"none","matchedWords":[]}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":2,"geoDistance":484907,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":1,"matchedGeoLocation":{"lat":51.5106,"lng":-0.0529,"distance":484907}}}],"nbHits":1,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=%5B55.378051%2C-3.435973%5D&facetFilters=%5B%22firm_id%3A2%22%5D&getRankingInfo=true&page=0&hitsPerPage=1000&query=","automaticRadius":"16169862","serverUsed":"c11-eu-2.algolia.net","indexUsed":"firm-offices-test","parsedQuery":"","timeoutCounts":false,"timeoutHits":false}
+        333 417","matchLevel":"none","matchedWords":[]},"website":{"value":"http://example.net/offices/417","matchLevel":"none","matchedWords":[]}}}],"nbHits":1,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=&facetFilters=%5B%22firm_id%3A2%22%5D&getRankingInfo=false&page=0&hitsPerPage=1000&query="}
 
 '
     http_version: 
-  recorded_at: Thu, 25 Apr 2019 15:32:10 GMT
+  recorded_at: Wed, 05 Jun 2019 10:46:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/services/helpers/params_parser_spec.rb
+++ b/spec/services/helpers/params_parser_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Helpers::ParamsParser, type: :helper do
               coordinates: [],
               filters: {},
               random_search_seed: 123,
-              postcode: 'EC1N 2TD',
               page: 1
             }
           end
@@ -46,7 +45,7 @@ RSpec.describe Helpers::ParamsParser, type: :helper do
               described_class::SearchFirmsParams.new(
                 '',
                 'face_to_face',
-                [55.378051, -3.435973],
+                [],
                 {},
                 123,
                 1
@@ -60,7 +59,7 @@ RSpec.describe Helpers::ParamsParser, type: :helper do
             {
               firm_name: '',
               advice_method: 'face_to_face',
-              coordinates: [55.378051, -3.435973],
+              coordinates: ['55.378051', '-3.435973'],
               filters: {},
               random_search_seed: 123,
               page: 1
@@ -100,7 +99,7 @@ RSpec.describe Helpers::ParamsParser, type: :helper do
               described_class::SearchFirmsParams.new(
                 '',
                 'phone_or_online',
-                [55.378051, -3.435973],
+                [],
                 { adviser_qualification_ids: '1' },
                 123,
                 1
@@ -128,7 +127,7 @@ RSpec.describe Helpers::ParamsParser, type: :helper do
               described_class::SearchFirmsParams.new(
                 'test',
                 'phone_or_online',
-                [55.378051, -3.435973],
+                [],
                 { adviser_accreditation_ids: '2' },
                 123,
                 1
@@ -157,7 +156,7 @@ RSpec.describe Helpers::ParamsParser, type: :helper do
               described_class::SearchFirmsParams.new(
                 'test',
                 'phone_or_online',
-                [55.378051, -3.435973],
+                [],
                 { workplace_financial_advice_flag: '1' },
                 123,
                 1
@@ -198,7 +197,7 @@ RSpec.describe Helpers::ParamsParser, type: :helper do
           expect(parse).to eq(
             described_class::FetchFirmProfileParams.new(
               1,
-              [55.378051, -3.435973],
+              [],
               1
             )
           )

--- a/spec/services/search_firms_spec.rb
+++ b/spec/services/search_firms_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SearchFirms do
       let(:cassette_name) { :search_in_person_valid_geocode }
       let(:params) do
         base_search_params.merge(
-          postcode: 'EC4A 2AH',
+          coordinates: ['51.5139284', '-0.1113308'],
           advice_method: 'face_to_face'
         )
       end


### PR DESCRIPTION
This PR is fixing a minor bug when geocoding the closest adviser distance on a firm's profile.

In short: a redundant second geocoding using empty coordinates happens when no postcode is provided (i.e. from the search by postcode), resulting in otherwise displaying that the closest adviser is somewhere in the middle of UK.

More info in the card: [TP10546](https://moneyadviceservice.tpondemand.com/entity/10546-rad-adviser-distance-inadequate-in-search) and the commit.


