### PR TITLE
Strip useless whitespace from postcode

### DIFF
--- a/app/forms/filters/advice_method.rb
+++ b/app/forms/filters/advice_method.rb
@@ -21,7 +21,7 @@ module Filters
     end
 
     def coordinates
-      @coordinates ||= Geocode.call(postcode)
+      @coordinates ||= Geocode.call(stripped_postcode)
     end
 
     def postcode
@@ -35,13 +35,17 @@ module Filters
     private
 
     def geocode_postcode
-      return if postcode =~ /\A[A-Z\d]{1,4} ?[A-Z\d]{1,3}\z/ && coordinates
+      return if stripped_postcode =~ /\A[A-Z\d]{1,4} ?[A-Z\d]{1,3}\z/ && coordinates
 
       errors.add(:postcode, I18n.t('search.errors.geocode_failure'))
     end
 
     def upcase_postcode
       postcode.try(:upcase!)
+    end
+
+    def stripped_postcode
+      postcode&.gsub(' ', '')
     end
   end
 end

--- a/features/cassettes/algolia/firm-profile/viewing-a-firm-profile-following-search-in-person-results/post/1/indexes/firm-advisers-test/query.yml
+++ b/features/cassettes/algolia/firm-profile/viewing-a-firm-profile-following-search-in-person-results/post/1/indexes/firm-advisers-test/query.yml
@@ -60,8 +60,8 @@ http_interactions:
         Schaden","travel_distance":100,"firm":{"id":3},"objectID":"5","_highlightResult":{"firm":{"registered_name":{"value":"Test
         Firm Brighton","matchLevel":"none","matchedWords":[]}}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":4,"geoDistance":76510,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":1,"matchedGeoLocation":{"lat":50.8263,"lng":-0.1409,"distance":76510}}}],"nbHits":3,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=%5B51.5139284%2C-0.1113308%5D&aroundRadius=1207008&attributesToRetrieve=%5B%22_geoloc%22%2C%22name%22%2C%22travel_distance%22%2C%22firm.id%22%5D&distinct=true&facetFilters=%5B%22firm.postcode_searchable%3Atrue%22%5D&getRankingInfo=true&page=0&hitsPerPage=1000&query=","serverUsed":"c11-eu-2.algolia.net","indexUsed":"firm-advisers-test","parsedQuery":"","timeoutCounts":false,"timeoutHits":false}
 
-'
-    http_version: 
+        '
+    http_version:
   recorded_at: Thu, 25 Apr 2019 15:32:07 GMT
 - request:
     method: post
@@ -124,8 +124,8 @@ http_interactions:
         Firm Brighton","postcode_searchable":true,"website_address":null,"telephone_number":null,"email_address":null,"free_initial_meeting":true,"minimum_fixed_fee":0,"retirement_income_products_flag":true,"pension_transfer_flag":false,"long_term_care_flag":false,"equity_release_flag":true,"inheritance_tax_and_estate_planning_flag":false,"wills_and_probate_flag":false,"other_advice_methods":[],"investment_sizes":[3],"in_person_advice_methods":[2],"adviser_qualification_ids":[],"adviser_accreditation_ids":[],"ethical_investing_flag":false,"sharia_investing_flag":false,"workplace_financial_advice_flag":false,"non_uk_residents_flag":false,"languages":[],"total_offices":0,"total_advisers":1},"objectID":"5","_highlightResult":{"firm":{"registered_name":{"value":"Test
         Firm Brighton","matchLevel":"none","matchedWords":[]}}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":4,"geoDistance":76510,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":2,"matchedGeoLocation":{"lat":50.8263,"lng":-0.1409,"distance":76510}}}],"nbHits":3,"page":0,"nbPages":1,"hitsPerPage":10,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=%5B51.5139284%2C-0.1113308%5D&aroundRadius=1207008&attributesToRetrieve=%5B%22firm%22%5D&distinct=true&facetFilters=%5B%22firm.postcode_searchable%3Atrue%22%2C%5B%22firm.id%3A1%22%2C%22firm.id%3A2%22%2C%22firm.id%3A3%22%5D%5D&getRankingInfo=true&page=0&hitsPerPage=10&query=","serverUsed":"c11-eu-2.algolia.net","indexUsed":"firm-advisers-test","parsedQuery":"","timeoutCounts":false,"timeoutHits":false}
 
