### PR TITLE
Restores deleted styles

### DIFF
--- a/app/assets/stylesheets/layouts/_office.scss
+++ b/app/assets/stylesheets/layouts/_office.scss
@@ -1,3 +1,28 @@
 .l-office-col {
   margin: 0;
 }
+
+.contact-link {
+  color: $contact-link-text-color;
+  line-height: $baseline-unit*6;
+
+  // These are usually set either by us or by default, but
+  // tel links are strange and we need to tell them again.
+  &[href^="tel:"] {
+    color: $contact-link-text-color;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.contact-link__svg-icon {
+  @include inline-block();
+  position: relative;
+  top: 5px;
+  margin-right: $baseline-unit;
+  width: 20px;
+  height: 20px;
+  fill: $contact-link-fill-color;
+}


### PR DESCRIPTION
[TP10843](https://maps.tpondemand.com/entity/10843-rad-large-icons-showing-up-on)

This work addresses a fault that has developed with the display of some icons on the "Offices" panel of an advisor's profile page. This has occurred because some styles relating to these elements were removed as part of an earlier piece of work. This PR restores the removed styles. 

Current: 
![image](https://user-images.githubusercontent.com/6080548/69072108-0ad3b080-0a23-11ea-8237-8592339fc1b7.png)

Fixed: 
![image](https://user-images.githubusercontent.com/6080548/69072127-11fabe80-0a23-11ea-9991-533a8138c37f.png)
