### PR TITLE
[DEV APPROVED] Show nearest office telephone number on firm profile

### DIFF
--- a/app/helpers/office_helper.rb
+++ b/app/helpers/office_helper.rb
@@ -1,6 +1,14 @@
 module OfficeHelper
   SCHEME = 'https://'.freeze
 
+  def display_telephone(firm)
+    if params[:postcode].present? && firm.offices.present?
+      firm.offices.first.telephone_number
+    else
+      firm.telephone_number
+    end
+  end
+
   def office_address(office)
     [
       office.address_line_one,

--- a/app/views/firms/partials/_header.html.erb
+++ b/app/views/firms/partials/_header.html.erb
@@ -15,7 +15,7 @@
       render(
         partial: 'firms/partials/firm_links',
         locals: {
-          telephone_number: firm.telephone_number,
+          telephone_number: display_telephone(firm),
           email_address: offices.first.email_address,
           website_address: display_website(offices.first, firm)
         }

--- a/spec/helpers/office_helper_spec.rb
+++ b/spec/helpers/office_helper_spec.rb
@@ -18,20 +18,60 @@ RSpec.describe OfficeHelper, type: :helper do
   end
 
   let(:website) { 'http://www.postman.com' }
-  let(:office_result) { Results::OfficePresenter.new(data) }
+  let(:office) { Results::OfficePresenter.new(data) }
   let(:firm_data) do
     {
-      'offices' => [office_result],
+      'offices' => [office],
       'advisers' => [],
       'website_address' => 'http://www.firmsite.com'
     }
   end
-  let(:firm_result) { Results::FirmPresenter.new(firm_data) }
+  let(:firm) { Results::FirmPresenter.new(firm_data) }
+
+  describe '#display_telephone' do
+    let(:firm_data) { { 'telephone_number' => '333 333333333' } }
+
+    before do
+      allow(helper).to receive(:params).and_return(params)
+    end
+
+    context 'when searching by postcode' do
+      let(:params) { { postcode: 'NW8' } }
+
+      before do
+        allow(firm).to receive(:offices).and_return(offices)
+      end
+
+      context 'when firm has offices' do
+        let(:offices) { [double(telephone_number: '0118 9021633')] }
+
+        it 'returns telephone from the first office (nearest office)' do
+          expect(display_telephone(firm)).to eq('0118 9021633')
+        end
+      end
+
+      context 'when firm does not have offices' do
+        let(:offices) { [] }
+
+        it 'returns telephone from the firm' do
+          expect(display_telephone(firm)).to eq('333 333333333')
+        end
+      end
+    end
+
+    context 'when not searching by postcode' do
+      let(:params) { { postcode: nil } }
+
+      it 'returns telephone from the firm' do
+        expect(display_telephone(firm)).to eq('333 333333333')
+      end
+    end
+  end
 
   describe '#office_address' do
     it 'outputs a ", " concatenated string of the address' do
       expected = 'c/o Postman Pat, Forge Cottage, Greendale, Cumbria, LA8 9BE'
-      expect(office_address(office_result)).to eq(expected)
+      expect(office_address(office)).to eq(expected)
     end
   end
 
@@ -39,7 +79,7 @@ RSpec.describe OfficeHelper, type: :helper do
     context 'when the office has its own website address' do
       it 'returns the office website' do
         expected = 'http://www.postman.com'
-        expect(display_website(office_result, firm_result)).to eq(expected)
+        expect(display_website(office, firm)).to eq(expected)
       end
     end
 
@@ -48,7 +88,7 @@ RSpec.describe OfficeHelper, type: :helper do
 
       it 'returns the firm\'s website' do
         expected = 'http://www.firmsite.com'
-        expect(display_website(office_result, firm_result)).to eq(expected)
+        expect(display_website(office, firm)).to eq(expected)
       end
     end
   end
@@ -58,7 +98,7 @@ RSpec.describe OfficeHelper, type: :helper do
 
     it 'ensures the return of display_website has a scheme' do
       expected = 'https://www.no-scheme.com'
-      expect(website_url(office_result, firm_result)).to eq(expected)
+      expect(website_url(office, firm)).to eq(expected)
     end
 
     context 'when the scheme is present' do
@@ -66,7 +106,7 @@ RSpec.describe OfficeHelper, type: :helper do
 
       it 'does not change its value' do
         expected = 'http://www.with-scheme.com'
-        expect(website_url(office_result, firm_result)).to eq(expected)
+        expect(website_url(office, firm)).to eq(expected)
       end
     end
 
@@ -75,7 +115,7 @@ RSpec.describe OfficeHelper, type: :helper do
 
       it 'strips the return before calling URI' do
         expected = 'http://www.with-scheme.com'
-        expect(website_url(office_result, firm_result)).to eq(expected)
+        expect(website_url(office, firm)).to eq(expected)
       end
     end
 
@@ -85,7 +125,7 @@ RSpec.describe OfficeHelper, type: :helper do
       let(:firm_data) do
         {
           '_source' => {
-            'offices' => [office_result],
+            'offices' => [office],
             'advisers' => [],
             'website_address' => ''
           }
@@ -93,7 +133,7 @@ RSpec.describe OfficeHelper, type: :helper do
       end
 
       it 'returns' do
-        expect(website_url(office_result, firm_result)).to eq(nil)
+        expect(website_url(office, firm)).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
[TP card](https://moneyadviceservice.tpondemand.com/entity/10618-rad-nearest-office-phone-number-to)

## Goal

On a firm's profile, display phone number belonging to the nearest office, when performing a postcode search