-'
-    http_version: 
+        '
+    http_version:
   recorded_at: Thu, 25 Apr 2019 15:32:07 GMT
 - request:
     method: post
@@ -189,7 +189,62 @@ http_interactions:
         333 135","email_address":"office135@example.org","free_initial_meeting":true,"minimum_fixed_fee":0,"retirement_income_products_flag":true,"pension_transfer_flag":false,"long_term_care_flag":false,"equity_release_flag":true,"inheritance_tax_and_estate_planning_flag":false,"wills_and_probate_flag":false,"other_advice_methods":[],"investment_sizes":[1],"in_person_advice_methods":[2],"adviser_qualification_ids":[3,4],"adviser_accreditation_ids":[1,2],"ethical_investing_flag":false,"sharia_investing_flag":false,"workplace_financial_advice_flag":true,"non_uk_residents_flag":false,"languages":["ita"],"total_offices":2,"total_advisers":2},"objectID":"1","_highlightResult":{"firm":{"registered_name":{"value":"Test
         Firm Central London","matchLevel":"none","matchedWords":[]}}},"_rankingInfo":{"nbTypos":0,"firstMatchedWord":0,"proximityDistance":0,"userScore":0,"geoDistance":1139,"geoPrecision":1,"nbExactWords":0,"words":0,"filters":1,"matchedGeoLocation":{"lat":51.5119,"lng":-0.0952,"distance":1139}}}],"nbHits":2,"page":0,"nbPages":1,"hitsPerPage":1000,"processingTimeMS":1,"exhaustiveNbHits":true,"query":"","params":"aroundLatLng=%5B51.5139284%2C-0.1113308%5D&distinct=false&facetFilters=%5B%22firm.id%3A1%22%5D&getRankingInfo=true&page=0&hitsPerPage=1000&query=","automaticRadius":"15740070","serverUsed":"c11-eu-2.algolia.net","indexUsed":"firm-advisers-test","parsedQuery":"","timeoutCounts":false,"timeoutHits":false}
 
-'
-    http_version: 
+        '
+    http_version:
   recorded_at: Thu, 25 Apr 2019 15:32:08 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: post
+    uri: https://bhpslyij2l-dsn.algolia.net/1/indexes/firm-advisers-test/query
+    body:
+      encoding: UTF-8
+      string: '{"params":"aroundLatLng=%5B51.5139684%2C-0.1112699%5D\u0026distinct=false\u0026facetFilters=%5B%22firm.id%3A1%22%5D\u0026getRankingInfo=true\u0026page=0\u0026hitsPerPage=1000\u0026query="}'
+    headers:
+      User-Agent:
+      - Algolia for Ruby (1.27.1); Ruby (2.6.5)
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 09 Jan 2023 14:21:46 GMT
+      X-Algolia-Api-Key:
+      - "<API_KEY>"
+      X-Algolia-Application-Id:
+      - "<APP_ID>"
+      Content-Type:
+      - application/json; charset=utf-8
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 09 Jan 2023 14:21:47 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '60'
+      Connection:
+      - keep-alive
+      Accept-Encoding:
+      - deflate, gzip
+      Cache-Control:
+      - no-store
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Content-Disposition:
+      - inline; filename=a.txt
+    body:
+      encoding: UTF-8
+      string: '{"message":"Invalid Application-ID or API key","status":403}'
+    http_version:
+  recorded_at: Mon, 09 Jan 2023 14:21:47 GMT
+recorded_with: VCR 5.0.0

