### PR TITLE
Resolve issue with "Show more offices" link

### DIFF
--- a/app/views/firms/partials/_offices.html.erb
+++ b/app/views/firms/partials/_offices.html.erb
@@ -47,7 +47,7 @@
     </div>
   <% end %>
 
-  <a data-dough-show-more-trigger class="office__show-more-trigger is-hidden" href="#">
+  <a data-dough-show-more-trigger class="office__show-more-trigger is-hidden" href="">
     <%= t('firms.show.panels.offices.show_more') %>
   </a>
 </div>


### PR DESCRIPTION
This doesn't expand into further offices due to a jquery oddity with a blank anchor reference.