### PR TITLE
Remove Pension Transfer Gold Standard

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -367,7 +367,6 @@ cy:
           "3": Chartered Financial Planner
           "4": Certified Financial Planner
           "10": Chartered Wealth Manager
-          "11": Pension Transfer Gold Standard
           "12": Chartered Associate of The London Institute of Banking & Finance
           "13": Chartered Fellow of The London Institute of Banking & Finance
       accreditation:
@@ -468,10 +467,6 @@ cy:
         chartered_wealth:
           title: Chartered Wealth Manager
           description: Mae statws Rheolwr Cyfoeth Siartredig hefyd yn cael ei ddyfarnu gan y Sefydliad Siartredig Gwarantau a Buddsoddiadau (CISI).  Er mwyn cael dyfarniad o’r teitl Rheolwr Cyfoeth Siartredig, rhaid i gynghorwyr ariannol feddu ar Gymhwyster Rheolwr Cyfoeth Siartredig CISI Lefel 7 (Gradd Meistr CISI mewn Rheoli Cyfoeth yn flaenorol) neu feddu ar ardystiad Cynllunydd Ariannol Ardystiedig a bod yn aelod Siartredig o’r CISI.  Rhaid bod cynghorwyr hefyd wedi cwblhau un flwyddyn o ddatblygiad proffesiynol parhaus y gellir ei ddilysu.
-        pension_transfer_gold:
-          title: Pension Transfer Gold Standard
-          description: Mae Safon Aur Trosglwyddiadau Pensiwn yn god ymarfer gorau sydd wedi ei fabwysiadu'n wirfoddol gan gwmnïau a chynghorwyr ariannol a reoleiddir yn cynnig cyngor arbenigol ar drosglwyddiadau pensiwn.  Yn benodol mae’r Safon yn cynnig cyngor ariannol ar drosglwyddiadau o gynlluniau pensiwn sydd â buddion wedi eu diogelu neu warantu.  Mae cwmnïau a chynghorwyr ariannol sy'n mabwysiadu'r Safon yn dilyn cyfres o egwyddorion yn ychwanegol i’r hyn sy'n ofynnol gan reoleiddiad. <br /> <br /> Ar gyfer eich diogelwch chi, mae’r Llywodraeth wedi ei gwneud yn ofyniad cyfreithiol i geisio cyngor ariannol cyn i chi drosglwyddo o gynlluniau pensiwn penodol.  Mae’r Safon Aur Trosglwyddiadau Pensiwn wedi ei gynllunio i'ch helpu i adnabod a chanfod cwmnïau a chynghorwyr sy'n gallu darparu'r cyngor arbenigol hwn ac sy’n ymlynu i safonau proffesiynol uchel.
-          link: Ceir rhagor o wybodaeth <a href="https://www.thepfs.org/media/10121247/pension-transfer-gold-standard-logo-consumer-guide-a5-size-web-p1.pdf">yma</a>.
         bs8577_certified:
           title: Y Safon Brydeinig mewn Cynllunio Ariannol BS 8577
           description: Mae’r Safon Brydeinig mewn Cynllunio Ariannol BS 8577 yn sefydlu fframwaith i gwmnïau sy'n cynnig cyngor a gwasanaethau cynllunio ariannol. Fe’i datblygwyd gan y Sefydliad Safonau Prydeinig (BSI) ac mae’n dynodi’r arfer gorau ar gyfer mewnosod system reoli weithredol effeithiol o fewn y cwmni, i alluogi cwmnïau sy’n meddu ar y Safon i ddarparu'r gwasanaeth o’r radd uchaf posibl. Mae’r Safon yn ymgorffori’r holl agweddau sy'n cefnogi darpariaeth gwasanaethau cyngor, gan amlinellu cymwyseddau craidd sy'n ofynnol gan gwmnïau, eu cynghorwyr a chynllunwyr i sicrhau rhyngweithiad teg, tryloyw a phroffesiynol gyda chleientiaid. Yn aml bydd gan gwmnïau sy'n meddu ar BS 8577 Gynghorwyr Ariannol sydd ag ISO 22222, sef safon ryngwladol mewn cynllunio ariannol personol.