--- a/features/cassettes/google/maps/api/geocode/json/address_5B_5D_EC1N2TD_2C_United_Kingdom_language_5B_5D_en_sensor_5B_5D_false.yml
+++ b/features/cassettes/google/maps/api/geocode/json/address_5B_5D_EC1N2TD_2C_United_Kingdom_language_5B_5D_en_sensor_5B_5D_false.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://maps.googleapis.com/maps/api/geocode/json?address=EC1N%202TD,%20United%20Kingdom&key=<GOOGLE_GEOCODER_API_KEY>&language=en&sensor=false
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=EC1N2TD,%20United%20Kingdom&key=<GOOGLE_GEOCODER_API_KEY>&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''

--- a/features/cassettes/google/maps/api/geocode/json/address_5B_5D_EC4A2AH_2C_United_Kingdom_language_5B_5D_en_sensor_5B_5D_false.yml
+++ b/features/cassettes/google/maps/api/geocode/json/address_5B_5D_EC4A2AH_2C_United_Kingdom_language_5B_5D_en_sensor_5B_5D_false.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://maps.googleapis.com/maps/api/geocode/json?address=EC4A%202AH,%20United%20Kingdom&key=<GOOGLE_GEOCODER_API_KEY>&language=en&sensor=false
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=EC4A2AH,%20United%20Kingdom&key=<GOOGLE_GEOCODER_API_KEY>&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''
@@ -21,30 +21,25 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 09 Jan 2023 14:21:46 GMT
-      Pragma:
-      - no-cache
+      - Thu, 28 Mar 2019 11:20:21 GMT
       Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
+      - Fri, 29 Mar 2019 11:20:21 GMT
       Cache-Control:
-      - no-cache, must-revalidate
+      - public, max-age=86400
       Access-Control-Allow-Origin:
       - "*"
-      X-Goog-Maps-Metro-Area:
-      - London
       Server:
       - mafe
+      Content-Length:
+      - '522'
       X-Xss-Protection:
-      - '0'
+      - 1; mode=block
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=84
+      - gfet4t7; dur=361
       Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
-        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
-      Transfer-Encoding:
-      - chunked
+      - quic=":443"; ma=2592000; v="46,44,43,39"
     body:
       encoding: ASCII-8BIT
       string: |
@@ -87,27 +82,27 @@ http_interactions:
                  "geometry" : {
                     "bounds" : {
                        "northeast" : {
-                          "lat" : 51.5141126,
-                          "lng" : -0.1110886
+                          "lat" : 51.5141193,
+                          "lng" : -0.111087
                        },
                        "southwest" : {
-                          "lat" : 51.5137844,
-                          "lng" : -0.111383
+                          "lat" : 51.5138213,
+                          "lng" : -0.1116846
                        }
                     },
                     "location" : {
-                       "lat" : 51.5139684,
-                       "lng" : -0.1112699
+                       "lat" : 51.5139284,
+                       "lng" : -0.1113308
                     },
                     "location_type" : "APPROXIMATE",
                     "viewport" : {
                        "northeast" : {
-                          "lat" : 51.51529748029149,
-                          "lng" : -0.109886819708498
+                          "lat" : 51.51531928029149,
+                          "lng" : -0.110036819708498
                        },
                        "southwest" : {
-                          "lat" : 51.5125995197085,
-                          "lng" : -0.112584780291502
+                          "lat" : 51.51262131970849,
+                          "lng" : -0.112734780291502
                        }
                     }
                  },
@@ -117,6 +112,6 @@ http_interactions:
            ],
            "status" : "OK"
         }
-    http_version:
-  recorded_at: Mon, 09 Jan 2023 14:21:46 GMT
-recorded_with: VCR 5.0.0
+    http_version: 
+  recorded_at: Thu, 28 Mar 2019 11:20:21 GMT
+recorded_with: VCR 4.0.0

--- a/features/firm_profile.feature
+++ b/features/firm_profile.feature
@@ -42,7 +42,7 @@ Feature: Firm profile
       | Caitlyn Kohler |
 
   Scenario: Viewing a firm profile following search "in person" results
