### PR TITLE
Target `mailto` and `tel` protocol links

### DIFF
--- a/app/views/contact_methods/_call_us.html.erb
+++ b/app/views/contact_methods/_call_us.html.erb
@@ -9,7 +9,7 @@
     </li>
     <li class="contact-panel__additional-info">
       <p class="contact-panel__contact-number">
-        <a class="contact-panel__telephone t-contact-number" href="<%= t('contact_panels.call_us.telephone_number_url') %>">
+        <a class="contact-panel__telephone t-contact-number" href="<%= t('contact_panels.call_us.telephone_number_url') %>" target="_parent">
           <%= t('contact_panels.call_us.telephone_number') %>
         </a>
       </p>
@@ -18,13 +18,13 @@
     <li class="contact-panel__additional-info">
       <p>
         <%= t('contact_panels.call_us.email_info') %>
-        <a href="mailto:<%= t('contact_panels.call_us.email_address') %>"><%= t('contact_panels.call_us.email_address') %></a>.
+        <a href="mailto:<%= t('contact_panels.call_us.email_address') %>" target="_parent"><%= t('contact_panels.call_us.email_address') %></a>.
       </p>
     </li>
     <!-- Button -->
     <li class="contact-panel__additional-info">
       <div class="contact-panel__button-container">
-        <a class="contact-panel__button button" href="mailto:<%= t('contact_panels.call_us.email_address') %>">
+        <a class="contact-panel__button button" href="mailto:<%= t('contact_panels.call_us.email_address') %>" target="_parent">
           <%= t('contact_panels.call_us.email_button') %>
         </a>
       </div>

--- a/app/views/firms/partials/_firm_links.html.erb
+++ b/app/views/firms/partials/_firm_links.html.erb
@@ -1,7 +1,7 @@
 <ul class="firm__links">
   <% if telephone_number.present? %>
     <li>
-      <%= link_to "tel:#{telephone_number}", class: 'outline-button t-telephone' do %>
+      <%= link_to "tel:#{telephone_number}", class: 'outline-button t-telephone', target: '_parent' do %>
         <%= svg_icon :phone_ringing, title: t('firms.show.telephone_number'), class: 'outline-button__svg-icon'
         %><%= telephone_number %>
       <% end %>
@@ -10,7 +10,7 @@
 
   <% if email_address.present? %>
     <li>
-      <%= mail_to email_address, class: 'outline-button t-email' do %>
+      <%= mail_to email_address, class: 'outline-button t-email', target: '_parent'  do %>
         <%= svg_icon :envelope, title: t('firms.show.email_address'), class: 'outline-button__svg-icon'
         %><%= t('firms.show.email_firm') %>
       <% end %>

--- a/app/views/firms/partials/_offices.html.erb
+++ b/app/views/firms/partials/_offices.html.erb
@@ -17,13 +17,13 @@
         </div>
         <div class="l-2col-even l-office-col">
           <div class="office__telephone">
-            <%= link_to "tel:#{office.telephone_number}", class: 'contact-link' do %>
+            <%= link_to "tel:#{office.telephone_number}", class: 'contact-link', target: '_parent' do %>
               <%= svg_icon :phone_ringing, title: t('firms.show.panels.offices.telephone'), class: 'contact-link__svg-icon'
               %><%= office.telephone_number %>
             <% end %>
           </div>
           <div class="office__email">
-            <%= link_to "mailto:#{office.email_address}", class: 'contact-link' do %>
+            <%= link_to "mailto:#{office.email_address}", class: 'contact-link', target: '_parent' do %>
               <%= svg_icon :envelope, title: t('firms.show.panels.offices.email_office'), class: 'contact-link__svg-icon'
               %><%= t('firms.show.panels.offices.email_office') %>
             <% end %>


### PR DESCRIPTION
Turns out these fail when embedded in iframes unless the target is
explicitly set.