### PR TITLE
[DEV APPROVED] 11364 coronavirus banner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'bowndler', github: 'moneyadviceservice/bowndler'
 gem 'dough-ruby',
     git: 'https://github.com/moneyadviceservice/dough.git',
     branch: 'master',
-    ref: '238a329'
+    ref: 'bc219c1'
 gem 'geocoder', '~> 1.4.7'
 gem 'httpclient', '~> 2.8.3'
 gem 'jquery-rails'

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -12,6 +12,7 @@
 //= depend_on_asset dough/assets/js/lib/utilities
 //= depend_on_asset dough/assets/js/lib/mediaQueries
 //= depend_on_asset dough/assets/js/lib/componentLoader
+//= depend_on_asset dough/assets/js/components/CovidBanner
 //= depend_on_asset dough/assets/js/components/DoughBaseComponent
 //= depend_on_asset dough/assets/js/components/TabSelector
 //= depend_on_asset dough/assets/js/components/Validation
@@ -38,6 +39,7 @@
       utilities: requirejs_path('dough/assets/js/lib/utilities'),
       mediaQueries: requirejs_path('dough/assets/js/lib/mediaQueries'),
       componentLoader: requirejs_path('dough/assets/js/lib/componentLoader'),
+      CovidBanner: requirejs_path('dough/assets/js/components/CovidBanner'),
       DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),
       TabSelector: requirejs_path('dough/assets/js/components/TabSelector'),
       Validation: requirejs_path('dough/assets/js/components/Validation'),

--- a/app/assets/stylesheets/components/_covid_banner.scss
+++ b/app/assets/stylesheets/components/_covid_banner.scss
@@ -1,0 +1,7 @@
+// This is a temporary over-ride to the Yeast styles for this banner
+// It is needed because there is no WhatsApp button on RAD
+// This should be added and this style removed
+
+.covid_banner {
+	padding-right: $default-gutter; // calc(76px + #{$default-gutter * 4}); 
+}

--- a/app/assets/stylesheets/shared/_enhanced.scss
+++ b/app/assets/stylesheets/shared/_enhanced.scss
@@ -33,6 +33,7 @@
 @import 'yeast/assets/layout/common/contact_panel';
 @import 'yeast/assets/layout/common/contact_panels';
 @import 'yeast/assets/layout/common/context_bar';
+@import 'yeast/assets/layout/common/covid_banner';
 @import 'yeast/assets/layout/common/footer';
 @import 'yeast/assets/layout/common/footer_primary';
 @import 'yeast/assets/layout/common/footer_secondary';
@@ -65,6 +66,7 @@
 @import 'components/button';
 @import 'components/callout';
 @import 'components/contact_panels';
+@import 'components/covid_banner';
 @import 'components/education';
 @import 'components/firm';
 @import 'components/footer';

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,16 @@ class ApplicationController < ActionController::Base
 
   before_action :set_locale
 
+  BANNER_DISMISSED_COOKIE_NAME = '_covid_banner'.freeze
+  BANNER_DISMISSED_COOKIE_VALUE = 'y'.freeze
+
   include Chat
+
+  def covid_banner_dismissed?
+    cookies.permanent[BANNER_DISMISSED_COOKIE_NAME] != BANNER_DISMISSED_COOKIE_VALUE
+  end
+
+  helper_method :covid_banner_dismissed?
 
   private
 

--- a/app/views/application/_covid_banner.erb
+++ b/app/views/application/_covid_banner.erb
@@ -1,0 +1,15 @@
+<div class="covid_banner" data-dough-component="CovidBanner">
+	<div class="l-constrained">
+		<div class="covid_banner__content">
+			<div class="covid_banner__inner">
+				<a href="#" class="covid_banner__close" data-dough-close>
+					<svg xmlns="http://www.w3.org/2000/svg" class="svg-icon svg-icon--mobile-close-box">
+						<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-icon--mobile-close-box"></use>
+					</svg>
+				</a>
+				<p class="covid_banner__head"><%= t('covid_banner.head') %></p>
+				<p class="covid_banner__body"><%= t('covid_banner.body_html', href: t('covid_banner.href')) %></p>
+			</div>
+		</div>
+	</div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -176,6 +176,10 @@
   <%= render 'header' %>
   <%= render 'breadcrumbs' %>
 
