### PR TITLE
Remove href anchor

### DIFF
--- a/app/views/firms/partials/_advisers.html.erb
+++ b/app/views/firms/partials/_advisers.html.erb
@@ -36,7 +36,7 @@
     <% end %>
   <% end %>
 
-  <a data-dough-show-more-trigger class="adviser__show-more-trigger is-hidden" href="#">
+  <a data-dough-show-more-trigger class="adviser__show-more-trigger is-hidden" href="">
     <%= t('firms.show.panels.advisers.show_more') %>
   </a>
 </div>


### PR DESCRIPTION
There is a weird issue with jumplinks and how href attributes are
parsed and this causes some issues with links and buttons bound in
javascript. Removing the redundant attribute content resolves the issue
for now.