@@ -533,7 +528,6 @@ cy:
       "8": ignored
       "9": ignored
       "10": chartered_wealth
-      "11": pension_transfer_gold
       "12": chartered_associate
       "13": chartered_fellow
   accreditation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -368,7 +368,6 @@ en:
           "3": Chartered Financial Planner
           "4": Certified Financial Planner
           "10": Chartered Wealth Manager
-          "11": Pension Transfer Gold Standard
           "12": Chartered Associate of The London Institute of Banking & Finance
           "13": Chartered Fellow of The London Institute of Banking & Finance
       accreditation:
@@ -466,10 +465,6 @@ en:
         chartered_wealth:
           title: Chartered Wealth Manager
           description: Chartered Wealth Manager status is also awarded by the Chartered Institute of Securities and Investments (CISI).  To be awarded the title Chartered Wealth Manager, financial advisers must possess the Level 7 CISI Chartered Wealth Manager Qualification (formerly known as the CISI Masters in Wealth Management) or hold the Certified Financial Planner certification and be a Chartered member of the CISI.  Advisers must also have completed one year of verifiable continued professional development.
-        pension_transfer_gold:
-          title: Pension Transfer Gold Standard
-          description: The Pension Transfer Gold Standard is a code of best practice voluntarily adopted by regulated financial firms and advisers offering specialist advice on pension transfers.  In particular the Standard covers financial advice on transfers from pension schemes that have protected or guaranteed benefits.  Financial firms and advisers who adopt the Standard adhere to a set of principles over and above those they are required to follow by  regulation. <br /> <br /> For your own protection, the Government has made it a legal requirement to seek financial advice before you transfer from certain pension schemes.  The Pension Transfer Gold Standard is designed to help you recognise  and find firms and advisers that are able to provide this specialist advice and which adheres to high professional standards.
-          link: You can find out more <a href="https://www.thepfs.org/media/10121247/pension-transfer-gold-standard-logo-consumer-guide-a5-size-web-p1.pdf">here</a>.
         bs8577_certified:
           title: British Standard in Financial Planning BS 8577
           description: The British Standard in Financial Planning BS 8577 sets out a framework for firms offering financial advice and planning services.  It was developed by the British Standards Institute (BSI) and specifies best practice for embedding an effective operational management system within the firm, enabling firms which hold the Standard to provide the highest possible standard of service.  The Standard incorporates all aspects that support the provision of advice services, outlining core competencies required from companies, their advisers and planners to ensure a fair, transparent and professional interaction with clients.  Firms holding BS 8577 often have Financial Advisers who hold the ISO 22222 which is an international standard in personal financial planning.
@@ -531,7 +526,6 @@ en:
       "8": ignored
       "9": ignored
       "10": chartered_wealth
-      "11": pension_transfer_gold
       "12": chartered_associate
       "13": chartered_fellow
   accreditation:

--- a/features/search_filters.feature
+++ b/features/search_filters.feature
@@ -21,13 +21,6 @@ Feature: Search filters
       | Test Firm Remote 2    |
       | Test Firm East London |
 
-  Scenario: Filter by accreditations and qualifications
-    When I am performing the "firm by name" search with value "Test Firm"
-    And I choose the accreditation / qualification "Pension Transfer Gold Standard"
-    Then I should see the following firms
-      | name                     |
-      | Test Firm East London    |
-
   Scenario: Filter by adviser spoken language
     When I am performing the "firm by name" search with value "Test Firm"
     And I choose the language "Italian"

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -358,7 +358,6 @@ RSpec.describe SearchForm do
           ['Chartered Financial Planner', 'q3'],
           ['Chartered Wealth Manager', 'q10'],
           ['ISO 22222', 'a3'],
-          ['Pension Transfer Gold Standard', 'q11'],
           %w[SOLLA a1]
         ]
         expect(form.options_for_qualifications_and_accreditations)


### PR DESCRIPTION
This is temporarily being placed on hold so we can remove it from filters and glossaries.