+  <% if covid_banner_dismissed? %>
+    <%= render 'covid_banner' %>
+  <% end %>
+
   <main role="main" id="main">
     <%= content_for :validation_summary %>
 

--- a/app/views/shared/svg/_icon_sprite.html.erb
+++ b/app/views/shared/svg/_icon_sprite.html.erb
@@ -1,4 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <symbol id="svg-icon--mobile-close-box" viewBox="0 0 17.375 17.375">
+    <path fill="#565656" stroke="#4D4D4D" stroke-width="1.75" stroke-miterlimit="10"
+      d="M1.084 1.29L16.25 16.46M16.25 1.29L1.084 16.46" />
+  </symbol>
   <!-- social sharing icons -->
   <symbol id="svg-icon--facebook" viewBox="26.924 6.373 14.153 27.255">
     <path d="M36.107 33.623v-12.43h4.174l.625-4.846h-4.797v-3.09c0-1.404.392-2.36 2.402-2.36l2.564-.002V6.563c-.442-.059-1.967-.19-3.737-.19-3.697 0-6.233 2.256-6.233 6.405v3.572h-4.183v4.845h4.183v12.433h5.003l-.001-.005z"/>

--- a/bower.json.erb
+++ b/bower.json.erb
@@ -2,7 +2,7 @@
   "name": "rad-consumer",
   "dependencies": {
     "dough": "<%= gem_path('dough-ruby') %>",
-    "yeast": "1.13.0",
+    "yeast": "1.14.0",
     "requirejs": "2.1.*",
     "jquery": "3.3.*",
     "requirejs-plugins": "~1.0.3"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -112,6 +112,11 @@ cy:
     mps_provided_2: yn cael ei ddarparu gan
     mps: Gwasanaeth Arian a Phensiynau
 
+  covid_banner: 
+    head: Coronafeirws – beth mae’n ei olygu i chi
+    body_html: <a href="%{href}">Darganfyddwch beth mae gennych hawl iddo</a>
+    href: https://www.moneyadviceservice.org.uk/cy/articles/coronafirws-beth-mae-yn-ei-olygu-i-chi
+
   breadcrumbs:
     home: Hafan
     pension_and_retirement: Pensiynau ac ymddeoliad

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,6 +112,11 @@ en:
     mps_provided_2: Service is provided by
     mps: Money & Pensions Service
 
+  covid_banner: 
+    head: Coronavirus – what it means for you
+    body_html: <a href="%{href}">Find out what you're entitled to</a>
+    href: https://www.moneyadviceservice.org.uk/en/articles/coronavirus-what-it-means-for-you
+
   breadcrumbs:
     home: Home
     pension_and_retirement: Pensions and Retirement


### PR DESCRIPTION
[TP11364](https://maps.tpondemand.com/entity/11364-sticky-banner-on-rad-website-for)

This work implements the Coronavirus banner on RAD. This repeats the task from frontend in [TP11363](https://maps.tpondemand.com/entity/11363-sticky-banner-on-mas-website-for) and should match this exactly for look and feel and for functionality with a couple of exceptions: 
- There is no WhatsApp button on RAD so the width of the banner remains constant. 
- There is no "Back to Top" functionality on long pages so no requirement to dynamically change the position of the banner in response to this element. 

The Dough component is re-used here with no changes. 

The Yeast styles are used here with no changes, though there is an extra style added in RAD to over-ride the width in smaller viewports (as explained above with respect to the WhatsApp button). 

![image](https://user-images.githubusercontent.com/6080548/77891436-ddb4cb80-7268-11ea-9fd8-1ffc0b2edc25.png)
