### PR TITLE
#10960 RAD Consumer: pension_pot_size error in search results

### DIFF
--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -19,6 +19,9 @@ class SearchForm
   validate :geocode_postcode, if: :face_to_face?
 
   def initialize(attributes = {})
+    attributes.each do |key, _|
+      attributes.delete(key.to_sym) unless SearchForm.attribute_method? key
+    end
     attributes.fetch(:filters, {}).each do |key, value|
       public_send("#{key}=", value) if respond_to?("#{key}=")
     end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -490,4 +490,12 @@ RSpec.describe SearchForm do
       expect(form.as_json).to eq(expected_hash)
     end
   end
+
+  describe '#new' do
+    it 'gracefully discards unsupported params' do
+      expect(described_class.attribute_method?('pension_pot_size')).to be_falsey
+      expect(described_class.attribute_method?('advice_method')).to be_truthy
+      expect { described_class.new(pension_pot_size: 'any', advice_method: 'face_to_face') }.to_not raise_exception
+    end
+  end
 end

--- a/spec/support/feature_spec_helper.rb
+++ b/spec/support/feature_spec_helper.rb
@@ -17,7 +17,6 @@ def and_i_clear_any_filters_from_the_previous_search
     f.postcode.set nil
 
     f.retirement_income_products.set false
-    f.pension_pot_size.set SearchForm::ANY_SIZE_VALUE
     f.pension_transfer.set false
     f.options_when_paying_for_care.set false
     f.equity_release.set false

--- a/spec/support/in_person_section.rb
+++ b/spec/support/in_person_section.rb
@@ -4,7 +4,6 @@ class InPersonSection < SitePrism::Section
   element :search, '.button--primary'
 
   element :retirement_income_products, '.t-retirement_income_products'
-  element :pension_pot_size, '.t-pension-pot-size'
   element :pension_transfer, '.t-pension_transfer'
   element :options_when_paying_for_care, '.t-options_when_paying_for_care'
   element :equity_release, '.t-equity_release'

--- a/spec/support/remote_section.rb
+++ b/spec/support/remote_section.rb
@@ -4,7 +4,6 @@ class RemoteSection < SitePrism::Section
   element :search, '.button--primary'
 
   element :retirement_income_products, '.t-retirement_income_products'
-  element :pension_pot_size, '.t-pension-pot-size'
   element :pension_transfer, '.t-pension_transfer'
   element :options_when_paying_for_care, '.t-options_when_paying_for_care'
   element :equity_release, '.t-equity_release'

--- a/spec/support/search_criteria_section.rb
+++ b/spec/support/search_criteria_section.rb
@@ -1,7 +1,6 @@
 class SearchCriteriaSection < SitePrism::Section
   element :postcode, '#search_form_postcode'
   element :pension_pot, '#search_form_pension_pot'
-  element :pension_pot_size, '#search_form_pension_pot_size'
   element :pension_pot_transfer, '#search_form_pension_pot_transfer'
 
   element :options_when_paying_for_care, '#search_form_options_when_paying_for_care'

--- a/spec/support/search_form_section.rb
+++ b/spec/support/search_form_section.rb
@@ -10,7 +10,6 @@ class SearchFormSection < SitePrism::Section
   element :firm_name, '.t-firm_name'
 
   element :retirement_income_products, '.t-retirement_income_products'
-  element :pension_pot_size, '.t-pension-pot-size'
   element :pension_transfer, '.t-pension_transfer'
   element :languages, '.t-languages'
   element :options_when_paying_for_care, '.t-options_when_paying_for_care'


### PR DESCRIPTION
[TP](https://maps.tpondemand.com/restui/board.aspx?#page=board/5682182231901749200&appConfig=eyJhY2lkIjoiMTc4RkJENkI4OEUyMjA0MjI2RTM2NTMxOEZFNEFDMEIifQ==&boardPopup=bug/10960/silent)

The search filter pension_pot_size is no longer exists and appears to be renamed
into investment_size. Remaining references to pension_pot_size seems to be
leftovers.

This commit removes any reference of the pension_pot_size and gracefully removes
any unsupported params from search request in order not to raise exceptions.