### PR TITLE
Remove anchors from glossary links

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -21,7 +21,7 @@ module SearchHelper
     return if key.match?(/^translation missing/)
 
     info = t("search.accreditations.items.#{key}")
-    link_to glossary_path(locale: locale, anchor: key), class: "accreditation t-#{kind}" do
+    link_to glossary_path(locale: locale), class: "accreditation t-#{kind}" do
       image_tag "#{key}.png", alt: info[:title], class: 'accreditation__img'
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -360,9 +360,9 @@ en:
       qualifications_and_accreditations:
         heading: "I would like an adviser with the following accreditations / qualifications:"
         tooltip_html: |
-          Find out more about adviser accreditations/qualifications by clicking <a href="https://directory.moneyhelper.org/en/glossary/#chartered_fp" target="_blank">here</a>.
+          Find out more about adviser accreditations/qualifications by clicking <a href="/en/glossary">here</a>.
         label: Filter by adviser qualification or accreditation
-        url: "/en/glossary/#chartered_fp"
+        url: "/en/glossary"
       qualification:
         ordinal:
           "3": Chartered Financial Planner


### PR DESCRIPTION
These are causing issues with 'jump links' and scrolling after the
resize component kicks in so for now we can remove the anchor element
and at least have them functioning.