### PR TITLE
Add a rake task to cleanup stale sessions

### DIFF
--- a/lib/tasks/sessions.rake
+++ b/lib/tasks/sessions.rake
@@ -1,0 +1,6 @@
+namespace :sessions do
+  desc 'Delete expired sessions'
+  task cleanup: :environment do
+    ActiveRecord::SessionStore::Session.where('updated_at < ?', 1.month.ago).delete_all
+  end
+end


### PR DESCRIPTION
This grows unbounded and in production there are more than 2.5m rows
that have been redundant for years.