### PR TITLE
12564 scroll i os

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,8 @@ gem 'bowndler', github: 'moneyadviceservice/bowndler'
 # is the same as the Gem version.
 gem 'dough-ruby',
     git: 'https://github.com/moneyadviceservice/dough.git',
-    branch: 'master',
-    ref: 'bc219c1'
+    branch: 'PostMessages_v6.2',
+    ref: '4a52cb8'
 gem 'geocoder', '~> 1.6.3'
 gem 'httpclient', '~> 2.8.3'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,11 @@ GIT
 
 GIT
   remote: https://github.com/moneyadviceservice/dough.git
-  revision: bc219c1f1721c6d9a0abc97cf5974db1a4ae65dd
-  ref: bc219c1
-  branch: master
+  revision: 4a52cb8e15c7dd6c0f30c81e0bfd685dfb5c7f77
+  ref: 4a52cb8
+  branch: PostMessages_v6.2
   specs:
-    dough-ruby (6.1.0)
+    dough-ruby (6.2.0)
       activemodel
       activesupport
       rails (>= 3.2)

--- a/app/assets/javascripts/require_config.js.erb
+++ b/app/assets/javascripts/require_config.js.erb
@@ -14,6 +14,7 @@
 //= depend_on_asset dough/assets/js/lib/componentLoader
 //= depend_on_asset dough/assets/js/components/CovidBanner
 //= depend_on_asset dough/assets/js/components/DoughBaseComponent
+//= depend_on_asset dough/assets/js/components/PostMessages
 //= depend_on_asset dough/assets/js/components/TabSelector
 //= depend_on_asset dough/assets/js/components/Validation
 //= depend_on_asset modules/FirmMap
@@ -41,6 +42,7 @@
       componentLoader: requirejs_path('dough/assets/js/lib/componentLoader'),
       CovidBanner: requirejs_path('dough/assets/js/components/CovidBanner'),
       DoughBaseComponent: requirejs_path('dough/assets/js/components/DoughBaseComponent'),
+      PostMessages: requirejs_path('dough/assets/js/components/PostMessages'),
       TabSelector: requirejs_path('dough/assets/js/components/TabSelector'),
       Validation: requirejs_path('dough/assets/js/components/Validation'),
       FirmMap: requirejs_path('modules/FirmMap'),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -173,7 +173,12 @@
 
   <%= render 'svg_icons' %>
 
-  <main role="main" id="main">
+  <main 
+    role="main" 
+    id="main"
+    data-dough-component="PostMessages"
+    data-dough-post-messages-config='{"masresize": "true"}'
+  >
     <%= content_for :validation_summary %>
 
     <%= yield %>


### PR DESCRIPTION
[TP-12564](https://maps.tpondemand.com/entity/12564-rad-scrolling-issue-on-firms-on)

This work implements the existing `PostMessages` Dough component on this repo. It adds a method to send a message from the iFrame to the parent when a change is detected in the body size of the document so that the iFrame height can be adjusted to fit the resized content. 

The component was updated in [PR345](https://github.com/moneyadviceservice/dough/pull/345) on Dough. 