-    When I am performing the "in person" search with value "EC4A 2AH"
+    When I am performing the "in person" search with value "EC4A2AH"
     And I open the profile of firm "Test Firm Central London" from the results
     Then I can see the closest adviser "0.3" miles away
     When I click on the "offices" tab

--- a/spec/fixtures/vcr_cassettes/geocoded_postcode.yml
+++ b/spec/fixtures/vcr_cassettes/geocoded_postcode.yml
@@ -105,7 +105,7 @@ http_interactions:
            ],
            "status" : "OK"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 18 Mar 2019 10:51:34 GMT
 - request:
     method: get
@@ -216,6 +216,99 @@ http_interactions:
            ],
            "status" : "OK"
         }
-    http_version: 
+    http_version:
   recorded_at: Mon, 18 Mar 2019 10:51:34 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=RG21AA,%20United%20Kingdom&key=<GOOGLE_GEOCODER_API_KEY>&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 09 Jan 2023 13:43:55 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=61
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "results" : [
+              {
+                 "address_components" : [
+                    {
+                       "long_name" : "United Kingdom",
+                       "short_name" : "GB",
+                       "types" : [ "country", "political" ]
+                    }
+                 ],
+                 "formatted_address" : "United Kingdom",
+                 "geometry" : {
+                    "bounds" : {
+                       "northeast" : {
+                          "lat" : 60.91569999999999,
+                          "lng" : 33.9165549
+                       },
+                       "southwest" : {
+                          "lat" : 34.5614,
+                          "lng" : -8.8988999
+                       }
+                    },
+                    "location" : {
+                       "lat" : 55.378051,
+                       "lng" : -3.435973
+                    },
+                    "location_type" : "APPROXIMATE",
+                    "viewport" : {
+                       "northeast" : {
+                          "lat" : 61.5471111,
+                          "lng" : 9.584415699999999
+                       },
+                       "southwest" : {
+                          "lat" : 47.5554486,
+                          "lng" : -18.5319589
+                       }
+                    }
+                 },
+                 "partial_match" : true,
+                 "place_id" : "ChIJqZHHQhE7WgIReiWIMkOg-MQ",
+                 "types" : [ "country", "political" ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version:
+  recorded_at: Mon, 09 Jan 2023 13:43:55 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/search_in_person_failed_geocode.yml
+++ b/spec/fixtures/vcr_cassettes/search_in_person_failed_geocode.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=EX1WRNG,%20United%20Kingdom&key=<GOOGLE_GEOCODER_API_KEY>&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 09 Jan 2023 14:07:41 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=2
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "error_message" : "The provided API key is invalid. ",
+           "results" : [],
+           "status" : "REQUEST_DENIED"
+        }
+    http_version:
+  recorded_at: Mon, 09 Jan 2023 14:07:41 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/search_in_person_valid_geocode.yml
+++ b/spec/fixtures/vcr_cassettes/search_in_person_valid_geocode.yml
@@ -275,7 +275,7 @@ http_interactions:
   recorded_at: Thu, 14 Mar 2019 02:52:52 GMT
 - request:
     method: get
-    uri: https://maps.googleapis.com/maps/api/geocode/json?address=EC4A%202AH,%20United%20Kingdom&key=<GOOGLE_GEOCODER_API_KEY>&language=en&sensor=false
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=EC4A2AH,%20United%20Kingdom&key=<GOOGLE_GEOCODER_API_KEY>&language=en&sensor=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -260,6 +260,16 @@ RSpec.describe SearchForm do
         end
       end
 
+      context 'and a badly spaced postcode is given' do
+        it 'is valid' do
+          form.postcode = ' R G 2  1 A A  '
+
+          VCR.use_cassette(:geocoded_postcode) do
+            expect(form).to be_valid
+          end
+        end
+      end
+
       it 'does not pass on any advice methods' do
         expect(form.remote_advice_method_ids).to be_empty
       end


### PR DESCRIPTION
Strips whitespace from a postcode before attempting to geocode. Does not alter the presented postcode apart from upcasing.