### PR TITLE
Legacy redirects to new AEM embeds

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,26 @@
+ENGLISH_EMBED_URL = 'https://www.moneyhelper.org.uk/en/pensions-and-retirement/taking-your-pension/find-a-retirement-adviser'.freeze
+WELSH_EMBED_URL   = 'https://www.moneyhelper.org.uk/cy/pensions-and-retirement/taking-your-pension/find-a-retirement-adviser'.freeze
+
 Rails.application.routes.draw do
-  get '/' => redirect('/en')
+  # these would match legacy, non-embed URLs
+  constraints(MasRedirectConstraints.new(redirect: true)) do
+    get '/', to: redirect(ENGLISH_EMBED_URL)
 
-  scope '/:locale', locale: /en|cy/ do
-    root 'landing_page#show'
+    get '/en(*all)', to: redirect(ENGLISH_EMBED_URL)
+    get '/cy(*all)', to: redirect(WELSH_EMBED_URL)
+  end
 
-    get '/search', to: 'search#index'
-    get '/glossary', to: 'glossary#show'
+  # these will continue to be served from the embed URLs
+  constraints(MasRedirectConstraints.new(redirect: false)) do
+    get '/' => redirect('/en')
 
-    resources :firms, only: [:show]
+    scope '/:locale', locale: /en|cy/ do
+      root 'landing_page#show'
+
+      get '/search', to: 'search#index'
+      get '/glossary', to: 'glossary#show'
+
+      resources :firms, only: [:show]
+    end
   end
 end

--- a/lib/mas_redirect_constraints.rb
+++ b/lib/mas_redirect_constraints.rb
@@ -1,0 +1,17 @@
+class MasRedirectConstraints
+  def initialize(redirect: true)
+    @redirect = redirect
+  end
+
+  def matches?(request)
+    return true unless @redirect
+
+    request.host.include?(legacy_host)
+  end
+
+  private
+
+  def legacy_host
+    ENV.fetch('LEGACY_HOST') { 'directory.moneyadviceservice.org.uk' }
+  end
+end

--- a/spec/requests/legacy_redirect_spec.rb
+++ b/spec/requests/legacy_redirect_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe 'Legacy redirects from non-embedded TLDs' do
+  before do
+    host! 'directory.moneyadviceservice.org.uk'
+  end
+
+  context 'for the naked locale' do
+    it 'redirects to the EN default' do
+      get 'http://directory.moneyadviceservice.org.uk'
+
+      expect(response).to redirect_to(ENGLISH_EMBED_URL)
+    end
+  end
+
+  context 'for the EN locale' do
+    it 'redirects to the EN default' do
+      # without further path segments
+      get 'http://directory.moneyadviceservice.org.uk/en'
+      expect(response).to redirect_to(ENGLISH_EMBED_URL)
+
+      # with further path segments
+      get 'http://directory.moneyadviceservice.org.uk/en/blah/blah/meh'
+      expect(response).to redirect_to(ENGLISH_EMBED_URL)
+    end
+  end
+
+  context 'for the CY locale' do
+    it 'redirects to the CY default' do
+      # without further path segments
+      get 'http://directory.moneyadviceservice.org.uk/cy'
+      expect(response).to redirect_to(WELSH_EMBED_URL)
+
+      # with further path segments
+      get 'http://directory.moneyadviceservice.org.uk/cy/hey/hi/'
+      expect(response).to redirect_to(WELSH_EMBED_URL)
+    end
+  end
+end


### PR DESCRIPTION
When requests are made with the legacy host
`directory.moneyadviceservice.org.uk` the application will redirect to
the new AEM page, with the correct embed.