### PR TITLE
[DEV APPROVED] Adds smallprint to footer for Welsh language users

### DIFF
--- a/app/views/contact_methods/_webchat.html.erb
+++ b/app/views/contact_methods/_webchat.html.erb
@@ -15,6 +15,11 @@
   <ul class="t-chat-opening-times contact-panel__list unstyled-list">
     <%= t('contact_panels.webchat.opening_times_html') %>
   </ul>
+
+  <p class="smallprint">
+    <%= t('contact_panels.language_availability') %>
+  </p>
+
   <!-- Button -->
   <div class="contact-panel__button-container" id="js-chat-cta">
     <div class="contact-panel__button button is-disabled t-chat-button">

--- a/app/views/contact_methods/_whatsapp.html.erb
+++ b/app/views/contact_methods/_whatsapp.html.erb
@@ -15,6 +15,11 @@
         <p><%= t('contact_panels.whatsapp.text3') %></p>
       </li>
     </ul>
+
+    <p class="smallprint">
+      <%= t('contact_panels.language_availability') %>
+    </p>
+
     <% if chat_opening_hours.open? %>
       <div class="contact-panel__button-container">
         <a class="contact-panel__button button t-whatsapp-button" href="https://wa.me/447701342744">

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -2,7 +2,7 @@
   "name": "rad-consumer",
   "dependencies": {
     "dough": "<%= gem_path('dough-ruby') %>",
-    "yeast": "1.12.0",
+    "yeast": "1.13.0",
     "requirejs": "2.1.*",
     "jquery": "3.3.*",
     "requirejs-plugins": "~1.0.3"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -122,6 +122,7 @@ cy:
     directory_url: /cy
 
   contact_panels:
+    language_availability: Ar hyn o bryd mae’r gwasanaeth hwn ar gael yn Saesneg yn unig.
     webchat:
       title: Gwe-sgwrs
       available:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,7 @@ en:
     directory_url: /en
 
   contact_panels:
+    language_availability: This service is currently only available in English.
     webchat:
       title: Web chat
       available:


### PR DESCRIPTION
[TP11052](https://maps.tpondemand.com/entity/11052-add-only-available-in-english-to)

This is the equivalent ticket in RAD to [TP10734](https://maps.tpondemand.com/entity/10734-relocate-the-only-available-in-english) in Frontend. 

The main difference is that the footer is not CMS-controlled in RAD as it is in frontend so the text is added to the codebase. 

Although this text is only required to be rendered to Welsh language users I have added the English equivalent to the translation file to avoid any potential problems with blank values in the file. The text is nonetheless hidden by the CSS for English language users. 

There are no styles added in this PR since these are shared with Frontend via Yeast. 

**Current**

![image](https://user-images.githubusercontent.com/6080548/72981006-a131a300-3dd3-11ea-8a5b-520dd518f3d0.png)

**Updated**

![image](https://user-images.githubusercontent.com/6080548/72981021-a8f14780-3dd3-11ea-9a30-cfb9ab6c787b.png)
